### PR TITLE
Shorthands - closes #29

### DIFF
--- a/CSSParser.php
+++ b/CSSParser.php
@@ -201,7 +201,7 @@ class CSSParser {
 	
 	private function parseRuleSet($oRuleSet) {
 		while(!$this->comes('}')) {
-			$oRuleSet->append($this->parseRule());
+			$oRuleSet->appendRule($this->parseRule());
 			$this->consumeWhiteSpace();
 		}
 		$this->consume('}');

--- a/tests/CSSDeclarationBlockTest.php
+++ b/tests/CSSDeclarationBlockTest.php
@@ -194,7 +194,7 @@ class CSSDeclarationBlockTest extends PHPUnit_Framework_TestCase
 		return array(
 			array(
 				'p {border-right: none;border: 1px solid rgb(0,0,0);}',
-				'p {border-right-style: none;border-top-width: 1px;border-right-width: 1px;border-bottom-width: 1px;border-left-width: 1px;border-top-style: solid;border-right-style: solid;border-bottom-style: solid;border-left-style: solid;border-right-color: rgb(0,0,0);border-bottom-color: rgb(0,0,0);border-left-color: rgb(0,0,0);border-top-color: rgb(0,0,0);}'
+				'p {border-right-style: none;border-top-width: 1px;border-right-width: 1px;border-bottom-width: 1px;border-left-width: 1px;border-top-style: solid;border-right-style: solid;border-bottom-style: solid;border-left-style: solid;border-top-color: rgb(0,0,0);border-right-color: rgb(0,0,0);border-bottom-color: rgb(0,0,0);border-left-color: rgb(0,0,0);}'
 			),	
 			array(
 				'p { border: 1px solid rgb(0,0,0); border-right: none; }',


### PR DESCRIPTION
I had to change the implementation of CSSRuleSet.
The rules list is now a numerically indexed array instead of an associative array.
This allows us to have things like this:

``` css
p {
  border-style: solid !important;
  foobar: baz;
  border-style: none;
}
```

And then do this:

``` php
foreach($oRuleSet->getRules('border-style') as $position => $rule) {
  printf("%d => %s", $position, $rule);
}
/*
0 =>  border-style: solid !important;
2 => border-style: none;
*/
echo $oRuleSet->getAppliedRule('border-style');
/*
border-style: solid !important;
*/
```

This allows expand/createShorthands to get around some edge cases.
