### PR TITLE
Fix KeyFrame reference in Parser.php

### DIFF
--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -5,7 +5,7 @@ namespace Sabberworm\CSS;
 use Sabberworm\CSS\CSSList\CSSList;
 use Sabberworm\CSS\CSSList\Document;
 use Sabberworm\CSS\CSSList\MediaQuery;
-use Sabberworm\CSS\CSSList\Keyframe;
+use Sabberworm\CSS\CSSList\KeyFrame;
 use Sabberworm\CSS\Property\Import;
 use Sabberworm\CSS\Property\Charset;
 use Sabberworm\CSS\Property\CSSNamespace;


### PR DESCRIPTION
Some CSS files require the use of the keyFrame class. 

This has been misspelt in the Parser.php class on line 8 and results in the following fatal PHP error:

Fatal error: Class 'Sabberworm\CSS\CSSList\Keyframe' not found in /vendor/sabberworm/php-css-parser/lib/Sabberworm/CSS/Parser.php on line 116
