### PR TITLE
Fix parsing negative numeric arguments without a leading digit

### DIFF
--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -350,7 +350,10 @@ class Parser {
 	private function parsePrimitiveValue() {
 		$oValue = null;
 		$this->consumeWhiteSpace();
-		if (is_numeric($this->peek()) || (($this->comes('-') || $this->comes('.')) && is_numeric($this->peek(1, 1)))) {
+		if (is_numeric($this->peek()) ||
+		    (($this->comes('-') || $this->comes('.')) &&
+		     (($peek = $this->peek(1, 1)) || true) &&
+		     (($peek == '.') || is_numeric($peek)))) {
 			$oValue = $this->parseNumericValue();
 		} else if ($this->comes('#') || $this->comes('rgb') || $this->comes('hsl')) {
 			$oValue = $this->parseColorValue();


### PR DESCRIPTION
E.g. this:
   -.5em

Was being parsed/output as
- 0.5em
