### PR TITLE
Optimize output of color values

### DIFF
--- a/lib/Sabberworm/CSS/Value/Color.php
+++ b/lib/Sabberworm/CSS/Value/Color.php
@@ -21,4 +21,21 @@ class Color extends CSSFunction {
 		return $this->getName();
 	}
 
+	public function __toString() {
+		if (isset($this->aComponents['a'])) {
+            return parent::__toString();
+        }
+
+		$out = sprintf(
+		    '%o2x%02x%02x',
+		    $this->aComponents['r'],
+		    $this->aComponents['g'],
+		    $this->aComponents['b'],
+        );
+
+		return (($out[0] == $out[1]) && ($out[2] == $out[3]) && ($out[4] == $out[5]))
+		    ? '#' . $out[0] . $out[2] . $out[4]
+		    : '#' . $out;
+	}
+
 }


### PR DESCRIPTION
Useful to manipulate colors in integers in PHP code. But once output,
there really is no difference.  And this:

   #fff

is much more space-efficient than this:

   rgb(255,255,255)

(at least for this example, the former is 400% more efficient)
