### PR TITLE
Unit fix

### DIFF
--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -389,7 +389,9 @@ class Parser {
 		$sUnit = null;
 		$units = array(
 			'%', 'em', 'ex', 'px', 'deg', 's', 'cm', 'pt', 'in', 'pc', 'cm',
-			'mm'
+			'mm',
+			// These are non "size" values, but they are still numeric
+			'deg', 'grad', 'rad', 'turns', 's', 'ms', 'Hz', 'kHz'
 		);
 
 		foreach ($units as $val) {


### PR DESCRIPTION
Obviously... feel free to edit as you see fit.  But the non-"size" part needs to occur or else the output is invalid.

With this commit, PHP-CSS-Parser can now import jquerymobile CSS code (a good test case since it contains a bunch of advanced CSS selectors/CSS3) and export it and the exported code doesn't break jquerymobile.
