### PR TITLE
Fix Size output for locales that use non-period decimal separators

### DIFF
--- a/lib/Sabberworm/CSS/Value/Size.php
+++ b/lib/Sabberworm/CSS/Value/Size.php
@@ -60,7 +60,8 @@ class Size extends PrimitiveValue {
 	}
 
 	public function __toString() {
-		return str_replace('0.', '.', $this->fSize) . ($this->sUnit === null ? '' : $this->sUnit);
+		$l = localeconv();
+		return str_replace(array($l['decimal_point'], '0.'), '.', $this->fSize) . ($this->sUnit === null ? '' : $this->sUnit);
 	}
 
 }


### PR DESCRIPTION
e.g., a locale like pt_PT parses this:

width: 0.15em;

as "0,15".
