### PR TITLE
Performance take2

### DIFF
--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -43,7 +43,16 @@ class Parser {
 		}
 		$this->oParserSettings = $oParserSettings;
 		$this->blockRules = explode('/', AtRule::BLOCK_RULES);
-		$this->sizeUnits = explode('/', Size::ABSOLUTE_SIZE_UNITS.'/'.Size::RELATIVE_SIZE_UNITS.'/'.Size::NON_SIZE_UNITS);
+
+		foreach (explode('/', Size::ABSOLUTE_SIZE_UNITS.'/'.Size::RELATIVE_SIZE_UNITS.'/'.Size::NON_SIZE_UNITS) as $val) {
+			$size = strlen($val);
+			if (isset($this->sizeUnits[$size])) {
+				$this->sizeUnits[$size][] = $val;
+			} else {
+				$this->sizeUnits[$size] = array($val);
+			}
+		}
+		ksort($this->sizeUnits, SORT_NUMERIC);
 	}
 
 	public function setCharset($sCharset) {
@@ -397,11 +406,12 @@ class Parser {
 				$sSize .= $this->consume(1);
 			}
 		}
+
 		$sUnit = null;
-		foreach($this->sizeUnits as $sDefinedUnit) {
-			if ($this->comes($sDefinedUnit, true)) {
-				$sUnit = $sDefinedUnit;
-				$this->consume($sDefinedUnit);
+		foreach ($this->sizeUnits as $len => $val) {
+			if (($pos = array_search($this->peek($len), $val)) !== false) {
+				$sUnit = $val[$pos];
+				$this->consume($len);
 				break;
 			}
 		}


### PR DESCRIPTION
So a smaller, less ambitious performance try.  The combination of these provides about a 25% performance boost, at least according to xdebug data.

peek() is the deadly method that needs to be worked on further.  It consumes about 36% of runtime.  comes() is the next biggest performance hog, but it only consumes about 11%.
