### PR TITLE
Fix case-insensitive dimension/keyword determination

### DIFF
--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -43,16 +43,6 @@ class Parser {
 		}
 		$this->oParserSettings = $oParserSettings;
 		$this->blockRules = explode('/', AtRule::BLOCK_RULES);
-
-		foreach (explode('/', Size::ABSOLUTE_SIZE_UNITS.'/'.Size::RELATIVE_SIZE_UNITS.'/'.Size::NON_SIZE_UNITS) as $val) {
-			$size = strlen($val);
-			if (isset($this->sizeUnits[$size])) {
-				$this->sizeUnits[$size][] = $val;
-			} else {
-				$this->sizeUnits[$size] = array($val);
-			}
-		}
-		ksort($this->sizeUnits, SORT_NUMERIC);
 	}
 
 	public function setCharset($sCharset) {
@@ -66,6 +56,19 @@ class Parser {
 
 	public function parse() {
 		$this->setCharset($this->oParserSettings->sDefaultCharset);
+
+		$this->sizeUnits = array();
+		foreach (explode('/', Size::ABSOLUTE_SIZE_UNITS.'/'.Size::RELATIVE_SIZE_UNITS.'/'.Size::NON_SIZE_UNITS) as $val) {
+			$val = $this->strtolower($val);
+			$size = strlen($val);
+			if (isset($this->sizeUnits[$size])) {
+				$this->sizeUnits[$size][] = $val;
+			} else {
+				$this->sizeUnits[$size] = array($val);
+			}
+		}
+		ksort($this->sizeUnits, SORT_NUMERIC);
+
 		$oResult = new Document();
 		$this->parseDocument($oResult);
 		return $oResult;
@@ -409,8 +412,9 @@ class Parser {
 
 		$sUnit = null;
 		foreach ($this->sizeUnits as $len => $val) {
-			if (($pos = array_search($this->peek($len), $val)) !== false) {
-				$sUnit = $val[$pos];
+			$peek = $this->peek($len);
+			if (array_search($this->strtolower($peek), $val) !== false) {
+				$sUnit = $peek;
 				$this->consume($len);
 				break;
 			}

--- a/tests/Sabberworm/CSS/RuleSet/LenientParsingTest.php
+++ b/tests/Sabberworm/CSS/RuleSet/LenientParsingTest.php
@@ -44,7 +44,7 @@ class LenientParsingTest extends \PHPUnit_Framework_TestCase {
 		$sFile = dirname(__FILE__) . '/../../../files' . DIRECTORY_SEPARATOR . "case-insensitivity.css";
 		$oParser = new Parser(file_get_contents($sFile));
 		$oResult = $oParser->parse();
-		$this->assertSame('@charset "utf-8";@import url("test.css");@media screen {}#myid {case: insensitive !important;frequency: 30Hz;color: #ff0;color: hsl(40,40%,30%);font-family: Arial;}'."\n", $oResult->__toString());
+		$this->assertSame('@charset "utf-8";@import url("test.css");@media screen {}#myid {case: insensitive !important;frequency: 30hz;color: #ff0;color: hsl(40,40%,30%);font-family: Arial;}'."\n", $oResult->__toString());
 	}
 
 }


### PR DESCRIPTION
The test-case was a bit broken though - it changed the case of the Hz
keyword which isn't clear from the documentation.  Better solution is to
preserve the case in the original input.
