### PR TITLE
Fixed comments parsing

### DIFF
--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -546,10 +546,10 @@ class Parser {
 
 	private function consumeComment() {
 		if ($this->comes('/*')) {
-			$this->consume(2);
-			while ($this->consumeUntil('*', false, true)) {
-				if ($this->comes('/')) {
-					$this->consume(1);
+			$this->consume(1);
+			while ($this->consume(1) !== '') {
+				if ($this->comes('*/')) {
+					$this->consume(2);
 					return true;
 				}
 			}
@@ -567,6 +567,7 @@ class Parser {
 		$start = $this->iCurrentPosition;
 
 		while (($char = $this->consume(1)) !== '') {
+			$this->consumeComment();
 			if (in_array($char, $aEnd)) {
 				if ($bIncludeEnd) {
 					$out .= $char;

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -343,6 +343,14 @@ body {color: green;}' . "\n", $oDoc->__toString());
 }#unrelated {other: yes;}' . "\n", $oDoc->__toString());
 	}
 
+	function testComments() {
+		$oDoc = $this->parsedStructureForFile('comments');
+		$sExpected = '@import url("some/url.css") screen;.foo, #bar {background-color: #000;}
+@media screen {#foo.bar {position: absolute;}
+}';
+		$this->assertSame($sExpected, $oDoc->__toString());
+	}
+
 	function parsedStructureForFile($sFileName) {
 		$sFile = dirname(__FILE__) . '/../../files' . DIRECTORY_SEPARATOR . "$sFileName.css";
 		$oParser = new Parser(file_get_contents($sFile));

--- a/tests/files/comments.css
+++ b/tests/files/comments.css
@@ -1,0 +1,16 @@
+/**
+ * Comments Hell.
+ */
+@import /* Number 1 */"some/url.css"/* Number 2 */ screen/* Number 3 */;
+
+.foo, /* Number 4 */          #bar/* Number 5 */ {
+    background-color/* Number 6 */: #000/* Number 7 */;
+}
+
+@media /* Number 8 */screen /* Number 9 */{
+    /** Number 10 **/
+    #foo.bar {
+        position: absolute;/**/
+    }
+}
+/** Number 11 **/


### PR DESCRIPTION
## First bug

Comments in which the first character was `*` parsed incorrectly. The other part of the comment was joined with next token. You can reproduce this issue using this comment: 

```
/** Perfectly valid **/
```

I found and solved this bug very quickly. Set second argument of consumeUntil() call in consumeComment() method to `true` and all will work perfectly. But second bug made me rethink consumeComment() routine.
## Second bug

Almost all places where consumeUntil() method was used had bug with comments parsing. Here they are:
-  Getting media query for @import rule. If comment was between query and terminated semicolon then this comment was included in query.
- Getting arguments for unknown AT rules. If comment was between arguments or before `{` then this comment was included in arguments.
- On selectors parsing if comment was between selectors or before `{` bracket then selectors will contain this comment.
  I have decided to make comments remove right in consumeUntil() method because it is the root of the bug and every place which use it, is buggy.

I have added test for comments. You can compare result before and after this commit.
