### PR TITLE
Validate name-start code points for identifier

### DIFF
--- a/lib/Sabberworm/CSS/Parsing/ParserState.php
+++ b/lib/Sabberworm/CSS/Parsing/ParserState.php
@@ -72,7 +72,7 @@ class ParserState {
             $sResult = $this->parseCharacter(true);
         }
 
-		if (!$this->oParserSettings->bLenientParsing && $sResult === null) {
+		if ($sResult === null) {
 			throw new UnexpectedTokenException($sResult, $this->peek(5), 'identifier', $this->iLineNo);
 		}
 		$sCharacter = null;

--- a/lib/Sabberworm/CSS/Parsing/ParserState.php
+++ b/lib/Sabberworm/CSS/Parsing/ParserState.php
@@ -54,14 +54,14 @@ class ParserState {
 
         if ( $bNameStartCodePoint ) {
             // Check if 3 code points would start an identifier. See <https://drafts.csswg.org/css-syntax-3/#would-start-an-identifier>.
-            $sNameStartCodePoint = '[a-zA-Z_]|[\x80-\xFF}]';
+            $sNameStartCodePoint = '[a-zA-Z_]|[\x80-\xFF]';
             $sEscapeCode = '\\[^\r\n\f]';
 
             if (
                 ! (
-                    preg_match("/-([-${sNameStartCodePoint}]|${sEscapeCode})/isSu", $this->peek(3)) ||
-                    preg_match("/${sNameStartCodePoint}/isSu", $this->peek()) ||
-                    preg_match("/${sEscapeCode}/isS", $this->peek(2))
+                    preg_match("/^-([-${sNameStartCodePoint}]|${sEscapeCode})/isSu", $this->peek(3)) ||
+                    preg_match("/^${sNameStartCodePoint}/isSu", $this->peek()) ||
+                    preg_match("/^${sEscapeCode}/isS", $this->peek(2))
                 )
             ) {
                 $bCanParseCharacter = false;

--- a/lib/Sabberworm/CSS/Parsing/ParserState.php
+++ b/lib/Sabberworm/CSS/Parsing/ParserState.php
@@ -72,7 +72,7 @@ class ParserState {
             $sResult = $this->parseCharacter(true);
         }
 
-		if ($sResult === null) {
+		if (!$this->oParserSettings->bLenientParsing && $sResult === null) {
 			throw new UnexpectedTokenException($sResult, $this->peek(5), 'identifier', $this->iLineNo);
 		}
 		$sCharacter = null;

--- a/lib/Sabberworm/CSS/Value/Color.php
+++ b/lib/Sabberworm/CSS/Value/Color.php
@@ -14,7 +14,7 @@ class Color extends CSSFunction {
 		$aColor = array();
 		if ($oParserState->comes('#')) {
 			$oParserState->consume('#');
-			$sValue = $oParserState->parseIdentifier(false);
+			$sValue = $oParserState->parseIdentifier(false, false);
 			if ($oParserState->strlen($sValue) === 3) {
 				$sValue = $sValue[0] . $sValue[0] . $sValue[1] . $sValue[1] . $sValue[2] . $sValue[2];
 			} else if ($oParserState->strlen($sValue) === 4) {

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -767,10 +767,30 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 		$this->assertSame($sExpected, $oDoc->render());
 	}
 
+    function getInvalidIdentifiers() {
+        return array(
+            array(
+                'body { -0-transition: all .3s ease-in-out; }',
+                'Identifier expected. Got “-0-tr” [line no: 1]'
+            ),
+            array(
+                'body { 4-o-transition: all .3s ease-in-out; }',
+                'Identifier expected. Got “4-o-t” [line no: 1]'
+            )
+        );
+	}
+
     /**
-     * @expectedException \Sabberworm\CSS\Parsing\UnexpectedTokenException
+     * @dataProvider getInvalidIdentifiers
      */
-    function testInvalidIdentifier() {
-        $this->parsedStructureForFile('-invalid-identifier', Settings::create()->withLenientParsing(false));
+    function testInvalidIdentifier($css, $errorMessage) {
+        try {
+            $settings = Settings::create()->withLenientParsing(false);
+            $parser = new Parser($css, $settings);
+            $parser->parse();
+            $this->fail( 'UnexpectedTokenException not thrown' );
+        } catch ( UnexpectedTokenException $e ) {
+            $this->assertEquals( $errorMessage, $e->getMessage() );
+        }
     }
 }

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -769,28 +769,21 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 
     function getInvalidIdentifiers() {
         return array(
-            array(
-                'body { -0-transition: all .3s ease-in-out; }',
-                'Identifier expected. Got “-0-tr” [line no: 1]'
-            ),
-            array(
-                'body { 4-o-transition: all .3s ease-in-out; }',
-                'Identifier expected. Got “4-o-t” [line no: 1]'
-            )
+            array('body { -0-transition: all .3s ease-in-out; }' ),
+            array('body { 4-o-transition: all .3s ease-in-out; }' ),
         );
 	}
 
     /**
      * @dataProvider getInvalidIdentifiers
+     *
+     * @param string $css CSS text.
      */
-    function testInvalidIdentifier($css, $errorMessage) {
-        try {
-            $settings = Settings::create()->withLenientParsing(false);
-            $parser = new Parser($css, $settings);
-            $parser->parse();
-            $this->fail( 'UnexpectedTokenException not thrown' );
-        } catch ( UnexpectedTokenException $e ) {
-            $this->assertEquals( $errorMessage, $e->getMessage() );
-        }
+    function testInvalidIdentifier($css) {
+        $this->setExpectedException( 'Sabberworm\CSS\Parsing\UnexpectedTokenException' );
+
+        $oSettings = Settings::create()->withLenientParsing(false);
+        $oParser = new Parser($css, $oSettings);
+        $oParser->parse();
     }
 }

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -769,8 +769,8 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 
     function getInvalidIdentifiers() {
         return array(
-            array('body { -0-transition: all .3s ease-in-out; }' ),
-            array('body { 4-o-transition: all .3s ease-in-out; }' ),
+            array('body { -0-transition: all .3s ease-in-out; }'),
+            array('body { 4-o-transition: all .3s ease-in-out; }'),
         );
 	}
 

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -214,7 +214,7 @@ body {color: green;}', $oDoc->render());
 		$this->assertSame('#header {margin: 10px 2em 1cm 2%;color: red !important;frequency: 30Hz;}
 body {color: green;}', $oDoc->render());
 	}
-	
+
 	function testRuleGetters() {
 		$oDoc = $this->parsedStructureForFile('values');
 		$aBlocks = $oDoc->getAllDeclarationBlocks();
@@ -319,7 +319,7 @@ foo|test {gaga: 1;}
 |test {gaga: 2;}';
 		$this->assertSame($sExpected, $oDoc->render());
 	}
-	
+
 	function testInnerColors() {
 		$oDoc = $this->parsedStructureForFile('inner-color');
 		$sExpected = 'test {background: -webkit-gradient(linear,0 0,0 bottom,from(#006cad),to(hsl(202,100%,49%)));}';
@@ -359,7 +359,7 @@ foo|test {gaga: 1;}
 		$this->assertSame('@media screen {html {some: -test(val2);}}
 #unrelated {other: yes;}', $oDoc->render());
 	}
-	
+
 	/**
 	* @expectedException Sabberworm\CSS\Parsing\OutputException
 	*/
@@ -766,4 +766,11 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 		$sExpected = "@import url(\"example.css\") only screen and (max-width: 600px);";
 		$this->assertSame($sExpected, $oDoc->render());
 	}
+
+    /**
+     * @expectedException \Sabberworm\CSS\Parsing\UnexpectedTokenException
+     */
+    function testInvalidIdentifier() {
+        $this->parsedStructureForFile('-invalid-identifier', Settings::create()->withLenientParsing(false));
+    }
 }

--- a/tests/files/-invalid-identifier.css
+++ b/tests/files/-invalid-identifier.css
@@ -1,0 +1,6 @@
+body {
+    transition: all .3s ease-in-out;
+    -webkit-transition: all .3s ease-in-out;
+    -moz-transition: all .3s ease-in-out;
+    -0-transition: all .3s ease-in-out;
+}

--- a/tests/files/-invalid-identifier.css
+++ b/tests/files/-invalid-identifier.css
@@ -1,6 +1,0 @@
-body {
-    transition: all .3s ease-in-out;
-    -webkit-transition: all .3s ease-in-out;
-    -moz-transition: all .3s ease-in-out;
-    -0-transition: all .3s ease-in-out;
-}


### PR DESCRIPTION
When given the following CSS:

```css
body {
    transition: all .3s ease-in-out;
    -webkit-transition: all .3s ease-in-out;
    -moz-transition: all .3s ease-in-out;
    -0-transition: all .3s ease-in-out;
}
```

The parser does not remove or throw an exception for the malformed rule `-0-transition`, as it is a syntax error:

![image](https://user-images.githubusercontent.com/16200219/72869578-a8768500-3cdd-11ea-8a56-7e2c0219fcba.png)

This occurs because the check to validate if the rule is an [identifier](https://drafts.csswg.org/css-syntax-3/#identifier) does not validate if the [first 3 code points are valid](https://drafts.csswg.org/css-syntax-3/#would-start-an-identifier).

---

This PR adds a check to validate the first 3 code points in an identifier. If a malformed identifier is given, an `UnexpectedTokenException` exception will be thrown before the identifier is consumed.