### PR TITLE
Add additional validation for size unit

### DIFF
--- a/lib/Sabberworm/CSS/Value/Size.php
+++ b/lib/Sabberworm/CSS/Value/Size.php
@@ -38,26 +38,21 @@ class Size extends PrimitiveValue {
 		}
 
 		$sUnit = null;
-		$sParsedUnit = null;
 		$aSizeUnits = self::getSizeUnits();
-
 		$iMaxSizeUnitLength = max(array_keys($aSizeUnits));
-		if ( preg_match( '/^[a-zA-Z0-9%]+/', $oParserState->peek($iMaxSizeUnitLength), $matches ) ) {
-			$sParsedUnit = $matches[0];
-		}
 
-		foreach($aSizeUnits as $iLength => $aValues) {
-			$sKey = strtolower($oParserState->peek($iLength));
-			if(array_key_exists($sKey, $aValues)) {
-				if (strtolower($sParsedUnit) !== $sKey) {
-					throw new UnexpectedTokenException('Unit', $sParsedUnit, 'identifier', $oParserState->currentLine());
-				}
-				if (($sUnit = $aValues[$sKey]) !== null) {
-					$oParserState->consume($iLength);
-					break;
-				}
+		if ( preg_match( '/^[a-zA-Z0-9%]+/', $oParserState->peek($iMaxSizeUnitLength), $matches ) ) {
+			$sUnit = strtolower($matches[0]);
+			$iUnitLength = strlen($sUnit);
+
+			if (isset($aSizeUnits[$iUnitLength][$sUnit])) {
+				$sUnit = $aSizeUnits[$iUnitLength][$sUnit];
+				$oParserState->consume($iUnitLength);
+			} else {
+				throw new UnexpectedTokenException('Unit', $sUnit, 'identifier', $oParserState->currentLine());
 			}
 		}
+
 		return new Size(floatval($sSize), $sUnit, $bIsColorComponent, $oParserState->currentLine());
 	}
 

--- a/lib/Sabberworm/CSS/Value/Size.php
+++ b/lib/Sabberworm/CSS/Value/Size.php
@@ -41,7 +41,7 @@ class Size extends PrimitiveValue {
 		$aSizeUnits = self::getSizeUnits();
 		$iMaxSizeUnitLength = max(array_keys($aSizeUnits));
 
-		if ( preg_match( '/^[a-zA-Z0-9%]+/', $oParserState->peek($iMaxSizeUnitLength), $matches ) ) {
+		if ( preg_match( '/^(%|[a-zA-Z0-9]+)/', $oParserState->peek($iMaxSizeUnitLength), $matches ) ) {
 			$sUnit = strtolower($matches[0]);
 			$iUnitLength = strlen($sUnit);
 

--- a/lib/Sabberworm/CSS/Value/Size.php
+++ b/lib/Sabberworm/CSS/Value/Size.php
@@ -37,39 +37,35 @@ class Size extends PrimitiveValue {
 			}
 		}
 
-        $sParsedUnit = '';
-        $iOffset = 0;
+		$sParsedUnit = '';
+		$iOffset = 0;
 		while (true) {
-		    $sChar = $oParserState->peek(1, $iOffset);
-            $iPeek = ord($sChar);
+			$sChar = $oParserState->peek(1, $iOffset);
+			$iPeek = ord($sChar);
 
-            // Ranges: a-z A-Z 0-9 %
-            if (($iPeek >= 97 && $iPeek <= 122) ||
-                ($iPeek >= 65 && $iPeek <= 90) ||
-                ($iPeek >= 48 && $iPeek <= 57) ||
-                ($iPeek === 37)) {
-                $sParsedUnit .= $sChar;
-                $iOffset++;
-            } else {
-                break;
-            }
-        }
+			// Ranges: a-z A-Z 0-9 %
+			if (($iPeek >= 97 && $iPeek <= 122) ||
+				($iPeek >= 65 && $iPeek <= 90) ||
+				($iPeek >= 48 && $iPeek <= 57) ||
+				($iPeek === 37)) {
+				$sParsedUnit .= $sChar;
+				$iOffset++;
+			} else {
+				break;
+			}
+		}
 
-        $sUnit = null;
-        $aSizeUnits = self::getSizeUnits();
+		$sUnit = null;
+		$aSizeUnits = self::getSizeUnits();
 
 		foreach($aSizeUnits as $iLength => $aValues) {
-		    $iConsumeLength = $iLength;
 			$sKey = strtolower($oParserState->peek($iLength));
 			if(array_key_exists($sKey, $aValues)) {
-			    if (strtolower($sParsedUnit) !== $sKey) {
-                    if (!$oParserState->getSettings()->bLenientParsing) {
-                        throw new UnexpectedTokenException('Unit', $sParsedUnit, 'identifier', $oParserState->currentLine());
-                    }
-                    $iConsumeLength = strlen($sParsedUnit);
-                }
+				if (strtolower($sParsedUnit) !== $sKey) {
+					throw new UnexpectedTokenException('Unit', $sParsedUnit, 'identifier', $oParserState->currentLine());
+				}
 				if (($sUnit = $aValues[$sKey]) !== null) {
-					$oParserState->consume($iConsumeLength);
+					$oParserState->consume($iLength);
 					break;
 				}
 			}

--- a/lib/Sabberworm/CSS/Value/Size.php
+++ b/lib/Sabberworm/CSS/Value/Size.php
@@ -37,26 +37,14 @@ class Size extends PrimitiveValue {
 			}
 		}
 
-		$sParsedUnit = '';
-		$iOffset = 0;
-		while (true) {
-			$sChar = $oParserState->peek(1, $iOffset);
-			$iPeek = ord($sChar);
-
-			// Ranges: a-z A-Z 0-9 %
-			if (($iPeek >= 97 && $iPeek <= 122) ||
-				($iPeek >= 65 && $iPeek <= 90) ||
-				($iPeek >= 48 && $iPeek <= 57) ||
-				($iPeek === 37)) {
-				$sParsedUnit .= $sChar;
-				$iOffset++;
-			} else {
-				break;
-			}
-		}
-
 		$sUnit = null;
+		$sParsedUnit = null;
 		$aSizeUnits = self::getSizeUnits();
+
+		$iMaxSizeUnitLength = max(array_keys($aSizeUnits));
+		if ( preg_match( '/^[a-zA-Z0-9%]+/', $oParserState->peek($iMaxSizeUnitLength), $matches ) ) {
+			$sParsedUnit = $matches[0];
+		}
 
 		foreach($aSizeUnits as $iLength => $aValues) {
 			$sKey = strtolower($oParserState->peek($iLength));

--- a/lib/Sabberworm/CSS/Value/Size.php
+++ b/lib/Sabberworm/CSS/Value/Size.php
@@ -3,6 +3,7 @@
 namespace Sabberworm\CSS\Value;
 
 use Sabberworm\CSS\Parsing\ParserState;
+use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 
 class Size extends PrimitiveValue {
 
@@ -38,11 +39,21 @@ class Size extends PrimitiveValue {
 
 		$sUnit = null;
 		$aSizeUnits = self::getSizeUnits();
-		foreach($aSizeUnits as $iLength => &$aValues) {
+		$sUnit = strtolower($oParserState->parseIdentifier());
+		$oParserState->backtrack(strlen($sUnit));
+
+		foreach($aSizeUnits as $iLength => $aValues) {
+		    $iConsumeLength = $iLength;
 			$sKey = strtolower($oParserState->peek($iLength));
 			if(array_key_exists($sKey, $aValues)) {
+			    if ($sUnit !== $sKey) {
+                    if (!$oParserState->getSettings()->bLenientParsing) {
+                        throw new UnexpectedTokenException('Unit', $sUnit, 'identifier', $oParserState->currentLine());
+                    }
+                    $iConsumeLength = strlen($sUnit);
+                }
 				if (($sUnit = $aValues[$sKey]) !== null) {
-					$oParserState->consume($iLength);
+					$oParserState->consume($iConsumeLength);
 					break;
 				}
 			}

--- a/lib/Sabberworm/CSS/Value/Size.php
+++ b/lib/Sabberworm/CSS/Value/Size.php
@@ -8,7 +8,7 @@ class Size extends PrimitiveValue {
 
 	const ABSOLUTE_SIZE_UNITS = 'px/cm/mm/mozmm/in/pt/pc/vh/vw/vmin/vmax/rem'; //vh/vw/vm(ax)/vmin/rem are absolute insofar as they don’t scale to the immediate parent (only the viewport)
 	const RELATIVE_SIZE_UNITS = '%/em/ex/ch/fr';
-	const NON_SIZE_UNITS = 'deg/grad/rad/s/ms/turns/Hz/kHz';
+	const NON_SIZE_UNITS = 'deg/grad/rad/s/ms/turn/Hz/kHz';
 
 	private static $SIZE_UNITS = null;
 

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -787,4 +787,22 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 		$sExpected = "@import url(\"example.css\") only screen and (max-width: 600px);";
 		$this->assertSame($sExpected, $oDoc->render());
 	}
+
+    function testTurnUnitLenient() {
+        $sText = ".foo {transform: rotate(1turn);}\n.bar {transform: rotate(1turns);}";
+        $sExpected = ".foo {transform: rotate(1turn);}\n.bar {transform: rotate(1turn);}";
+
+        $oParser = new Parser($sText);
+        $this->assertSame($sExpected, $oParser->parse()->render());
+    }
+
+    function testTurnUnitStrict() {
+        $sText = ".foo {transform: rotate(1turn);}\n.bar {transform: rotate(1turns);}";
+
+        $oParser = new Parser($sText, Settings::create()->beStrict());
+
+        // Line 2 contains the invalid unit and so should be reported.
+        $this->setExpectedException( 'Sabberworm\CSS\Parsing\UnexpectedTokenException', 'Identifier expected. Got “turns” [line no: 2]' );
+        $oParser->parse();
+    }
 }

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -788,21 +788,21 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 		$this->assertSame($sExpected, $oDoc->render());
 	}
 
-    function testTurnUnitLenient() {
-        $sText = ".foo {transform: rotate(1turn);}\n.bar {transform: rotate(1turns);}";
-        $sExpected = ".foo {transform: rotate(1turn);}\n.bar {transform: rotate(1turn);}";
+	function testTurnUnitLenient() {
+		$sText = ".foo {transform: rotate(1turn);}\n.bar {transform: rotate(1turns);}";
+		$sExpected = ".foo {transform: rotate(1turn);}\n.bar {}";
 
-        $oParser = new Parser($sText);
-        $this->assertSame($sExpected, $oParser->parse()->render());
-    }
+		$oParser = new Parser($sText);
+		$this->assertSame($sExpected, $oParser->parse()->render());
+	}
 
-    function testTurnUnitStrict() {
-        $sText = ".foo {transform: rotate(1turn);}\n.bar {transform: rotate(1turns);}";
+	function testTurnUnitStrict() {
+		$sText = ".foo {transform: rotate(1turn);}\n.bar {transform: rotate(1turns);}";
 
-        $oParser = new Parser($sText, Settings::create()->beStrict());
+		$oParser = new Parser($sText, Settings::create()->beStrict());
 
-        // Line 2 contains the invalid unit and so should be reported.
-        $this->setExpectedException( 'Sabberworm\CSS\Parsing\UnexpectedTokenException', 'Identifier expected. Got “turns” [line no: 2]' );
-        $oParser->parse();
-    }
+		// Line 2 contains the invalid unit and so should be reported.
+		$this->setExpectedException( 'Sabberworm\CSS\Parsing\UnexpectedTokenException', 'Identifier expected. Got “turns” [line no: 2]' );
+		$oParser->parse();
+	}
 }


### PR DESCRIPTION
This PR adds additional validation when parsing a size unit.

With this change, when parsing in strict mode an `UnexpectedTokenException` error will be thrown when an invalid size unit occurs after a number. When in lenient mode, however, if a valid size unit identifier is detected, it will be kept and the proceeding set of characters will be stripped. For example:

  | Dimension value | Strict parsing | Lenient parsing
---|---|---|---
**Before** | `1radsss` | `1 rad sss` | `1 rad sss`
**After** | `1radsss` | `UnexpectedTokenException` | Value is removed

Also, there is no such unit named `turns`, but there is one called `turn` ([ref](https://drafts.csswg.org/css-values-3/#turn)), which I suppose is what was meant here :smile:.