### PR TITLE
Remove from CSSList via key

### DIFF
--- a/lib/Sabberworm/CSS/CSSList/CSSList.php
+++ b/lib/Sabberworm/CSS/CSSList/CSSList.php
@@ -246,11 +246,18 @@ abstract class CSSList implements Renderable, Commentable
 
     /**
      * Removes an item from the CSS list.
-     * @param RuleSet|Import|Charset|CSSList $oItemToRemove May be a RuleSet (most likely a DeclarationBlock), a Import, a Charset or another CSSList (most likely a MediaQuery)
+     *
+     * @param RuleSet|Import|Charset|CSSList|int $oItemToRemove May be a RuleSet (most likely a DeclarationBlock), a Import, a Charset or another CSSList (most likely a MediaQuery)
      * @return bool Whether the item was removed.
      */
     public function remove($oItemToRemove)
     {
+        if (is_numeric($oItemToRemove) && array_key_exists($oItemToRemove, $this->aContents)) {
+            unset($this->aContents[$oItemToRemove]);
+
+            return true;
+        }
+
         $iKey = array_search($oItemToRemove, $this->aContents, true);
         if ($iKey !== false) {
             unset($this->aContents[$iKey]);

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -389,6 +389,18 @@ foo|test {gaga: 1;}
 #unrelated {other: yes;}', $oDoc->render());
     }
 
+    public function testListValueRemovalByKey()
+    {
+        $oDoc = $this->parsedStructureForFile('atrules');
+        foreach ($oDoc->getContents() as $key => $oItem) {
+            if ($oItem instanceof AtRule) {
+                $oDoc->remove($key);
+            }
+        }
+
+        $this->assertSame('html, body {font-size: -.6em;}', $oDoc->render());
+    }
+
     /**
     * @expectedException Sabberworm\CSS\Parsing\OutputException
     */


### PR DESCRIPTION
If you're looping over `getContents()` and want to remove items from the `CSSList` it would be more performant to remove items by the key given it's already known. The current method uses `array_search` which is wasteful in the specified scenario.