### PR TITLE
Allow calc() function inside rgba() and hsla()

### DIFF
--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -49,18 +49,21 @@ class Color extends CSSFunction
             $oParserState->consumeWhiteSpace();
             $oParserState->consume('(');
 
-            $bContainsVar = false;
+            $bContainsVarOrCalc = false;
             $iLength = $oParserState->strlen($sColorMode);
             for ($i = 0; $i < $iLength; ++$i) {
                 $oParserState->consumeWhiteSpace();
                 if ($oParserState->comes('var')) {
                     $aColor[$sColorMode[$i]] = CSSFunction::parseIdentifierOrFunction($oParserState);
-                    $bContainsVar = true;
+                    $bContainsVarOrCalc = true;
+                } elseif ($oParserState->comes('calc')) {
+                    $aColor[$sColorMode[$i]] = CalcFunction::parse($oParserState);
+                    $bContainsVarOrCalc = true;
                 } else {
                     $aColor[$sColorMode[$i]] = Size::parse($oParserState, true);
                 }
 
-                if ($bContainsVar && $oParserState->comes(')')) {
+                if ($bContainsVarOrCalc && $oParserState->comes(')')) {
                     // With a var argument the function can have fewer arguments
                     break;
                 }
@@ -72,7 +75,7 @@ class Color extends CSSFunction
             }
             $oParserState->consume(')');
 
-            if ($bContainsVar) {
+            if ($bContainsVarOrCalc) {
                 return new CSSFunction($sColorMode, array_values($aColor), ',', $oParserState->currentLine());
             }
         }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -120,7 +120,10 @@ class ParserTest extends \PHPUnit\Framework\TestCase
             . 'background-color: rgb(255,var(--rg));background-color: hsl(var(--some-hsl));}'
             . "\n"
             . '#variables-alpha {background-color: rgba(var(--some-rgb),.1);'
-            . 'background-color: rgba(var(--some-rg),255,.1);background-color: hsla(var(--some-hsl),.1);}',
+            . 'background-color: rgba(var(--some-rg),255,.1);background-color: hsla(var(--some-hsl),.1);}'
+            . "\n"
+            . '#calc {background-color: rgba(var(--some-rgb),calc(var(--some-alpha) * .1));'
+            . 'background-color: hsla(var(--some-hsl),calc(var(--some-alpha) * .1));}',
             $oDoc->render()
         );
     }

--- a/tests/fixtures/colortest.css
+++ b/tests/fixtures/colortest.css
@@ -26,3 +26,8 @@
 	background-color: rgba(var(--some-rg), 255, 0.1);
 	background-color: hsla(var(--some-hsl), 0.1);
 }
+
+#calc {
+	background-color: rgba(var(--some-rgb), calc(var(--some-alpha) * 0.1));
+	background-color: hsla(var(--some-hsl), calc(var(--some-alpha) * 0.1));
+}


### PR DESCRIPTION
This fix allows the alpha value of rgba() and hsla() functions to accept
a calc() function.