### PR TITLE
Fix comments being omitted in the middle of a rule

### DIFF
--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -89,7 +89,7 @@ abstract class CSSList implements Renderable, Commentable
                 $oListItem->setComments($comments);
                 $oList->append($oListItem);
             }
-            $oParserState->consumeWhiteSpace();
+            $oParserState->consumeWhiteSpace(false);
         }
         if (!$bIsRoot && !$bLenientParsing) {
             throw new SourceException("Unexpected end of document", $oParserState->currentLine());

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -197,18 +197,24 @@ class ParserState
     }
 
     /**
+     * @param bool $consumeComments defaults to true
      * @return array<int, Comment>|void
      *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    public function consumeWhiteSpace()
+    public function consumeWhiteSpace($consumeComments = true)
     {
         $comments = [];
         do {
             while (preg_match('/\\s/isSu', $this->peek()) === 1) {
                 $this->consume(1);
             }
+
+            if (!$consumeComments) {
+                return [];
+            }
+
             if ($this->oParserSettings->bLenientParsing) {
                 try {
                     $oComment = $this->consumeComment();

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -106,7 +106,7 @@ class Rule implements Renderable, Commentable
         while ($oParserState->comes(';')) {
             $oParserState->consume(';');
         }
-        $oParserState->consumeWhiteSpace();
+        $oParserState->consumeWhiteSpace(false);
 
         return $oRule;
     }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1123,6 +1123,20 @@ body {background-color: red;}';
     /**
      * @test
      */
+    public function innerCommentExtracting()
+    {
+        $parser = new Parser('div {left:10px;/*Find Me!*/text-align:left;}');
+        $doc = $parser->parse();
+        $contents = $doc->getContents();
+        $divRules = $contents[0]->getRules();
+        $comments = $divRules[1]->getComments();
+        self::assertCount(1, $comments);
+        self::assertEquals("Find Me!", $comments[0]->getComment());
+    }
+
+    /**
+     * @test
+     */
     public function topLevelCommentExtracting()
     {
         $parser = new Parser('/*Find Me!*/div {left:10px; text-align:left;}');


### PR DESCRIPTION
This is an updated version of #180 

We do rely on this patch, it would be great if it could be merged into the main repository. 