### PR TITLE
Fix PHP 8.1 compatibility in ParserState::strsplit()

### DIFF
--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -480,7 +480,7 @@ class ParserState
     {
         if ($this->oParserSettings->bMultibyteSupport) {
             if ($this->streql($this->sCharset, 'utf-8')) {
-                return preg_split('//u', $sString, null, PREG_SPLIT_NO_EMPTY);
+                return preg_split('//u', $sString, -1, PREG_SPLIT_NO_EMPTY);
             } else {
                 $iLength = mb_strlen($sString, $this->sCharset);
                 $aResult = [];


### PR DESCRIPTION
> Error Message: preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated

see sabberworm/PHP-CSS-Parser#338