### PR TITLE
Do not allow string values for rules anymore

### DIFF
--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -24,7 +24,7 @@ class Rule implements Renderable, Commentable
     private $sRule;
 
     /**
-     * @var RuleValueList|string|null
+     * @var RuleValueList|null
      */
     private $mValue;
 
@@ -171,7 +171,7 @@ class Rule implements Renderable, Commentable
     }
 
     /**
-     * @return RuleValueList|string|null
+     * @return RuleValueList|null
      */
     public function getValue()
     {
@@ -179,7 +179,7 @@ class Rule implements Renderable, Commentable
     }
 
     /**
-     * @param RuleValueList|string|null $mValue
+     * @param RuleValueList|null $mValue
      *
      * @return void
      */


### PR DESCRIPTION
String values had not been allowed for rules, and should not
be. (Passing string values was a bug in the Emogrifier
library.)

@see https://github.com/MyIntervals/emogrifier/pull/1144

This reverts commit 67a6e95f8ad2c9c3d8d745f1943eda8da81383a4.