### PR TITLE
[TASK] Avoid poor scaling of `array_search()` with very long arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Improve performance of Value::parseValue with many delimiters by refactoring to remove array_search()
 - Add visibility to all class/interface constants (#469)
 
 ### Deprecated

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -70,20 +70,26 @@ abstract class Value implements Renderable
             if (count($aStack) === 1) {
                 return $aStack[0];
             }
-            $iStartPosition = null;
-            while (($iStartPosition = array_search($sDelimiter, $aStack, true)) !== false) {
+            $aNewStack = [];
+            for ($iStartPosition = 0; $iStartPosition < count($aStack); $iStartPosition += 1) {
+                if ($iStartPosition === (count($aStack) - 1) || $sDelimiter !== $aStack[$iStartPosition + 1]) {
+                    $aNewStack[] = $aStack[$iStartPosition];
+                    continue;
+                }
                 $iLength = 2; //Number of elements to be joined
-                for ($i = $iStartPosition + 2; $i < count($aStack); $i += 2, ++$iLength) {
+                for ($i = $iStartPosition + 3; $i < count($aStack); $i += 2, ++$iLength) {
                     if ($sDelimiter !== $aStack[$i]) {
                         break;
                     }
                 }
                 $oList = new RuleValueList($sDelimiter, $oParserState->currentLine());
-                for ($i = $iStartPosition - 1; $i - $iStartPosition + 1 < $iLength * 2; $i += 2) {
+                for ($i = $iStartPosition; $i - $iStartPosition < $iLength * 2; $i += 2) {
                     $oList->addListComponent($aStack[$i]);
                 }
-                array_splice($aStack, $iStartPosition - 1, $iLength * 2 - 1, [$oList]);
+                $aNewStack[] = $oList;
+                $iStartPosition += $iLength * 2 - 2;
             }
+            $aStack = $aNewStack;
         }
         if (!isset($aStack[0])) {
             throw new UnexpectedTokenException(

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -66,8 +66,8 @@ abstract class Value implements Renderable
             $oParserState->consumeWhiteSpace();
         }
         // Convert the list to list objects
-        $iStackLength = count($aStack);
         foreach ($aListDelimiters as $sDelimiter) {
+            $iStackLength = count($aStack);
             if ($iStackLength === 1) {
                 return $aStack[0];
             }

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -71,13 +71,14 @@ abstract class Value implements Renderable
                 return $aStack[0];
             }
             $aNewStack = [];
-            for ($iStartPosition = 0; $iStartPosition < count($aStack); ++$iStartPosition) {
-                if ($iStartPosition === (count($aStack) - 1) || $sDelimiter !== $aStack[$iStartPosition + 1]) {
+            $aStackLength = count($aStack);
+            for ($iStartPosition = 0; $iStartPosition < $aStackLength; ++$iStartPosition) {
+                if ($iStartPosition === ($aStackLength - 1) || $sDelimiter !== $aStack[$iStartPosition + 1]) {
                     $aNewStack[] = $aStack[$iStartPosition];
                     continue;
                 }
                 $iLength = 2; //Number of elements to be joined
-                for ($i = $iStartPosition + 3; $i < count($aStack); $i += 2, ++$iLength) {
+                for ($i = $iStartPosition + 3; $i < $aStackLength; $i += 2, ++$iLength) {
                     if ($sDelimiter !== $aStack[$i]) {
                         break;
                     }

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -72,7 +72,7 @@ abstract class Value implements Renderable
                 return $aStack[0];
             }
             $aNewStack = [];
-            for ($iStartPosition = 0; $iStartPosition < $aStackLength; ++$iStartPosition) {
+            for ($iStartPosition = 0; $iStartPosition < $iStackLength; ++$iStartPosition) {
                 if ($iStartPosition === ($iStackLength - 1) || $sDelimiter !== $aStack[$iStartPosition + 1]) {
                     $aNewStack[] = $aStack[$iStartPosition];
                     continue;

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -71,7 +71,7 @@ abstract class Value implements Renderable
                 return $aStack[0];
             }
             $aNewStack = [];
-            for ($iStartPosition = 0; $iStartPosition < count($aStack); $iStartPosition += 1) {
+            for ($iStartPosition = 0; $iStartPosition < count($aStack); ++$iStartPosition) {
                 if ($iStartPosition === (count($aStack) - 1) || $sDelimiter !== $aStack[$iStartPosition + 1]) {
                     $aNewStack[] = $aStack[$iStartPosition];
                     continue;

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -66,19 +66,19 @@ abstract class Value implements Renderable
             $oParserState->consumeWhiteSpace();
         }
         // Convert the list to list objects
+        $iStackLength = count($aStack);
         foreach ($aListDelimiters as $sDelimiter) {
-            if (count($aStack) === 1) {
+            if ($iStackLength === 1) {
                 return $aStack[0];
             }
             $aNewStack = [];
-            $aStackLength = count($aStack);
             for ($iStartPosition = 0; $iStartPosition < $aStackLength; ++$iStartPosition) {
-                if ($iStartPosition === ($aStackLength - 1) || $sDelimiter !== $aStack[$iStartPosition + 1]) {
+                if ($iStartPosition === ($iStackLength - 1) || $sDelimiter !== $aStack[$iStartPosition + 1]) {
                     $aNewStack[] = $aStack[$iStartPosition];
                     continue;
                 }
                 $iLength = 2; //Number of elements to be joined
-                for ($i = $iStartPosition + 3; $i < $aStackLength; $i += 2, ++$iLength) {
+                for ($i = $iStartPosition + 3; $i < $iStackLength; $i += 2, ++$iLength) {
                     if ($sDelimiter !== $aStack[$i]) {
                         break;
                     }


### PR DESCRIPTION
When there are many many elements in $aStack, starting the delimiter search from the beginning for each loop is very very slow. I addressed this by building a new array rather than modifying $aStack in place and iterating over it in a single pass. The particular 1.6M style string that was giving me trouble went from taking 4 minutes to parse to 5 seconds.