### PR TITLE
[TASK] Avoid generating a `composer.lock`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
         "allow-plugins": {
             "phpstan/extension-installer": true
         },
+        "lock": false,
         "preferred-install": {
             "*": "dist"
         },


### PR DESCRIPTION
This is a library, and libraries should not have a lock file.

Fixes #469