### PR TITLE
[BUGFIX] Allow at-rules to be parsed in strict mode (#456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Fix (regression) failure to parse at-rules with strict parsing (#456)
+
 ## 8.5.0
 
 ### Added

--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -131,18 +131,15 @@ abstract class CSSList implements Renderable, Commentable
             }
             return $oAtRule;
         } elseif ($oParserState->comes('}')) {
-            if (!$oParserState->getSettings()->bLenientParsing) {
-                throw new UnexpectedTokenException('CSS selector', '}', 'identifier', $oParserState->currentLine());
-            } else {
-                if ($bIsRoot) {
-                    if ($oParserState->getSettings()->bLenientParsing) {
-                        return DeclarationBlock::parse($oParserState);
-                    } else {
-                        throw new SourceException("Unopened {", $oParserState->currentLine());
-                    }
+            if ($bIsRoot) {
+                if ($oParserState->getSettings()->bLenientParsing) {
+                    return DeclarationBlock::parse($oParserState);
                 } else {
-                    return null;
+                    throw new SourceException("Unopened {", $oParserState->currentLine());
                 }
+            } else {
+                // End of list
+                return null;
             }
         } else {
             return DeclarationBlock::parse($oParserState, $oList);

--- a/tests/CSSList/AtRuleBlockListTest.php
+++ b/tests/CSSList/AtRuleBlockListTest.php
@@ -17,7 +17,7 @@ final class AtRuleBlockListTest extends TestCase
     /**
      * @return array<string, array{0: string}>
      */
-    public static function provideMinWidthMediaRule(): array
+    public static function provideMinWidthMediaRule()
     {
         return [
             'without spaces around arguments' => ['@media(min-width: 768px){.class{color:red}}'],
@@ -28,7 +28,7 @@ final class AtRuleBlockListTest extends TestCase
     /**
      * @return array<string, array{0: string}>
      */
-    public static function provideSyntacticlyCorrectAtRule(): array
+    public static function provideSyntacticlyCorrectAtRule()
     {
         return [
             'media print' => ['@media print { html { background: white; color: black; } }'],
@@ -110,10 +110,12 @@ final class AtRuleBlockListTest extends TestCase
     /**
      * @test
      *
+     * @param string $css
+     *
      * @dataProvider provideMinWidthMediaRule
      * @dataProvider provideSyntacticlyCorrectAtRule
      */
-    public function parsesSyntacticlyCorrectAtRuleInStrictMode(string $css): void
+    public function parsesSyntacticlyCorrectAtRuleInStrictMode($css)
     {
         $contents = (new Parser($css, Settings::create()->beStrict()))->parse()->getContents();
 

--- a/tests/CSSList/AtRuleBlockListTest.php
+++ b/tests/CSSList/AtRuleBlockListTest.php
@@ -7,12 +7,46 @@ use Sabberworm\CSS\Comment\Commentable;
 use Sabberworm\CSS\CSSList\AtRuleBlockList;
 use Sabberworm\CSS\Parser;
 use Sabberworm\CSS\Renderable;
+use Sabberworm\CSS\Settings;
 
 /**
  * @covers \Sabberworm\CSS\CSSList\AtRuleBlockList
  */
 final class AtRuleBlockListTest extends TestCase
 {
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function provideMinWidthMediaRule(): array
+    {
+        return [
+            'without spaces around arguments' => ['@media(min-width: 768px){.class{color:red}}'],
+            'with spaces around arguments' => ['@media (min-width: 768px) {.class{color:red}}'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function provideSyntacticlyCorrectAtRule(): array
+    {
+        return [
+            'media print' => ['@media print { html { background: white; color: black; } }'],
+            'keyframes' => ['@keyframes mymove { from { top: 0px; } }'],
+            'supports' => ['
+                @supports (display: flex) {
+                    .flex-container > * {
+                        text-shadow: 0 0 2px blue;
+                        float: none;
+                    }
+                    .flex-container {
+                        display: flex;
+                    }
+                }
+            '],
+        ];
+    }
+
     /**
      * @test
      */
@@ -44,22 +78,11 @@ final class AtRuleBlockListTest extends TestCase
     }
 
     /**
-     * @return array<string, array<int, string>>
-     */
-    public static function mediaRuleDataProvider()
-    {
-        return [
-            'without spaces around arguments' => ['@media(min-width: 768px){.class{color:red}}'],
-            'with spaces around arguments' => ['@media (min-width: 768px) {.class{color:red}}'],
-        ];
-    }
-
-    /**
      * @test
      *
      * @param string $css
      *
-     * @dataProvider mediaRuleDataProvider
+     * @dataProvider provideMinWidthMediaRule
      */
     public function parsesRuleNameOfMediaQueries($css)
     {
@@ -74,7 +97,7 @@ final class AtRuleBlockListTest extends TestCase
      *
      * @param string $css
      *
-     * @dataProvider mediaRuleDataProvider
+     * @dataProvider provideMinWidthMediaRule
      */
     public function parsesArgumentsOfMediaQueries($css)
     {
@@ -82,5 +105,18 @@ final class AtRuleBlockListTest extends TestCase
         $atRuleBlockList = $contents[0];
 
         self::assertSame('(min-width: 768px)', $atRuleBlockList->atRuleArgs());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideMinWidthMediaRule
+     * @dataProvider provideSyntacticlyCorrectAtRule
+     */
+    public function parsesSyntacticlyCorrectAtRuleInStrictMode(string $css): void
+    {
+        $contents = (new Parser($css, Settings::create()->beStrict()))->parse()->getContents();
+
+        self::assertNotEmpty($contents, 'Failing CSS: `' . $css . '`');
     }
 }


### PR DESCRIPTION
The reverts the change to `CSSList` in
https://github.com/MyIntervals/PHP-CSS-Parser/commit/134f4e62fe8ab9f316425f3c0f480b3f4f52d804 and adds a comment that `null` is an expected return value when the end of the list (or block) is reached.

Fixes #352