### PR TITLE
[TASK] Stop collecting code coverage on the maintenance branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '5.6', '7.0', '7.1', '7.2', '7.3' ]
-        coverage: [ 'none' ]
-        include:
-          - php-version: '7.4'
-            coverage: xdebug
+        php-version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4' ]
 
     steps:
       - name: Checkout
@@ -57,7 +53,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
           ini-values: error_reporting=E_ALL
           tools: composer:v2
-          coverage: "${{ matrix.coverage }}"
+          coverage: none
 
       - name: Show the Composer configuration
         run: composer config --global --list
@@ -76,14 +72,7 @@ jobs:
           composer show;
 
       - name: Run Tests
-        run: ./vendor/bin/phpunit --coverage-clover build/coverage/xml
-
-      - name: Upload coverage results to Codacy
-        env:
-          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        if: "${{ matrix.coverage != 'none' && env.CODACY_PROJECT_TOKEN != '' }}"
-        run: |
-          ./vendor/bin/codacycoverage clover build/coverage/xml
+        run: ./vendor/bin/phpunit
 
   static-analysis:
     name: Static Analysis

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "ext-iconv": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.27",
-        "codacy/coverage": "^1.4.3"
+        "phpunit/phpunit": "^5.7.27"
     },
     "suggest": {
         "ext-mbstring": "for parsing UTF-8 CSS"


### PR DESCRIPTION
We're not using the code coverage of maintenance branches for anything and could as well speed up the CI build instead.