### PR TITLE
[FEATURE] Add --diff to PHP-CS-Fixer CI dry-run command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "ci": [
             "@ci:static"
         ],
-        "ci:php:fixer": "@php ./.phive/php-cs-fixer.phar --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots bin src tests",
+        "ci:php:fixer": "@php ./.phive/php-cs-fixer.phar --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff bin src tests",
         "ci:php:stan": "phpstan --no-progress --configuration=config/phpstan.neon",
         "ci:static": [
             "@ci:php:fixer",


### PR DESCRIPTION
This helps quickly identify the problem.

E.g.

Before:

```cmd
d:\dev\php-css-parser>composer ci:php:fixer
> @php ./.phive/php-cs-fixer.phar --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots bin src tests
PHP CS Fixer 3.49.0 (b6dc318) Insomnia by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 7.4.16
Loaded config default from "config/php-cs-fixer.php".
...............................................   1) tests\Value\SizeTest.php (function_declaration, php_unit_fqcn_annotation)

Found 1 of 52 files that can be fixed in 1.802 seconds, 20.000 MB memory used
..F..                                                      52 / 52 (100%)
Legend: .-no changes, F-fixed, S-skipped (cached or empty file), I-invalid file syntax (file ignored), E-error
Script @php ./.phive/php-cs-fixer.phar --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots bin src tests handling the ci:php:fixer event returned with error code 8
```

Not possible to know what the problem is without further investigation.

After:

```cmd
d:\dev\php-css-parser>composer ci:php:fixer
> @php ./.phive/php-cs-fixer.phar --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff bin src tests
   1) tests\Value\SizeTest.php (php_unit_fqcn_annotation)
      ---------- begin diff ----------
--- D:\dev\php-css-parser\tests\Value\SizeTest.php
+++ D:\dev\php-css-parser\tests\Value\SizeTest.php
@@ -8,7 +8,7 @@
 use Sabberworm\CSS\Value\Size;

 /**
- * @covers Size
+ * @covers \Size
  */
 final class SizeTest extends TestCase
 {

      ----------- end diff -----------

Found 1 of 52 files that can be fixed in 0.029 seconds, 14.000 MB memory used
PHP CS Fixer 3.49.0 (b6dc318) Insomnia by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 7.4.16
Loaded config default from "config/php-cs-fixer.php".
Using cache file ".php-cs-fixer.cache".
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSFSS                                                      52 / 52 (100%)
Legend: .-no changes, F-fixed, S-skipped (cached or empty file), I-invalid file syntax (file ignored), E-error
Script @php ./.phive/php-cs-fixer.phar --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff bin src tests handling the ci:php:fixer event returned with error code 8
```

It's now clear what the problem is, and it can be simply resolved. In this case the suggested fix was not correct.