### PR TITLE
[BUGFIX] Invoke PHIVE-installed tools via shell

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.49.0" installed="3.49.0" location="./.phive/php-cs-fixer.phar" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.49.0" installed="3.49.0" location="./.phive/php-cs-fixer" copy="false"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "ci": [
             "@ci:static"
         ],
-        "ci:php:fixer": "@php ./.phive/php-cs-fixer.phar --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff bin src tests",
+        "ci:php:fixer": "\"./.phive/php-cs-fixer\" --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff bin src tests",
         "ci:php:stan": "phpstan --no-progress --configuration=config/phpstan.neon",
         "ci:static": [
             "@ci:php:fixer",
@@ -73,7 +73,7 @@
         "fix:php": [
             "@fix:php:fixer"
         ],
-        "fix:php:fixer": "@php ./.phive/php-cs-fixer.phar --config=config/php-cs-fixer.php fix bin src tests",
+        "fix:php:fixer": "\"./.phive/php-cs-fixer\" --config=config/php-cs-fixer.php fix bin src tests",
         "phpstan:baseline": "phpstan --configuration=config/phpstan.neon --generate-baseline=config/phpstan-baseline.neon"
     },
     "scripts-descriptions": {


### PR DESCRIPTION
On Windows, the `.phive` directory contains batch files that in turn invoke the phar installed elsewhere on the system.  To be compatible with both Linux and Windows, the file must be invoked directly via the shell, and without the file extension specified.

Fixes #479.