### PR TITLE
[BUGFIX] Handle incorrect RGB colors better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Fix PHP notice caused by parsing invalid color values having less than 6 charachters (#485)
 - Fix (regression) failure to parse at-rules with strict parsing (#456)
 
 ## 8.5.0

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -63,12 +63,12 @@ class Color extends CSSFunction
                     'b' => new Size(intval($sValue[4] . $sValue[5], 16), null, true, $oParserState->currentLine()),
                 ];
             } else {
-                // the size of input color string is incorrect, use black color as fallback
-                $aColor = [
-                    'r' => new Size(0, null, true, $oParserState->currentLine()),
-                    'g' => new Size(0, null, true, $oParserState->currentLine()),
-                    'b' => new Size(0, null, true, $oParserState->currentLine()),
-                ];
+                throw new UnexpectedTokenException(
+                    'Invalid hex color value', 
+                    $sValue, 
+                    'custom', 
+                    $oParserState->currentLine()
+                );
             }
         } else {
             $sColorMode = $oParserState->parseIdentifier(true);

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -56,7 +56,7 @@ class Color extends CSSFunction
                         $oParserState->currentLine()
                     ),
                 ];
-            } else if ($oParserState->strlen($sValue) === 6) {
+            } elseif ($oParserState->strlen($sValue) === 6) {
                 $aColor = [
                     'r' => new Size(intval($sValue[0] . $sValue[1], 16), null, true, $oParserState->currentLine()),
                     'g' => new Size(intval($sValue[2] . $sValue[3], 16), null, true, $oParserState->currentLine()),

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -56,11 +56,18 @@ class Color extends CSSFunction
                         $oParserState->currentLine()
                     ),
                 ];
-            } else {
+            } else if ($oParserState->strlen($sValue) === 6) {
                 $aColor = [
                     'r' => new Size(intval($sValue[0] . $sValue[1], 16), null, true, $oParserState->currentLine()),
                     'g' => new Size(intval($sValue[2] . $sValue[3], 16), null, true, $oParserState->currentLine()),
                     'b' => new Size(intval($sValue[4] . $sValue[5], 16), null, true, $oParserState->currentLine()),
+                ];
+            } else {
+                // the size of input color string is incorrect, use black color as fallback
+                $aColor = [
+                    'r' => new Size(0, null, true, $oParserState->currentLine()),
+                    'g' => new Size(0, null, true, $oParserState->currentLine()),
+                    'b' => new Size(0, null, true, $oParserState->currentLine()),
                 ];
             }
         } else {

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -64,9 +64,9 @@ class Color extends CSSFunction
                 ];
             } else {
                 throw new UnexpectedTokenException(
-                    'Invalid hex color value', 
-                    $sValue, 
-                    'custom', 
+                    'Invalid hex color value',
+                    $sValue,
+                    'custom',
                     $oParserState->currentLine()
                 );
             }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -147,12 +147,7 @@ final class ParserTest extends TestCase
                     'a' => new Size(0000.3, null, true, $oColor->getLineNo()),
                 ], $oColor->getColor());
                 $aColorRule = $oRuleSet->getRules('outline-color');
-                $oColor = $aColorRule[0]->getValue();
-                self::assertEquals([
-                    'r' => new Size(0, null, true, $oColor->getLineNo()),
-                    'g' => new Size(0, null, true, $oColor->getLineNo()),
-                    'b' => new Size(0, null, true, $oColor->getLineNo()),
-                ], $oColor->getColor());
+                self::assertEmpty($aColorRule);                
             }
         }
         foreach ($oDoc->getAllValues('color') as $sColor) {
@@ -162,7 +157,7 @@ final class ParserTest extends TestCase
             '#mine {color: red;border-color: #0a64e6;border-color: rgba(10,100,231,.3);outline-color: #222;'
             . 'background-color: #232323;}'
             . "\n"
-            . '#yours {background-color: hsl(220,10%,220%);background-color: hsla(220,10%,220%,.3);outline-color: #000;}'
+            . '#yours {background-color: hsl(220,10%,220%);background-color: hsla(220,10%,220%,.3);}'
             . "\n"
             . '#variables {background-color: rgb(var(--some-rgb));background-color: rgb(var(--r),var(--g),var(--b));'
             . 'background-color: rgb(255,var(--g),var(--b));background-color: rgb(255,255,var(--b));'

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -147,7 +147,7 @@ final class ParserTest extends TestCase
                     'a' => new Size(0000.3, null, true, $oColor->getLineNo()),
                 ], $oColor->getColor());
                 $aColorRule = $oRuleSet->getRules('outline-color');
-                self::assertEmpty($aColorRule);                
+                self::assertEmpty($aColorRule);
             }
         }
         foreach ($oDoc->getAllValues('color') as $sColor) {

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -146,6 +146,13 @@ final class ParserTest extends TestCase
                     'l' => new Size(220.0, '%', true, $oColor->getLineNo()),
                     'a' => new Size(0000.3, null, true, $oColor->getLineNo()),
                 ], $oColor->getColor());
+                $aColorRule = $oRuleSet->getRules('outline-color');
+                $oColor = $aColorRule[0]->getValue();
+                self::assertEquals([
+                    'r' => new Size(0, null, true, $oColor->getLineNo()),
+                    'g' => new Size(0, null, true, $oColor->getLineNo()),
+                    'b' => new Size(0, null, true, $oColor->getLineNo()),
+                ], $oColor->getColor());
             }
         }
         foreach ($oDoc->getAllValues('color') as $sColor) {
@@ -155,7 +162,7 @@ final class ParserTest extends TestCase
             '#mine {color: red;border-color: #0a64e6;border-color: rgba(10,100,231,.3);outline-color: #222;'
             . 'background-color: #232323;}'
             . "\n"
-            . '#yours {background-color: hsl(220,10%,220%);background-color: hsla(220,10%,220%,.3);}'
+            . '#yours {background-color: hsl(220,10%,220%);background-color: hsla(220,10%,220%,.3);outline-color: #000;}'
             . "\n"
             . '#variables {background-color: rgb(var(--some-rgb));background-color: rgb(var(--r),var(--g),var(--b));'
             . 'background-color: rgb(255,var(--g),var(--b));background-color: rgb(255,255,var(--b));'

--- a/tests/fixtures/colortest.css
+++ b/tests/fixtures/colortest.css
@@ -9,6 +9,7 @@
 #yours {
 	background-color: hsl(220, 10%, 220%);
 	background-color: hsla(220, 10%, 220%, 0.3);
+	outline-color: #22;
 }
 
 #variables {


### PR DESCRIPTION
There is an issue when handling incorrect RGB colors which have lesser character numbers than 6. In this situation, we should probably either throw an exception OR define a fallback value for the color. 
In this PR, I have updated the code to use RGB(0,0,0) as the fallback color when this situation happens.
Thank you