### PR TITLE
[FEATURE] Add Composer scripts to run unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,5 +633,17 @@ class Sabberworm\CSS\CSSList\Document#4 (2) {
 
 ## Misc
 
-* Legacy Support: The latest pre-PSR-0 version of this project can be checked with the `0.9.0` tag.
-* Running Tests: To run all unit tests for this project, run `composer install` to install phpunit and use `./vendor/bin/phpunit`.
+### Legacy Support
+
+The latest pre-PSR-0 version of this project can be checked with the `0.9.0` tag.
+
+### Running Tests
+
+To run all continuous integration (CI) checks for this project (including unit tests),
+* run `composer install` to install the development dependencies managed with Composer;
+* run `phive install` to install the development dependencies managed with PHIVE;
+  * [Installation of PHIVE](https://github.com/phar-io/phive?tab=readme-ov-file#getting-phive)
+* run `composer ci` to run all static and dynamic CI checks.
+
+Details of other Composer scripts available (e.g. to run one specific CI check) are provided with `composer list`.
+


### PR DESCRIPTION
The `ci` script now also runs `ci:dynamic` which in turn runs `ci:tests`.

The PHPUnit cache is only applicable if the configuration is to run previously failing tests first, which it isn't, hence `--do-not-cache-result`.

Also update the readme instructions for running all code checks.

Relates to #486.