### PR TITLE
[TASK] Mark all class constants as `@internal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Mark all class constants as `@internal` (#494)
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Mark all class constants as `@internal` (#494)
+- Mark all class constants as `@internal` (#500)
 
 ### Deprecated
 

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -9,6 +9,8 @@ class ParserState
 {
     /**
      * @var null
+     *
+     * @internal
      */
     const EOF = null;
 

--- a/src/Property/AtRule.php
+++ b/src/Property/AtRule.php
@@ -12,6 +12,8 @@ interface AtRule extends Renderable, Commentable
      * we’re whitelisting the block rules and have anything else be treated as a set rule.
      *
      * @var string
+     *
+     * @internal
      */
     const BLOCK_RULES = 'media/document/supports/region-style/font-feature-values';
 
@@ -19,6 +21,8 @@ interface AtRule extends Renderable, Commentable
      * … and more font-specific ones (to be used inside font-feature-values)
      *
      * @var string
+     *
+     * @internal
      */
     const SET_RULES = 'font-face/counter-style/page/swash/styleset/annotation';
 

--- a/src/Property/KeyframeSelector.php
+++ b/src/Property/KeyframeSelector.php
@@ -8,6 +8,8 @@ class KeyframeSelector extends Selector
      * regexp for specificity calculations
      *
      * @var string
+     *
+     * @internal
      */
     const SELECTOR_VALIDATION_RX = '/
     ^(

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -12,6 +12,8 @@ class Selector
      * regexp for specificity calculations
      *
      * @var string
+     *
+     * @internal
      */
     const NON_ID_ATTRIBUTES_AND_PSEUDO_CLASSES_RX = '/
         (\.[\w]+)                   # classes
@@ -36,6 +38,8 @@ class Selector
      * regexp for specificity calculations
      *
      * @var string
+     *
+     * @internal
      */
     const ELEMENTS_AND_PSEUDO_ELEMENTS_RX = '/
         ((^|[\s\+\>\~]+)[\w]+   # elements
@@ -49,6 +53,8 @@ class Selector
      * regexp for specificity calculations
      *
      * @var string
+     *
+     * @internal
      */
     const SELECTOR_VALIDATION_RX = '/
         ^(

--- a/src/Value/CalcFunction.php
+++ b/src/Value/CalcFunction.php
@@ -10,11 +10,15 @@ class CalcFunction extends CSSFunction
 {
     /**
      * @var int
+     *
+     * @internal
      */
     const T_OPERAND = 1;
 
     /**
      * @var int
+     *
+     * @internal
      */
     const T_OPERATOR = 2;
 

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -16,16 +16,22 @@ class Size extends PrimitiveValue
      * vh/vw/vm(ax)/vmin/rem are absolute insofar as they don’t scale to the immediate parent (only the viewport)
      *
      * @var array<int, string>
+     *
+     * @internal
      */
     const ABSOLUTE_SIZE_UNITS = ['px', 'cm', 'mm', 'mozmm', 'in', 'pt', 'pc', 'vh', 'vw', 'vmin', 'vmax', 'rem'];
 
     /**
      * @var array<int, string>
+     *
+     * @internal
      */
     const RELATIVE_SIZE_UNITS = ['%', 'em', 'ex', 'ch', 'fr'];
 
     /**
      * @var array<int, string>
+     *
+     * @internal
      */
     const NON_SIZE_UNITS = ['deg', 'grad', 'rad', 's', 'ms', 'turn', 'Hz', 'kHz'];
 


### PR DESCRIPTION
This communicates that the constants must not be accessed from outside the project, thus preventing breakage as most of the constants will have a reduced visibility in version 9 (#470).