### PR TITLE
[CLEANUP] Use common ancestor `Value` in type specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,12 +813,6 @@ classDiagram
     RuleSet --> "*" Comment : aComments
     RuleSet --> "*" Rule : aRules
     URL --> "1" CSSString : oURL
-    ValueList --> "*" CSSFunction : aComponents
-    ValueList --> "*" CSSString : aComponents
-    ValueList --> "*" LineName : aComponents
-    ValueList --> "*" RuleValueList : aComponents
-    ValueList --> "*" Size : aComponents
-    ValueList --> "*" URL : aComponents
 ```
 
 ## Contributors/Thanks to

--- a/README.md
+++ b/README.md
@@ -813,6 +813,7 @@ classDiagram
     RuleSet --> "*" Comment : aComments
     RuleSet --> "*" Rule : aRules
     URL --> "1" CSSString : oURL
+    ValueList --> "*" Value : aComponents
 ```
 
 ## Contributors/Thanks to

--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -18,7 +18,7 @@ class CSSFunction extends ValueList
 
     /**
      * @param string $sName
-     * @param RuleValueList|array<int, RuleValueList|CSSFunction|CSSString|LineName|Size|URL|string> $aArguments
+     * @param RuleValueList|array<int, Value|string> $aArguments
      * @param string $sSeparator
      * @param int $iLineNo
      */
@@ -72,7 +72,7 @@ class CSSFunction extends ValueList
     }
 
     /**
-     * @return array<int, RuleValueList|CSSFunction|CSSString|LineName|Size|URL|string>
+     * @return array<int, Value|string>
      */
     public function getArguments()
     {

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -14,7 +14,7 @@ use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 class Color extends CSSFunction
 {
     /**
-     * @param array<int, RuleValueList|CSSFunction|CSSString|LineName|Size|URL|string> $aColor
+     * @param array<int, Value|string> $aColor
      * @param int $iLineNo
      */
     public function __construct(array $aColor, $iLineNo = 0)
@@ -125,7 +125,7 @@ class Color extends CSSFunction
     }
 
     /**
-     * @return array<int, RuleValueList|CSSFunction|CSSString|LineName|Size|URL|string>
+     * @return array<int, Value|string>
      */
     public function getColor()
     {
@@ -133,7 +133,7 @@ class Color extends CSSFunction
     }
 
     /**
-     * @param array<int, RuleValueList|CSSFunction|CSSString|LineName|Size|URL|string> $aColor
+     * @param array<int, Value|string> $aColor
      *
      * @return void
      */

--- a/src/Value/LineName.php
+++ b/src/Value/LineName.php
@@ -10,7 +10,7 @@ use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 class LineName extends ValueList
 {
     /**
-     * @param array<int, RuleValueList|CSSFunction|CSSString|LineName|Size|URL|string> $aComponents
+     * @param array<int, Value|string> $aComponents
      * @param int $iLineNo
      */
     public function __construct(array $aComponents = [], $iLineNo = 0)

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -30,14 +30,14 @@ abstract class Value implements Renderable
     /**
      * @param array<array-key, string> $aListDelimiters
      *
-     * @return RuleValueList|CSSFunction|CSSString|LineName|Size|URL|string
+     * @return Value|string
      *
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
      */
     public static function parseValue(ParserState $oParserState, array $aListDelimiters = [])
     {
-        /** @var array<int, RuleValueList|CSSFunction|CSSString|LineName|Size|URL|string> $aStack */
+        /** @var array<int, Value|string> $aStack */
         $aStack = [];
         $oParserState->consumeWhiteSpace();
         //Build a list of delimiters and parsed values

--- a/src/Value/ValueList.php
+++ b/src/Value/ValueList.php
@@ -13,7 +13,7 @@ use Sabberworm\CSS\OutputFormat;
 abstract class ValueList extends Value
 {
     /**
-     * @var array<int, RuleValueList|CSSFunction|CSSString|LineName|Size|URL|string>
+     * @var array<int, Value|string>
      */
     protected $aComponents;
 
@@ -23,8 +23,7 @@ abstract class ValueList extends Value
     protected $sSeparator;
 
     /**
-     * phpcs:ignore Generic.Files.LineLength
-     * @param array<int, RuleValueList|CSSFunction|CSSString|LineName|Size|URL|string>|RuleValueList|CSSFunction|CSSString|LineName|Size|URL|string $aComponents
+     * @param array<int, Value|string>|Value|string $aComponents
      * @param string $sSeparator
      * @param int $iLineNo
      */
@@ -39,7 +38,7 @@ abstract class ValueList extends Value
     }
 
     /**
-     * @param RuleValueList|CSSFunction|CSSString|LineName|Size|URL|string $mComponent
+     * @param Value|string $mComponent
      *
      * @return void
      */
@@ -49,7 +48,7 @@ abstract class ValueList extends Value
     }
 
     /**
-     * @return array<int, RuleValueList|CSSFunction|CSSString|LineName|Size|URL|string>
+     * @return array<int, Value|string>
      */
     public function getListComponents()
     {
@@ -57,7 +56,7 @@ abstract class ValueList extends Value
     }
 
     /**
-     * @param array<int, RuleValueList|CSSFunction|CSSString|LineName|Size|URL|string> $aComponents
+     * @param array<int, Value|string> $aComponents
      *
      * @return void
      */


### PR DESCRIPTION
Replace the list of various possible sub-types with the common ancestor.

Update the class diagram to indicate that `ValueList::$aComponents` no longer has a dependency on the sub-types definitions.

Resolves #499.  Supersedes and closes #506.