### PR TITLE
[TASK] Fix typo "abstruct" in the class diagram (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ classDiagram
     class DeclarationBlock {
     }
     class RuleSet {
-        <<abstruct>>
+        <<abstract>>
     }
     class AtRuleSet {
     }
@@ -669,12 +669,12 @@ classDiagram
     class Anchor {
     }
     class CSSBlockList {
-        <<abstruct>>
+        <<abstract>>
     }
     class Document {
     }
     class CSSList {
-        <<abstruct>>
+        <<abstract>>
     }
     class KeyFrame {
     }
@@ -687,21 +687,21 @@ classDiagram
     class CalcRuleValueList {
     }
     class ValueList {
-        <<abstruct>>
+        <<abstract>>
     }
     class CalcFunction {
     }
     class LineName {
     }
     class Value {
-        <<abstruct>>
+        <<abstract>>
     }
     class Size {
     }
     class CSSString {
     }
     class PrimitiveValue {
-        <<abstruct>>
+        <<abstract>>
     }
     class CSSFunction {
     }


### PR DESCRIPTION
This ends the abstruction of the class diagram.

These typos in the class diagram were caused by a typo in the Mermaid generation tool, which is now fixed.

https://github.com/tasuku43/php-mermaid-class-diagram/releases