### PR TITLE
[TASK] Use the development PHP INI on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          ini-file: development
           coverage: none
 
       - name: PHP Lint
@@ -51,7 +52,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          ini-values: error_reporting=E_ALL
+          ini-file: development
           tools: composer:v2
           coverage: none
 
@@ -98,6 +99,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          ini-file: development
           tools: "composer:v2, phive"
           coverage: none
 

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -26,7 +26,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          ini-values: error_reporting=E_ALL
+          ini-file: development
           tools: composer:v2
           coverage: xdebug
 


### PR DESCRIPTION
This allows us to see (and fail on) PHP warnings and notices.

Fixes #528