### PR TITLE
[TASK] rector: set PHP rule-set to the same version as composer.json

### DIFF
--- a/config/rector.php
+++ b/config/rector.php
@@ -13,7 +13,7 @@ return RectorConfig::configure()
             __DIR__ . '/../tests',
         ]
     )
-    ->withSets([SetList::PHP_71])
+    ->withPhpSets()
     ->withRules(
         [
             // AddVoidReturnTypeWhereNoReturnRector::class,


### PR DESCRIPTION
This way rector always follows the minimal required version in composer.json, which currently is PHP 7.2.

This helps with #433.