### PR TITLE
[CLEANUP] rector: Add void to PHPUnit test methods

### DIFF
--- a/tests/CSSList/AtRuleBlockListTest.php
+++ b/tests/CSSList/AtRuleBlockListTest.php
@@ -50,7 +50,7 @@ final class AtRuleBlockListTest extends TestCase
     /**
      * @test
      */
-    public function implementsAtRule()
+    public function implementsAtRule(): void
     {
         $subject = new AtRuleBlockList('');
 
@@ -60,7 +60,7 @@ final class AtRuleBlockListTest extends TestCase
     /**
      * @test
      */
-    public function implementsRenderable()
+    public function implementsRenderable(): void
     {
         $subject = new AtRuleBlockList('');
 
@@ -70,7 +70,7 @@ final class AtRuleBlockListTest extends TestCase
     /**
      * @test
      */
-    public function implementsCommentable()
+    public function implementsCommentable(): void
     {
         $subject = new AtRuleBlockList('');
 
@@ -84,7 +84,7 @@ final class AtRuleBlockListTest extends TestCase
      *
      * @dataProvider provideMinWidthMediaRule
      */
-    public function parsesRuleNameOfMediaQueries($css)
+    public function parsesRuleNameOfMediaQueries($css): void
     {
         $contents = (new Parser($css))->parse()->getContents();
         $atRuleBlockList = $contents[0];
@@ -99,7 +99,7 @@ final class AtRuleBlockListTest extends TestCase
      *
      * @dataProvider provideMinWidthMediaRule
      */
-    public function parsesArgumentsOfMediaQueries($css)
+    public function parsesArgumentsOfMediaQueries($css): void
     {
         $contents = (new Parser($css))->parse()->getContents();
         $atRuleBlockList = $contents[0];

--- a/tests/CSSList/DocumentTest.php
+++ b/tests/CSSList/DocumentTest.php
@@ -26,7 +26,7 @@ final class DocumentTest extends TestCase
     /**
      * @test
      */
-    public function implementsRenderable()
+    public function implementsRenderable(): void
     {
         self::assertInstanceOf(Renderable::class, $this->subject);
     }
@@ -34,7 +34,7 @@ final class DocumentTest extends TestCase
     /**
      * @test
      */
-    public function implementsCommentable()
+    public function implementsCommentable(): void
     {
         self::assertInstanceOf(Commentable::class, $this->subject);
     }
@@ -42,7 +42,7 @@ final class DocumentTest extends TestCase
     /**
      * @test
      */
-    public function getContentsInitiallyReturnsEmptyArray()
+    public function getContentsInitiallyReturnsEmptyArray(): void
     {
         self::assertSame([], $this->subject->getContents());
     }
@@ -66,7 +66,7 @@ final class DocumentTest extends TestCase
      *
      * @dataProvider contentsDataProvider
      */
-    public function setContentsSetsContents(array $contents)
+    public function setContentsSetsContents(array $contents): void
     {
         $this->subject->setContents($contents);
 
@@ -76,7 +76,7 @@ final class DocumentTest extends TestCase
     /**
      * @test
      */
-    public function setContentsReplacesContentsSetInPreviousCall()
+    public function setContentsReplacesContentsSetInPreviousCall(): void
     {
         $contents2 = [new DeclarationBlock()];
 

--- a/tests/CSSList/KeyFrameTest.php
+++ b/tests/CSSList/KeyFrameTest.php
@@ -26,7 +26,7 @@ final class KeyFrameTest extends TestCase
     /**
      * @test
      */
-    public function implementsAtRule()
+    public function implementsAtRule(): void
     {
         self::assertInstanceOf(AtRule::class, $this->subject);
     }
@@ -34,7 +34,7 @@ final class KeyFrameTest extends TestCase
     /**
      * @test
      */
-    public function implementsRenderable()
+    public function implementsRenderable(): void
     {
         self::assertInstanceOf(Renderable::class, $this->subject);
     }
@@ -42,7 +42,7 @@ final class KeyFrameTest extends TestCase
     /**
      * @test
      */
-    public function implementsCommentable()
+    public function implementsCommentable(): void
     {
         self::assertInstanceOf(Commentable::class, $this->subject);
     }

--- a/tests/Comment/CommentTest.php
+++ b/tests/Comment/CommentTest.php
@@ -19,7 +19,7 @@ final class CommentTest extends TestCase
     /**
      * @test
      */
-    public function implementsRenderable()
+    public function implementsRenderable(): void
     {
         $subject = new Comment();
 
@@ -29,7 +29,7 @@ final class CommentTest extends TestCase
     /**
      * @test
      */
-    public function getCommentOnEmptyInstanceReturnsReturnsEmptyString()
+    public function getCommentOnEmptyInstanceReturnsReturnsEmptyString(): void
     {
         $subject = new Comment();
 
@@ -39,7 +39,7 @@ final class CommentTest extends TestCase
     /**
      * @test
      */
-    public function getCommentInitiallyReturnsCommentPassedToConstructor()
+    public function getCommentInitiallyReturnsCommentPassedToConstructor(): void
     {
         $comment = 'There is no spoon.';
         $subject = new Comment($comment);
@@ -50,7 +50,7 @@ final class CommentTest extends TestCase
     /**
      * @test
      */
-    public function setCommentSetsComments()
+    public function setCommentSetsComments(): void
     {
         $comment = 'There is no spoon.';
         $subject = new Comment();
@@ -63,7 +63,7 @@ final class CommentTest extends TestCase
     /**
      * @test
      */
-    public function getLineNoOnEmptyInstanceReturnsReturnsZero()
+    public function getLineNoOnEmptyInstanceReturnsReturnsZero(): void
     {
         $subject = new Comment();
 
@@ -73,7 +73,7 @@ final class CommentTest extends TestCase
     /**
      * @test
      */
-    public function getLineNoInitiallyReturnsLineNumberPassedToConstructor()
+    public function getLineNoInitiallyReturnsLineNumberPassedToConstructor(): void
     {
         $lineNumber = 42;
         $subject = new Comment('', $lineNumber);
@@ -84,7 +84,7 @@ final class CommentTest extends TestCase
     /**
      * @test
      */
-    public function toStringRendersCommentEnclosedInCommentDelimiters()
+    public function toStringRendersCommentEnclosedInCommentDelimiters(): void
     {
         $comment = 'There is no spoon.';
         $subject = new Comment();
@@ -97,7 +97,7 @@ final class CommentTest extends TestCase
     /**
      * @test
      */
-    public function renderRendersCommentEnclosedInCommentDelimiters()
+    public function renderRendersCommentEnclosedInCommentDelimiters(): void
     {
         $comment = 'There is no spoon.';
         $subject = new Comment();
@@ -110,7 +110,7 @@ final class CommentTest extends TestCase
     /**
      * @test
      */
-    public function keepCommentsInOutput()
+    public function keepCommentsInOutput(): void
     {
         $oCss = TestsParserTest::parsedStructureForFile('comments');
         self::assertSame('/** Number 11 **/
@@ -152,7 +152,7 @@ final class CommentTest extends TestCase
     /**
      * @test
      */
-    public function stripCommentsFromOutput()
+    public function stripCommentsFromOutput(): void
     {
         $oCss = TestsParserTest::parsedStructureForFile('comments');
         self::assertSame('

--- a/tests/OutputFormatTest.php
+++ b/tests/OutputFormatTest.php
@@ -52,7 +52,7 @@ EOT;
     /**
      * @test
      */
-    public function plain()
+    public function plain(): void
     {
         self::assertSame(
             '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white;}
@@ -64,7 +64,7 @@ EOT;
     /**
      * @test
      */
-    public function compact()
+    public function compact(): void
     {
         self::assertSame(
             '.main,.test{font:italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background:white;}'
@@ -76,7 +76,7 @@ EOT;
     /**
      * @test
      */
-    public function pretty()
+    public function pretty(): void
     {
         self::assertSame(self::TEST_CSS, $this->oDocument->render(OutputFormat::createPretty()));
     }
@@ -84,7 +84,7 @@ EOT;
     /**
      * @test
      */
-    public function spaceAfterListArgumentSeparator()
+    public function spaceAfterListArgumentSeparator(): void
     {
         self::assertSame(
             '.main, .test {font: italic   normal   bold   16px/  1.2   '
@@ -97,7 +97,7 @@ EOT;
     /**
      * @test
      */
-    public function spaceAfterListArgumentSeparatorComplex()
+    public function spaceAfterListArgumentSeparatorComplex(): void
     {
         self::assertSame(
             '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",	Verdana,	sans-serif;background: white;}'
@@ -114,7 +114,7 @@ EOT;
     /**
      * @test
      */
-    public function spaceAfterSelectorSeparator()
+    public function spaceAfterSelectorSeparator(): void
     {
         self::assertSame(
             '.main,
@@ -127,7 +127,7 @@ EOT;
     /**
      * @test
      */
-    public function stringQuotingType()
+    public function stringQuotingType(): void
     {
         self::assertSame(
             '.main, .test {font: italic normal bold 16px/1.2 \'Helvetica\',Verdana,sans-serif;background: white;}
@@ -139,7 +139,7 @@ EOT;
     /**
      * @test
      */
-    public function rGBHashNotation()
+    public function rGBHashNotation(): void
     {
         self::assertSame(
             '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white;}
@@ -151,7 +151,7 @@ EOT;
     /**
      * @test
      */
-    public function semicolonAfterLastRule()
+    public function semicolonAfterLastRule(): void
     {
         self::assertSame(
             '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white}
@@ -163,7 +163,7 @@ EOT;
     /**
      * @test
      */
-    public function spaceAfterRuleName()
+    public function spaceAfterRuleName(): void
     {
         self::assertSame(
             '.main, .test {font:	italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background:	white;}
@@ -175,7 +175,7 @@ EOT;
     /**
      * @test
      */
-    public function spaceRules()
+    public function spaceRules(): void
     {
         self::assertSame('.main, .test {
 	font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;
@@ -191,7 +191,7 @@ EOT;
     /**
      * @test
      */
-    public function spaceBlocks()
+    public function spaceBlocks(): void
     {
         self::assertSame('
 .main, .test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white;}
@@ -204,7 +204,7 @@ EOT;
     /**
      * @test
      */
-    public function spaceBoth()
+    public function spaceBoth(): void
     {
         self::assertSame('
 .main, .test {
@@ -224,7 +224,7 @@ EOT;
     /**
      * @test
      */
-    public function spaceBetweenBlocks()
+    public function spaceBetweenBlocks(): void
     {
         self::assertSame(
             '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white;}'
@@ -236,7 +236,7 @@ EOT;
     /**
      * @test
      */
-    public function indentation()
+    public function indentation(): void
     {
         self::assertSame('
 .main, .test {
@@ -259,7 +259,7 @@ background-color: #fff;
     /**
      * @test
      */
-    public function spaceBeforeBraces()
+    public function spaceBeforeBraces(): void
     {
         self::assertSame(
             '.main, .test{font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white;}
@@ -271,7 +271,7 @@ background-color: #fff;
     /**
      * @test
      */
-    public function ignoreExceptionsOff()
+    public function ignoreExceptionsOff(): void
     {
         $this->expectException(OutputException::class);
 
@@ -290,7 +290,7 @@ background-color: #fff;
     /**
      * @test
      */
-    public function ignoreExceptionsOn()
+    public function ignoreExceptionsOn(): void
     {
         $aBlocks = $this->oDocument->getAllDeclarationBlocks();
         $oFirstBlock = $aBlocks[0];

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -40,7 +40,7 @@ final class ParserTest extends TestCase
     /**
      * @test
      */
-    public function parseForOneRuleSetReturnsDocumentWithOneRuleSet()
+    public function parseForOneRuleSetReturnsDocumentWithOneRuleSet(): void
     {
         $css = '.thing { left: 10px; }';
         $parser = new Parser($css);
@@ -57,7 +57,7 @@ final class ParserTest extends TestCase
     /**
      * @test
      */
-    public function files()
+    public function files(): void
     {
         $sDirectory = __DIR__ . '/fixtures';
         if ($rHandle = opendir($sDirectory)) {
@@ -90,7 +90,7 @@ final class ParserTest extends TestCase
      *
      * @test
      */
-    public function colorParsing()
+    public function colorParsing(): void
     {
         $oDoc = self::parsedStructureForFile('colortest');
         foreach ($oDoc->getAllRuleSets() as $oRuleSet) {
@@ -172,7 +172,7 @@ final class ParserTest extends TestCase
     /**
      * @test
      */
-    public function unicodeParsing()
+    public function unicodeParsing(): void
     {
         $oDoc = self::parsedStructureForFile('unicode');
         foreach ($oDoc->getAllDeclarationBlocks() as $oRuleSet) {
@@ -223,7 +223,7 @@ final class ParserTest extends TestCase
     /**
      * @test
      */
-    public function unicodeRangeParsing()
+    public function unicodeRangeParsing(): void
     {
         $oDoc = self::parsedStructureForFile('unicode-range');
         $sExpected = "@font-face {unicode-range: U+0100-024F,U+0259,U+1E??-2EFF,U+202F;}";
@@ -233,7 +233,7 @@ final class ParserTest extends TestCase
     /**
      * @test
      */
-    public function specificity()
+    public function specificity(): void
     {
         $oDoc = self::parsedStructureForFile('specificity');
         $oDeclarationBlock = $oDoc->getAllDeclarationBlocks();
@@ -285,7 +285,7 @@ final class ParserTest extends TestCase
     /**
      * @test
      */
-    public function manipulation()
+    public function manipulation(): void
     {
         $oDoc = self::parsedStructureForFile('atrules');
         self::assertSame(
@@ -391,7 +391,7 @@ body {color: green;}',
     /**
      * @test
      */
-    public function ruleGetters()
+    public function ruleGetters(): void
     {
         $oDoc = self::parsedStructureForFile('values');
         $aBlocks = $oDoc->getAllDeclarationBlocks();
@@ -414,7 +414,7 @@ body {color: green;}',
     /**
      * @test
      */
-    public function slashedValues()
+    public function slashedValues(): void
     {
         $oDoc = self::parsedStructureForFile('slashed');
         self::assertSame(
@@ -455,7 +455,7 @@ body {color: green;}',
     /**
      * @test
      */
-    public function functionSyntax()
+    public function functionSyntax(): void
     {
         $oDoc = self::parsedStructureForFile('functions');
         $sExpected = 'div.main {background-image: linear-gradient(#000,#fff);}'
@@ -493,7 +493,7 @@ body {color: green;}',
     /**
      * @test
      */
-    public function expandShorthands()
+    public function expandShorthands(): void
     {
         $oDoc = self::parsedStructureForFile('expand-shorthands');
         $sExpected = 'body {font: italic 500 14px/1.618 "Trebuchet MS",Georgia,serif;border: 2px solid #f0f;'
@@ -517,7 +517,7 @@ body {color: green;}',
     /**
      * @test
      */
-    public function createShorthands()
+    public function createShorthands(): void
     {
         $oDoc = self::parsedStructureForFile('create-shorthands');
         $sExpected = 'body {font-size: 2em;font-family: Helvetica,Arial,sans-serif;font-weight: bold;'
@@ -534,7 +534,7 @@ body {color: green;}',
     /**
      * @test
      */
-    public function namespaces()
+    public function namespaces(): void
     {
         $oDoc = self::parsedStructureForFile('namespaces');
         $sExpected = '@namespace toto "http://toto.example.org";
@@ -549,7 +549,7 @@ foo|test {gaga: 1;}
     /**
      * @test
      */
-    public function innerColors()
+    public function innerColors(): void
     {
         $oDoc = self::parsedStructureForFile('inner-color');
         $sExpected = 'test {background: -webkit-gradient(linear,0 0,0 bottom,from(#006cad),to(hsl(202,100%,49%)));}';
@@ -559,7 +559,7 @@ foo|test {gaga: 1;}
     /**
      * @test
      */
-    public function prefixedGradient()
+    public function prefixedGradient(): void
     {
         $oDoc = self::parsedStructureForFile('webkit');
         $sExpected = '.test {background: -webkit-linear-gradient(top right,white,black);}';
@@ -569,7 +569,7 @@ foo|test {gaga: 1;}
     /**
      * @test
      */
-    public function listValueRemoval()
+    public function listValueRemoval(): void
     {
         $oDoc = self::parsedStructureForFile('atrules');
         foreach ($oDoc->getContents() as $oItem) {
@@ -607,7 +607,7 @@ foo|test {gaga: 1;}
     /**
      * @test
      */
-    public function selectorRemoval()
+    public function selectorRemoval(): void
     {
         $this->expectException(OutputException::class);
 
@@ -628,7 +628,7 @@ body {font-size: 1.6em;}';
     /**
      * @test
      */
-    public function comments()
+    public function comments(): void
     {
         $oDoc = self::parsedStructureForFile('comments');
         $sExpected = <<<EXPECTED
@@ -642,7 +642,7 @@ EXPECTED;
     /**
      * @test
      */
-    public function urlInFile()
+    public function urlInFile(): void
     {
         $oDoc = self::parsedStructureForFile('url', Settings::create()->withMultibyteSupport(true));
         $sExpected = 'body {background: #fff url("https://somesite.com/images/someimage.gif") repeat top center;}
@@ -653,7 +653,7 @@ body {background-url: url("https://somesite.com/images/someimage.gif");}';
     /**
      * @test
      */
-    public function hexAlphaInFile()
+    public function hexAlphaInFile(): void
     {
         $oDoc = self::parsedStructureForFile('hex-alpha', Settings::create()->withMultibyteSupport(true));
         $sExpected = 'div {background: rgba(17,34,51,.27);}
@@ -664,7 +664,7 @@ div {background: rgba(17,34,51,.27);}';
     /**
      * @test
      */
-    public function calcInFile()
+    public function calcInFile(): void
     {
         $oDoc = self::parsedStructureForFile('calc', Settings::create()->withMultibyteSupport(true));
         $sExpected = 'div {width: calc(100% / 4);}
@@ -677,7 +677,7 @@ div {width: calc(50% - ( ( 4% ) * .5 ));}';
     /**
      * @test
      */
-    public function calcNestedInFile()
+    public function calcNestedInFile(): void
     {
         $oDoc = self::parsedStructureForFile('calc-nested', Settings::create()->withMultibyteSupport(true));
         $sExpected = '.test {font-size: calc(( 3 * 4px ) + -2px);top: calc(200px - calc(20 * 3px));}';
@@ -687,7 +687,7 @@ div {width: calc(50% - ( ( 4% ) * .5 ));}';
     /**
      * @test
      */
-    public function invalidCalcInFile()
+    public function invalidCalcInFile(): void
     {
         $oDoc = self::parsedStructureForFile('calc-invalid', Settings::create()->withMultibyteSupport(true));
         $sExpected = 'div {}
@@ -701,7 +701,7 @@ div {height: calc;}';
     /**
      * @test
      */
-    public function invalidCalc()
+    public function invalidCalc(): void
     {
         $parser = new Parser('div { height: calc(100px');
         $oDoc = $parser->parse();
@@ -731,7 +731,7 @@ div {height: calc;}';
     /**
      * @test
      */
-    public function gridLineNameInFile()
+    public function gridLineNameInFile(): void
     {
         $oDoc = self::parsedStructureForFile('grid-linename', Settings::create()->withMultibyteSupport(true));
         $sExpected = "div {grid-template-columns: [linename] 100px;}\n"
@@ -742,7 +742,7 @@ div {height: calc;}';
     /**
      * @test
      */
-    public function emptyGridLineNameLenientInFile()
+    public function emptyGridLineNameLenientInFile(): void
     {
         $oDoc = self::parsedStructureForFile('empty-grid-linename');
         $sExpected = '.test {grid-template-columns: [] 100px;}';
@@ -752,7 +752,7 @@ div {height: calc;}';
     /**
      * @test
      */
-    public function invalidGridLineNameInFile()
+    public function invalidGridLineNameInFile(): void
     {
         $oDoc = self::parsedStructureForFile('invalid-grid-linename', Settings::create()->withMultibyteSupport(true));
         $sExpected = "div {}";
@@ -762,7 +762,7 @@ div {height: calc;}';
     /**
      * @test
      */
-    public function unmatchedBracesInFile()
+    public function unmatchedBracesInFile(): void
     {
         $oDoc = self::parsedStructureForFile('unmatched_braces', Settings::create()->withMultibyteSupport(true));
         $sExpected = 'button, input, checkbox, textarea {outline: 0;margin: 0;}';
@@ -772,7 +772,7 @@ div {height: calc;}';
     /**
      * @test
      */
-    public function invalidSelectorsInFile()
+    public function invalidSelectorsInFile(): void
     {
         $oDoc = self::parsedStructureForFile('invalid-selectors', Settings::create()->withMultibyteSupport(true));
         $sExpected = '@keyframes mymove {from {top: 0px;}}
@@ -793,7 +793,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function selectorEscapesInFile()
+    public function selectorEscapesInFile(): void
     {
         $oDoc = self::parsedStructureForFile('selector-escapes', Settings::create()->withMultibyteSupport(true));
         $sExpected = '#\# {color: red;}
@@ -813,7 +813,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function identifierEscapesInFile()
+    public function identifierEscapesInFile(): void
     {
         $oDoc = self::parsedStructureForFile('identifier-escapes', Settings::create()->withMultibyteSupport(true));
         $sExpected = 'div {font: 14px Font Awesome\ 5 Pro;font: 14px Font Awesome\} 5 Pro;'
@@ -824,7 +824,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function selectorIgnoresInFile()
+    public function selectorIgnoresInFile(): void
     {
         $oDoc = self::parsedStructureForFile('selector-ignores', Settings::create()->withMultibyteSupport(true));
         $sExpected = '.some[selectors-may=\'contain-a-{\'] {}'
@@ -838,7 +838,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function keyframeSelectors()
+    public function keyframeSelectors(): void
     {
         $oDoc = self::parsedStructureForFile(
             'keyframe-selector-validation',
@@ -855,7 +855,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function lineNameFailure()
+    public function lineNameFailure(): void
     {
         $this->expectException(UnexpectedTokenException::class);
 
@@ -865,7 +865,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function calcFailure()
+    public function calcFailure(): void
     {
         $this->expectException(UnexpectedTokenException::class);
 
@@ -875,7 +875,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function urlInFileMbOff()
+    public function urlInFileMbOff(): void
     {
         $oDoc = self::parsedStructureForFile('url', Settings::create()->withMultibyteSupport(false));
         $sExpected = 'body {background: #fff url("https://somesite.com/images/someimage.gif") repeat top center;}'
@@ -887,7 +887,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function emptyFile()
+    public function emptyFile(): void
     {
         $oDoc = self::parsedStructureForFile('-empty', Settings::create()->withMultibyteSupport(true));
         $sExpected = '';
@@ -897,7 +897,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function emptyFileMbOff()
+    public function emptyFileMbOff(): void
     {
         $oDoc = self::parsedStructureForFile('-empty', Settings::create()->withMultibyteSupport(false));
         $sExpected = '';
@@ -907,7 +907,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function charsetLenient1()
+    public function charsetLenient1(): void
     {
         $oDoc = self::parsedStructureForFile('-charset-after-rule', Settings::create()->withLenientParsing(true));
         $sExpected = '#id {prop: var(--val);}';
@@ -917,7 +917,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function charsetLenient2()
+    public function charsetLenient2(): void
     {
         $oDoc = self::parsedStructureForFile('-charset-in-block', Settings::create()->withLenientParsing(true));
         $sExpected = '@media print {}';
@@ -927,7 +927,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function trailingWhitespace()
+    public function trailingWhitespace(): void
     {
         $oDoc = self::parsedStructureForFile('trailing-whitespace', Settings::create()->withLenientParsing(false));
         $sExpected = 'div {width: 200px;}';
@@ -937,7 +937,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function charsetFailure1()
+    public function charsetFailure1(): void
     {
         $this->expectException(UnexpectedTokenException::class);
 
@@ -947,7 +947,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function charsetFailure2()
+    public function charsetFailure2(): void
     {
         $this->expectException(UnexpectedTokenException::class);
 
@@ -957,7 +957,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function unopenedClosingBracketFailure()
+    public function unopenedClosingBracketFailure(): void
     {
         $this->expectException(SourceException::class);
 
@@ -971,7 +971,7 @@ body {background-color: red;}';
      *
      * @test
      */
-    public function missingPropertyValueStrict()
+    public function missingPropertyValueStrict(): void
     {
         $this->expectException(UnexpectedTokenException::class);
 
@@ -985,7 +985,7 @@ body {background-color: red;}';
      *
      * @test
      */
-    public function missingPropertyValueLenient()
+    public function missingPropertyValueLenient(): void
     {
         $parsed = self::parsedStructureForFile('missing-property-value', Settings::create()->withLenientParsing(true));
         $rulesets = $parsed->getAllRuleSets();
@@ -1020,7 +1020,7 @@ body {background-color: red;}';
      *
      * @test
      */
-    public function lineNumbersParsing()
+    public function lineNumbersParsing(): void
     {
         $oDoc = self::parsedStructureForFile('line-numbers');
         // array key is the expected line number
@@ -1076,7 +1076,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function unexpectedTokenExceptionLineNo()
+    public function unexpectedTokenExceptionLineNo(): void
     {
         $this->expectException(UnexpectedTokenException::class);
 
@@ -1092,7 +1092,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function ieHacksStrictParsing()
+    public function ieHacksStrictParsing(): void
     {
         $this->expectException(UnexpectedTokenException::class);
 
@@ -1103,7 +1103,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function ieHacksParsing()
+    public function ieHacksParsing(): void
     {
         $oDoc = self::parsedStructureForFile('ie-hacks', Settings::create()->withLenientParsing(true));
         $sExpected = 'p {padding-right: .75rem \9;background-image: none \9;color: red \9\0;'
@@ -1116,7 +1116,7 @@ body {background-color: red;}';
      *
      * @test
      */
-    public function commentExtracting()
+    public function commentExtracting(): void
     {
         $oDoc = self::parsedStructureForFile('comments');
         $aNodes = $oDoc->getContents();
@@ -1162,7 +1162,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function flatCommentExtracting()
+    public function flatCommentExtracting(): void
     {
         $parser = new Parser('div {/*Find Me!*/left:10px; text-align:left;}');
         $doc = $parser->parse();
@@ -1176,7 +1176,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function topLevelCommentExtracting()
+    public function topLevelCommentExtracting(): void
     {
         $parser = new Parser('/*Find Me!*/div {left:10px; text-align:left;}');
         $doc = $parser->parse();
@@ -1189,7 +1189,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function microsoftFilterStrictParsing()
+    public function microsoftFilterStrictParsing(): void
     {
         $this->expectException(UnexpectedTokenException::class);
 
@@ -1199,7 +1199,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function microsoftFilterParsing()
+    public function microsoftFilterParsing(): void
     {
         $oDoc = self::parsedStructureForFile('ms-filter');
         $sExpected = '.test {filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#80000000",'
@@ -1210,7 +1210,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function largeSizeValuesInFile()
+    public function largeSizeValuesInFile(): void
     {
         $oDoc = self::parsedStructureForFile('large-z-index', Settings::create()->withMultibyteSupport(false));
         $sExpected = '.overlay {z-index: 10000000000000000000000;}';
@@ -1220,7 +1220,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function scientificNotationSizeValuesInFile()
+    public function scientificNotationSizeValuesInFile(): void
     {
         $oDoc = $this->parsedStructureForFile(
             'scientific-notation-numbers',
@@ -1235,7 +1235,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function lonelyImport()
+    public function lonelyImport(): void
     {
         $oDoc = self::parsedStructureForFile('lonely-import');
         $sExpected = "@import url(\"example.css\") only screen and (max-width: 600px);";

--- a/tests/RuleSet/DeclarationBlockTest.php
+++ b/tests/RuleSet/DeclarationBlockTest.php
@@ -20,7 +20,7 @@ final class DeclarationBlockTest extends TestCase
      *
      * @test
      */
-    public function expandBorderShorthand($sCss, $sExpected)
+    public function expandBorderShorthand($sCss, $sExpected): void
     {
         $oParser = new Parser($sCss);
         $oDoc = $oParser->parse();
@@ -53,7 +53,7 @@ final class DeclarationBlockTest extends TestCase
      *
      * @test
      */
-    public function expandFontShorthand($sCss, $sExpected)
+    public function expandFontShorthand($sCss, $sExpected): void
     {
         $oParser = new Parser($sCss);
         $oDoc = $oParser->parse();
@@ -109,7 +109,7 @@ final class DeclarationBlockTest extends TestCase
      *
      * @test
      */
-    public function expandBackgroundShorthand($sCss, $sExpected)
+    public function expandBackgroundShorthand($sCss, $sExpected): void
     {
         $oParser = new Parser($sCss);
         $oDoc = $oParser->parse();
@@ -162,7 +162,7 @@ final class DeclarationBlockTest extends TestCase
      *
      * @test
      */
-    public function expandDimensionsShorthand($sCss, $sExpected)
+    public function expandDimensionsShorthand($sCss, $sExpected): void
     {
         $oParser = new Parser($sCss);
         $oDoc = $oParser->parse();
@@ -200,7 +200,7 @@ final class DeclarationBlockTest extends TestCase
      *
      * @test
      */
-    public function createBorderShorthand($sCss, $sExpected)
+    public function createBorderShorthand($sCss, $sExpected): void
     {
         $oParser = new Parser($sCss);
         $oDoc = $oParser->parse();
@@ -231,7 +231,7 @@ final class DeclarationBlockTest extends TestCase
      *
      * @test
      */
-    public function createFontShorthand($sCss, $sExpected)
+    public function createFontShorthand($sCss, $sExpected): void
     {
         $oParser = new Parser($sCss);
         $oDoc = $oParser->parse();
@@ -274,7 +274,7 @@ final class DeclarationBlockTest extends TestCase
      *
      * @test
      */
-    public function createDimensionsShorthand($sCss, $sExpected)
+    public function createDimensionsShorthand($sCss, $sExpected): void
     {
         $oParser = new Parser($sCss);
         $oDoc = $oParser->parse();
@@ -312,7 +312,7 @@ final class DeclarationBlockTest extends TestCase
      *
      * @test
      */
-    public function createBackgroundShorthand($sCss, $sExpected)
+    public function createBackgroundShorthand($sCss, $sExpected): void
     {
         $oParser = new Parser($sCss);
         $oDoc = $oParser->parse();
@@ -358,7 +358,7 @@ final class DeclarationBlockTest extends TestCase
     /**
      * @test
      */
-    public function overrideRules()
+    public function overrideRules(): void
     {
         $sCss = '.wrapper { left: 10px; text-align: left; }';
         $oParser = new Parser($sCss);
@@ -380,7 +380,7 @@ final class DeclarationBlockTest extends TestCase
     /**
      * @test
      */
-    public function ruleInsertion()
+    public function ruleInsertion(): void
     {
         $sCss = '.wrapper { left: 10px; text-align: left; }';
         $oParser = new Parser($sCss);
@@ -428,7 +428,7 @@ final class DeclarationBlockTest extends TestCase
      *
      * TODO: The order is different on PHP 5.6 than on PHP >= 7.0.
      */
-    public function orderOfElementsMatchingOriginalOrderAfterExpandingShorthands()
+    public function orderOfElementsMatchingOriginalOrderAfterExpandingShorthands(): void
     {
         $sCss = '.rule{padding:5px;padding-top: 20px}';
         $oParser = new Parser($sCss);

--- a/tests/RuleSet/LenientParsingTest.php
+++ b/tests/RuleSet/LenientParsingTest.php
@@ -24,7 +24,7 @@ final class LenientParsingTest extends TestCase
     /**
      * @test
      */
-    public function faultToleranceOff()
+    public function faultToleranceOff(): void
     {
         $this->expectException(UnexpectedTokenException::class);
 
@@ -36,7 +36,7 @@ final class LenientParsingTest extends TestCase
     /**
      * @test
      */
-    public function faultToleranceOn()
+    public function faultToleranceOn(): void
     {
         $sFile = __DIR__ . '/../fixtures/-fault-tolerance.css';
         $oParser = new Parser(file_get_contents($sFile), Settings::create()->withLenientParsing(true));
@@ -51,7 +51,7 @@ final class LenientParsingTest extends TestCase
     /**
      * @test
      */
-    public function endToken()
+    public function endToken(): void
     {
         $this->expectException(UnexpectedTokenException::class);
 
@@ -63,7 +63,7 @@ final class LenientParsingTest extends TestCase
     /**
      * @test
      */
-    public function endToken2()
+    public function endToken2(): void
     {
         $this->expectException(UnexpectedTokenException::class);
 
@@ -75,7 +75,7 @@ final class LenientParsingTest extends TestCase
     /**
      * @test
      */
-    public function endTokenPositive()
+    public function endTokenPositive(): void
     {
         $sFile = __DIR__ . '/../fixtures/-end-token.css';
         $oParser = new Parser(file_get_contents($sFile), Settings::create()->withLenientParsing(true));
@@ -86,7 +86,7 @@ final class LenientParsingTest extends TestCase
     /**
      * @test
      */
-    public function endToken2Positive()
+    public function endToken2Positive(): void
     {
         $sFile = __DIR__ . '/../fixtures/-end-token-2.css';
         $oParser = new Parser(file_get_contents($sFile), Settings::create()->withLenientParsing(true));
@@ -100,7 +100,7 @@ final class LenientParsingTest extends TestCase
     /**
      * @test
      */
-    public function localeTrap()
+    public function localeTrap(): void
     {
         setlocale(LC_ALL, "pt_PT", "no");
         $sFile = __DIR__ . '/../fixtures/-fault-tolerance.css';
@@ -116,7 +116,7 @@ final class LenientParsingTest extends TestCase
     /**
      * @test
      */
-    public function caseInsensitivity()
+    public function caseInsensitivity(): void
     {
         $sFile = __DIR__ . '/../fixtures/case-insensitivity.css';
         $oParser = new Parser(file_get_contents($sFile));
@@ -135,7 +135,7 @@ final class LenientParsingTest extends TestCase
     /**
      * @test
      */
-    public function invalidColor()
+    public function invalidColor(): void
     {
         $sFile = __DIR__ . '/../fixtures/invalid-color.css';
         $oParser = new Parser(file_get_contents($sFile), Settings::create()->withLenientParsing(true));
@@ -145,7 +145,7 @@ final class LenientParsingTest extends TestCase
     /**
      * @test
      */
-    public function invalidColorStrict()
+    public function invalidColorStrict(): void
     {
         $this->expectException(UnexpectedTokenException::class);
 

--- a/tests/Value/CalcRuleValueListTest.php
+++ b/tests/Value/CalcRuleValueListTest.php
@@ -14,7 +14,7 @@ final class CalcRuleValueListTest extends TestCase
     /**
      * @test
      */
-    public function isRuleValueList()
+    public function isRuleValueList(): void
     {
         $subject = new CalcRuleValueList();
 
@@ -24,7 +24,7 @@ final class CalcRuleValueListTest extends TestCase
     /**
      * @test
      */
-    public function getLineNumberByDefaultReturnsZero()
+    public function getLineNumberByDefaultReturnsZero(): void
     {
         $subject = new CalcRuleValueList();
 
@@ -34,7 +34,7 @@ final class CalcRuleValueListTest extends TestCase
     /**
      * @test
      */
-    public function getLineNoReturnsLineNumberProvidedToConstructor()
+    public function getLineNoReturnsLineNumberProvidedToConstructor(): void
     {
         $lineNumber = 42;
 
@@ -46,7 +46,7 @@ final class CalcRuleValueListTest extends TestCase
     /**
      * @test
      */
-    public function separatorAlwaysIsComma()
+    public function separatorAlwaysIsComma(): void
     {
         $subject = new CalcRuleValueList();
 


### PR DESCRIPTION
This applies the rule **AddTestsVoidReturnTypeWhereNoReturnRector**.

For Details see: https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#addtestsvoidreturntypewherenoreturnrector