### PR TITLE
[CLEANUP] rector: Add strict return array type based on created empty array and returned

### DIFF
--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -231,7 +231,7 @@ class ParserState
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    public function consumeWhiteSpace()
+    public function consumeWhiteSpace(): array
     {
         $aComments = [];
         do {

--- a/src/Property/CSSNamespace.php
+++ b/src/Property/CSSNamespace.php
@@ -115,7 +115,7 @@ class CSSNamespace implements AtRule
     /**
      * @return array<int, string>
      */
-    public function atRuleArgs()
+    public function atRuleArgs(): array
     {
         $aResult = [$this->mUrl];
         if ($this->sPrefix) {

--- a/src/Property/Import.php
+++ b/src/Property/Import.php
@@ -98,7 +98,7 @@ class Import implements AtRule
     /**
      * @return array<int, URL|string>
      */
-    public function atRuleArgs()
+    public function atRuleArgs(): array
     {
         $aResult = [$this->oLocation];
         if ($this->sMediaQuery) {

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -238,7 +238,7 @@ class Rule implements Renderable, Commentable
      *             Old-Style 2-dimensional array returned. Retained for (some) backwards-compatibility.
      *             Use `getValue()` instead and check for the existence of a (nested set of) ValueList object(s).
      */
-    public function getValues()
+    public function getValues(): array
     {
         if (!$this->mValue instanceof RuleValueList) {
             return [[$this->mValue]];


### PR DESCRIPTION
This applies the rule **AddTestsVoidReturnTypeWhereNoReturnRector**.
For Details see: https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#returntypefromstrictnewarrayrector