### PR TITLE
[TASK] Move linting to a Composer script and use it on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,11 @@ jobs:
               with:
                   php-version: ${{ matrix.php-version }}
                   ini-file: development
+                  tools: composer:v2
                   coverage: none
 
             - name: PHP Lint
-              run: find src tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+              run: composer ci:php:lint
 
     unit-tests:
         name: Unit tests

--- a/composer.json
+++ b/composer.json
@@ -96,6 +96,7 @@
         "ci": "Runs all dynamic and static code checks.",
         "ci:dynamic": "Runs all dynamic code checks (i.e., currently, the unit tests).",
         "ci:php:fixer": "Checks the code style with PHP CS Fixer.",
+        "ci:php:lint": "Checks the syntax of the PHP code.",
         "ci:php:stan": "Checks the types with PHPStan.",
         "ci:php:rector": "Checks the code for possible code updates and refactoring.",
         "ci:static": "Runs all static code analysis checks for the code.",

--- a/composer.json
+++ b/composer.json
@@ -69,11 +69,13 @@
         "ci:dynamic": [
             "@ci:tests"
         ],
-        "ci:php:fixer": "\"./.phive/php-cs-fixer\" --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff bin src tests",
-        "ci:php:stan": "phpstan --no-progress --configuration=config/phpstan.neon",
+        "ci:php:fixer": "\"./.phive/php-cs-fixer\" --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff bin src tests config",
+        "ci:php:lint": "find src tests config bin -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
         "ci:php:rector": "rector --no-progress-bar --dry-run --config=config/rector.php",
+        "ci:php:stan": "phpstan --no-progress --configuration=config/phpstan.neon",
         "ci:static": [
             "@ci:php:fixer",
+            "@ci:php:lint",
             "@ci:php:rector",
             "@ci:php:stan"
         ],


### PR DESCRIPTION
Also lint `config/` in order to catch e.g. language features that are not supported in all the PHP versions we support.

Fixes: #551