### PR TITLE
[TASK] Deprecate `Document::createShorthands`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
+- Deprecate `Document::createShorthands()` (#567)
 - Deprecate `DeclarationBlock::expandShorthands()` (#558)
 
 ### Removed

--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -140,6 +140,8 @@ class Document extends CSSBlockList
      * Create shorthands properties whenever possible.
      *
      * @return void
+     *
+     * @deprecated This will be removed without substitution in version 10.0.
      */
     public function createShorthands()
     {


### PR DESCRIPTION
The `expandShorthands`/`createShorthands` Functions are deprecated and will be removed without substitution in version 10.0. Expanding and creating the shorthand notation is out of the scope of this library. If you want to include this functionality in your project or build it into a separate package, get the code from the v8.5.1 version of this library.

Helps with fixing #512