### PR TITLE
[TASK] Deprecate `DeclarationBlock::expandDimensionsShorthand`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
+- Deprecate `DeclarationBlock::expandDimensionsShorthand()` (#571)
 - Deprecate `DeclarationBlock::expandBorderShorthand()` (#570)
 - Deprecate `DeclarationBlock::createShorthands()` (#569)
 - Deprecate `Document::expandShorthands()` (#566)

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -257,6 +257,8 @@ class DeclarationBlock extends RuleSet
      * Handles `margin`, `padding`, `border-color`, `border-style` and `border-width`.
      *
      * @return void
+     *
+     * @deprecated This will be removed without substitution in version 10.0.
      */
     public function expandDimensionsShorthand()
     {


### PR DESCRIPTION
The `expandShorthands`/`createShorthands` Functions are deprecated and will be removed without substitution in version 10.0. Expanding and creating the shorthand notation is out of the scope of this library. If you want to include this functionality in your project or build it into a separate package, get the code from the v8.5.1 version of this library.

Helps with fixing #512
