### PR TITLE
[TASK] Deprecate `DeclarationBlock::createListStyleShorthand`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
+- Deprecate `DeclarationBlock::createListStyleShorthand()` (#577)
 - Deprecate the `DeclarationBlock::createBackgroundShorthand()` (#576)
 - Deprecate `DeclarationBlock::createShorthandProperties()` (#575)
 - Deprecate `DeclarationBlock::expandListStyleShorthand()` (#574)

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -605,6 +605,8 @@ class DeclarationBlock extends RuleSet
 
     /**
      * @return void
+     *
+     * @deprecated This will be removed without substitution in version 10.0.
      */
     public function createListStyleShorthand()
     {


### PR DESCRIPTION
The `expandShorthands`/`createShorthands` Functions are deprecated and will be removed without substitution in version 10.0. Expanding and creating the shorthand notation is out of the scope of this library. If you want to include this functionality in your project or build it into a separate package, get the code from the v8.5.1 version of this library.

Helps with fixing #512