### PR TITLE
[TASK] Deprecate `DeclarationBlock::createBorderShorthand`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
+- Deprecate `DeclarationBlock::createBorderShorthand()` (#578)
 - Deprecate `DeclarationBlock::createFontShorthand()` (#580)
 - Deprecate `DeclarationBlock::createDimensionsShorthand()` (#579)
 - Deprecate `DeclarationBlock::createListStyleShorthand()` (#577)
-- Deprecate the `DeclarationBlock::createBackgroundShorthand()` (#576)
+- Deprecate `DeclarationBlock::createBackgroundShorthand()` (#576)
 - Deprecate `DeclarationBlock::createShorthandProperties()` (#575)
 - Deprecate `DeclarationBlock::expandListStyleShorthand()` (#574)
 - Deprecate `DeclarationBlock::expandBackgroundShorthand()` (#573)

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -624,6 +624,8 @@ class DeclarationBlock extends RuleSet
      * Should be run after `create_dimensions_shorthand`!
      *
      * @return void
+     *
+     * @deprecated This will be removed without substitution in version 10.0.
      */
     public function createBorderShorthand()
     {


### PR DESCRIPTION
The `expandShorthands`/`createShorthands` Functions are deprecated and will be removed without substitution in version 10.0. Expanding and creating the shorthand notation is out of the scope of this library. If you want to include this functionality in your project or build it into a separate package, get the code from the v8.5.1 version of this library.

Helps with fixing https://github.com/MyIntervals/PHP-CSS-Parser/issues/512