### PR TITLE
[TASK] Deprecate `DeclarationBlock::createFontShorthand`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
+- Deprecate `DeclarationBlock::createFontShorthand()` (#580)
 - Deprecate `DeclarationBlock::expandShorthands()` (#558)
 
 ### Removed

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -710,6 +710,8 @@ class DeclarationBlock extends RuleSet
      * At least `font-size` AND `font-family` must be present in order to create a shorthand declaration.
      *
      * @return void
+     *
+     * @deprecated This will be removed without substitution in version 10.0.
      */
     public function createFontShorthand()
     {


### PR DESCRIPTION
The `expandShorthands`/`createShorthands` Functions are deprecated and will be removed without substitution in version 10.0. Expanding and creating the shorthand notation is out of the scope of this library. If you want to include this functionality in your project or build it into a separate package, get the code from the v8.5.1 version of this library.

Helps with fixing https://github.com/MyIntervals/PHP-CSS-Parser/issues/512