### PR TITLE
[CLEANUP] Rector: Add strict return type based on returned strict expr type

### DIFF
--- a/src/CSSList/AtRuleBlockList.php
+++ b/src/CSSList/AtRuleBlockList.php
@@ -74,9 +74,6 @@ class AtRuleBlockList extends CSSBlockList implements AtRule
         return $sResult;
     }
 
-    /**
-     * @return bool
-     */
     public function isRootList(): bool
     {
         return false;

--- a/src/CSSList/AtRuleBlockList.php
+++ b/src/CSSList/AtRuleBlockList.php
@@ -77,7 +77,7 @@ class AtRuleBlockList extends CSSBlockList implements AtRule
     /**
      * @return bool
      */
-    public function isRootList()
+    public function isRootList(): bool
     {
         return false;
     }

--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -155,9 +155,6 @@ class Document extends CSSBlockList
         return $oOutputFormat->comments($this) . $this->renderListContents($oOutputFormat);
     }
 
-    /**
-     * @return bool
-     */
     public function isRootList(): bool
     {
         return true;

--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -158,7 +158,7 @@ class Document extends CSSBlockList
     /**
      * @return bool
      */
-    public function isRootList()
+    public function isRootList(): bool
     {
         return true;
     }

--- a/src/CSSList/KeyFrame.php
+++ b/src/CSSList/KeyFrame.php
@@ -79,9 +79,6 @@ class KeyFrame extends CSSList implements AtRule
         return $sResult;
     }
 
-    /**
-     * @return bool
-     */
     public function isRootList(): bool
     {
         return false;

--- a/src/CSSList/KeyFrame.php
+++ b/src/CSSList/KeyFrame.php
@@ -82,7 +82,7 @@ class KeyFrame extends CSSList implements AtRule
     /**
      * @return bool
      */
-    public function isRootList()
+    public function isRootList(): bool
     {
         return false;
     }

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -430,7 +430,7 @@ class ParserState
      *
      * @return bool
      */
-    public function streql($sString1, $sString2, $bCaseInsensitive = true)
+    public function streql($sString1, $sString2, $bCaseInsensitive = true): bool
     {
         if ($bCaseInsensitive) {
             return $this->strtolower($sString1) === $this->strtolower($sString2);

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -427,8 +427,6 @@ class ParserState
      * @param string $sString1
      * @param string $sString2
      * @param bool $bCaseInsensitive
-     *
-     * @return bool
      */
     public function streql($sString1, $sString2, $bCaseInsensitive = true): bool
     {

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -129,8 +129,6 @@ class DeclarationBlock extends RuleSet
      * Remove one of the selectors of the block.
      *
      * @param Selector|string $mSelector
-     *
-     * @return bool
      */
     public function removeSelector($mSelector): bool
     {

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -132,7 +132,7 @@ class DeclarationBlock extends RuleSet
      *
      * @return bool
      */
-    public function removeSelector($mSelector)
+    public function removeSelector($mSelector): bool
     {
         if ($mSelector instanceof Selector) {
             $mSelector = $mSelector->getSelector();

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -190,7 +190,7 @@ class Size extends PrimitiveValue
     /**
      * @return bool
      */
-    public function isRelative()
+    public function isRelative(): bool
     {
         if (in_array($this->sUnit, self::RELATIVE_SIZE_UNITS, true)) {
             return true;

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -187,9 +187,6 @@ class Size extends PrimitiveValue
         return !$this->isColorComponent();
     }
 
-    /**
-     * @return bool
-     */
     public function isRelative(): bool
     {
         if (in_array($this->sUnit, self::RELATIVE_SIZE_UNITS, true)) {


### PR DESCRIPTION
This applies the rule **ReturnTypeFromStrictBoolReturnExprRector**. For Details see:
https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#returntypefromstrictboolreturnexprrector