### PR TITLE
[CLEANUP] Rector: Change numeric return type based on strict returns type operations

### DIFF
--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -449,10 +449,8 @@ class ParserState
 
     /**
      * @param string $sString
-     *
-     * @return int
      */
-    public function strlen($sString)
+    public function strlen($sString): int
     {
         if ($this->oParserSettings->bMultibyteSupport) {
             return mb_strlen($sString, $this->sCharset);


### PR DESCRIPTION
This applies the rule **NumericReturnTypeFromStrictScalarReturnsRector**. For Details see:
https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#numericreturntypefromstrictscalarreturnsrector