### PR TITLE
[CLEANUP] Rector: Change return type based on strict returns type operations

### DIFF
--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -361,10 +361,7 @@ class ParserState
         return $mComment;
     }
 
-    /**
-     * @return bool
-     */
-    public function isEnd()
+    public function isEnd(): bool
     {
         return $this->iCurrentPosition >= $this->iLength;
     }


### PR DESCRIPTION
This applies the rule **BoolReturnTypeFromStrictScalarReturnsRector**. For Details see:
https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#boolreturntypefromstrictscalarreturnsrector