### PR TITLE
[CLEANUP] Rector: Add method return type based on strict ternary values

### DIFF
--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -241,10 +241,8 @@ abstract class CSSList implements Renderable, Commentable
      *
      * @param string $sIdentifier
      * @param string $sMatch
-     *
-     * @return bool
      */
-    private static function identifierIs($sIdentifier, $sMatch)
+    private static function identifierIs($sIdentifier, $sMatch): bool
     {
         return (strcasecmp($sIdentifier, $sMatch) === 0)
             ?: preg_match("/^(-\\w+-)?$sMatch$/i", $sIdentifier) === 1;

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -258,10 +258,8 @@ class ParserState
     /**
      * @param string $sString
      * @param bool $bCaseInsensitive
-     *
-     * @return bool
      */
-    public function comes($sString, $bCaseInsensitive = false)
+    public function comes($sString, $bCaseInsensitive = false): bool
     {
         $sPeek = $this->peek(strlen($sString));
         return ($sPeek == '')


### PR DESCRIPTION
This applies the rule **ReturnTypeFromStrictTernaryRector**. For Details see:
https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#returntypefromstrictternaryrector