### PR TITLE
[CLEANUP] Rector: Change return type based on strict scalar returns -…

### DIFF
--- a/src/CSSList/AtRuleBlockList.php
+++ b/src/CSSList/AtRuleBlockList.php
@@ -56,10 +56,7 @@ class AtRuleBlockList extends CSSBlockList implements AtRule
         return $this->render(new OutputFormat());
     }
 
-    /**
-     * @return string
-     */
-    public function render(OutputFormat $oOutputFormat)
+    public function render(OutputFormat $oOutputFormat): string
     {
         $sResult = $oOutputFormat->comments($this);
         $sResult .= $oOutputFormat->sBeforeAtRuleBlock;

--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -144,10 +144,8 @@ class Document extends CSSBlockList
      * Overrides `render()` to make format argument optional.
      *
      * @param OutputFormat|null $oOutputFormat
-     *
-     * @return string
      */
-    public function render(OutputFormat $oOutputFormat = null)
+    public function render(OutputFormat $oOutputFormat = null): string
     {
         if ($oOutputFormat === null) {
             $oOutputFormat = new OutputFormat();

--- a/src/CSSList/KeyFrame.php
+++ b/src/CSSList/KeyFrame.php
@@ -67,10 +67,7 @@ class KeyFrame extends CSSList implements AtRule
         return $this->render(new OutputFormat());
     }
 
-    /**
-     * @return string
-     */
-    public function render(OutputFormat $oOutputFormat)
+    public function render(OutputFormat $oOutputFormat): string
     {
         $sResult = $oOutputFormat->comments($this);
         $sResult .= "@{$this->vendorKeyFrame} {$this->animationName}{$oOutputFormat->spaceBeforeOpeningBrace()}{";

--- a/src/Comment/Comment.php
+++ b/src/Comment/Comment.php
@@ -61,10 +61,7 @@ class Comment implements Renderable
         return $this->render(new OutputFormat());
     }
 
-    /**
-     * @return string
-     */
-    public function render(OutputFormat $oOutputFormat)
+    public function render(OutputFormat $oOutputFormat): string
     {
         return '/*' . $this->sComment . '*/';
     }

--- a/src/OutputFormatter.php
+++ b/src/OutputFormatter.php
@@ -166,10 +166,8 @@ class OutputFormatter
      * @param string $sSeparator
      * @param array<array-key, Renderable|string> $aValues
      * @param bool $bIncreaseLevel
-     *
-     * @return string
      */
-    public function implode($sSeparator, array $aValues, $bIncreaseLevel = false)
+    public function implode($sSeparator, array $aValues, $bIncreaseLevel = false): string
     {
         $sResult = '';
         $oFormat = $this->oFormat;
@@ -218,7 +216,7 @@ class OutputFormatter
      *
      * @return string
      */
-    public function comments(Commentable $oCommentable)
+    public function comments(Commentable $oCommentable): string
     {
         if (!$this->oFormat->bRenderComments) {
             return '';
@@ -248,7 +246,7 @@ class OutputFormatter
     /**
      * @return string
      */
-    private function indent()
+    private function indent(): string
     {
         return str_repeat($this->oFormat->sIndentation, $this->oFormat->level());
     }

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -457,10 +457,8 @@ class ParserState
     /**
      * @param int $iStart
      * @param int $iLength
-     *
-     * @return string
      */
-    private function substr($iStart, $iLength)
+    private function substr($iStart, $iLength): string
     {
         if ($iLength < 0) {
             $iLength = $this->iLength - $iStart + $iLength;
@@ -479,10 +477,8 @@ class ParserState
 
     /**
      * @param string $sString
-     *
-     * @return string
      */
-    private function strtolower($sString)
+    private function strtolower($sString): string
     {
         if ($this->oParserSettings->bMultibyteSupport) {
             return mb_strtolower($sString, $this->sCharset);

--- a/src/Property/CSSNamespace.php
+++ b/src/Property/CSSNamespace.php
@@ -59,10 +59,7 @@ class CSSNamespace implements AtRule
         return $this->render(new OutputFormat());
     }
 
-    /**
-     * @return string
-     */
-    public function render(OutputFormat $oOutputFormat)
+    public function render(OutputFormat $oOutputFormat): string
     {
         return '@namespace ' . ($this->sPrefix === null ? '' : $this->sPrefix . ' ')
             . $this->mUrl->render($oOutputFormat) . ';';
@@ -107,7 +104,7 @@ class CSSNamespace implements AtRule
     /**
      * @return string
      */
-    public function atRuleName()
+    public function atRuleName(): string
     {
         return 'namespace';
     }

--- a/src/Property/Charset.php
+++ b/src/Property/Charset.php
@@ -77,18 +77,12 @@ class Charset implements AtRule
         return $this->render(new OutputFormat());
     }
 
-    /**
-     * @return string
-     */
-    public function render(OutputFormat $oOutputFormat)
+    public function render(OutputFormat $oOutputFormat): string
     {
         return "{$oOutputFormat->comments($this)}@charset {$this->oCharset->render($oOutputFormat)};";
     }
 
-    /**
-     * @return string
-     */
-    public function atRuleName()
+    public function atRuleName(): string
     {
         return 'charset';
     }

--- a/src/Property/Import.php
+++ b/src/Property/Import.php
@@ -78,19 +78,13 @@ class Import implements AtRule
         return $this->render(new OutputFormat());
     }
 
-    /**
-     * @return string
-     */
-    public function render(OutputFormat $oOutputFormat)
+    public function render(OutputFormat $oOutputFormat): string
     {
         return $oOutputFormat->comments($this) . "@import " . $this->oLocation->render($oOutputFormat)
             . ($this->sMediaQuery === null ? '' : ' ' . $this->sMediaQuery) . ';';
     }
 
-    /**
-     * @return string
-     */
-    public function atRuleName()
+    public function atRuleName(): string
     {
         return 'import';
     }

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -269,10 +269,7 @@ class Rule implements Renderable, Commentable
         return $this->render(new OutputFormat());
     }
 
-    /**
-     * @return string
-     */
-    public function render(OutputFormat $oOutputFormat)
+    public function render(OutputFormat $oOutputFormat): string
     {
         $sResult = "{$oOutputFormat->comments($this)}{$this->sRule}:{$oOutputFormat->spaceAfterRuleName()}";
         if ($this->mValue instanceof Value) { // Can also be a ValueList

--- a/src/RuleSet/AtRuleSet.php
+++ b/src/RuleSet/AtRuleSet.php
@@ -59,10 +59,7 @@ class AtRuleSet extends RuleSet implements AtRule
         return $this->render(new OutputFormat());
     }
 
-    /**
-     * @return string
-     */
-    public function render(OutputFormat $oOutputFormat)
+    public function render(OutputFormat $oOutputFormat): string
     {
         $sResult = $oOutputFormat->comments($this);
         $sArgs = $this->sArgs;

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -797,11 +797,9 @@ class DeclarationBlock extends RuleSet
     }
 
     /**
-     * @return string
-     *
      * @throws OutputException
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render(OutputFormat $oOutputFormat): string
     {
         $sResult = $oOutputFormat->comments($this);
         if (count($this->aSelectors) === 0) {

--- a/src/Value/CSSString.php
+++ b/src/Value/CSSString.php
@@ -98,10 +98,7 @@ class CSSString extends PrimitiveValue
         return $this->render(new OutputFormat());
     }
 
-    /**
-     * @return string
-     */
-    public function render(OutputFormat $oOutputFormat)
+    public function render(OutputFormat $oOutputFormat): string
     {
         $sString = addslashes($this->sString);
         $sString = str_replace("\n", '\A', $sString);

--- a/src/Value/LineName.php
+++ b/src/Value/LineName.php
@@ -55,10 +55,7 @@ class LineName extends ValueList
         return $this->render(new OutputFormat());
     }
 
-    /**
-     * @return string
-     */
-    public function render(OutputFormat $oOutputFormat)
+    public function render(OutputFormat $oOutputFormat): string
     {
         return '[' . parent::render(OutputFormat::createCompact()) . ']';
     }

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -179,7 +179,7 @@ class Size extends PrimitiveValue
      *
      * @return false if the unit an angle, a duration, a frequency or the number is a component in a Color object.
      */
-    public function isSize()
+    public function isSize(): bool
     {
         if (in_array($this->sUnit, self::NON_SIZE_UNITS, true)) {
             return false;
@@ -206,10 +206,7 @@ class Size extends PrimitiveValue
         return $this->render(new OutputFormat());
     }
 
-    /**
-     * @return string
-     */
-    public function render(OutputFormat $oOutputFormat)
+    public function render(OutputFormat $oOutputFormat): string
     {
         $l = localeconv();
         $sPoint = preg_quote($l['decimal_point'], '/');

--- a/src/Value/URL.php
+++ b/src/Value/URL.php
@@ -85,10 +85,7 @@ class URL extends PrimitiveValue
         return $this->render(new OutputFormat());
     }
 
-    /**
-     * @return string
-     */
-    public function render(OutputFormat $oOutputFormat)
+    public function render(OutputFormat $oOutputFormat): string
     {
         return "url({$this->oURL->render($oOutputFormat)})";
     }

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -183,12 +183,10 @@ abstract class Value implements Renderable
     }
 
     /**
-     * @return string
-     *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    private static function parseUnicodeRangeValue(ParserState $oParserState)
+    private static function parseUnicodeRangeValue(ParserState $oParserState): string
     {
         $iCodepointMaxLength = 6; // Code points outside BMP can use up to six digits
         $sRange = "";


### PR DESCRIPTION
… string, int, float or bool

This applies the rule **ReturnTypeFromStrictScalarReturnExprRector**. For Details see:
https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#returntypefromstrictscalarreturnexprrector