### PR TITLE
[CLEANUP] Rector: Add return type from return direct array

### DIFF
--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -270,10 +270,8 @@ class ParserState
     /**
      * @param int $iLength
      * @param int $iOffset
-     *
-     * @return string
      */
-    public function peek($iLength = 1, $iOffset = 0)
+    public function peek($iLength = 1, $iOffset = 0): string
     {
         $iOffset += $this->iCurrentPosition;
         if ($iOffset >= $this->iLength) {
@@ -285,12 +283,10 @@ class ParserState
     /**
      * @param int $mValue
      *
-     * @return string
-     *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    public function consume($mValue = 1)
+    public function consume($mValue = 1): string
     {
         if (is_string($mValue)) {
             $iLineCount = substr_count($mValue, "\n");
@@ -410,10 +406,7 @@ class ParserState
         );
     }
 
-    /**
-     * @return string
-     */
-    private function inputLeft()
+    private function inputLeft(): string
     {
         return $this->substr($this->iCurrentPosition, -1);
     }

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -117,7 +117,7 @@ class Rule implements Renderable, Commentable
      *
      * @return array<int, string>
      */
-    private static function listDelimiterForRule($sRule)
+    private static function listDelimiterForRule($sRule): array
     {
         if (preg_match('/^font($|-)/', $sRule)) {
             return [',', '/', ' '];

--- a/tests/CSSList/DocumentTest.php
+++ b/tests/CSSList/DocumentTest.php
@@ -50,7 +50,7 @@ final class DocumentTest extends TestCase
     /**
      * @return array<string, array<int, array<int, DeclarationBlock>>>
      */
-    public static function contentsDataProvider()
+    public static function contentsDataProvider(): array
     {
         return [
             'empty array' => [[]],

--- a/tests/RuleSet/DeclarationBlockTest.php
+++ b/tests/RuleSet/DeclarationBlockTest.php
@@ -33,7 +33,7 @@ final class DeclarationBlockTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public static function expandBorderShorthandProvider()
+    public static function expandBorderShorthandProvider(): array
     {
         return [
             ['body{ border: 2px solid #000 }', 'body {border-width: 2px;border-style: solid;border-color: #000;}'],
@@ -66,7 +66,7 @@ final class DeclarationBlockTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public static function expandFontShorthandProvider()
+    public static function expandFontShorthandProvider(): array
     {
         return [
             [
@@ -122,7 +122,7 @@ final class DeclarationBlockTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public static function expandBackgroundShorthandProvider()
+    public static function expandBackgroundShorthandProvider(): array
     {
         return [
             ['body {border: 1px;}', 'body {border: 1px;}'],
@@ -175,7 +175,7 @@ final class DeclarationBlockTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public static function expandDimensionsShorthandProvider()
+    public static function expandDimensionsShorthandProvider(): array
     {
         return [
             ['body {border: 1px;}', 'body {border: 1px;}'],
@@ -213,7 +213,7 @@ final class DeclarationBlockTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public static function createBorderShorthandProvider()
+    public static function createBorderShorthandProvider(): array
     {
         return [
             ['body {border-width: 2px;border-style: solid;border-color: #000;}', 'body {border: 2px solid #000;}'],
@@ -244,7 +244,7 @@ final class DeclarationBlockTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public static function createFontShorthandProvider()
+    public static function createFontShorthandProvider(): array
     {
         return [
             ['body {font-size: 12px; font-family: serif}', 'body {font: 12px serif;}'],
@@ -287,7 +287,7 @@ final class DeclarationBlockTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public static function createDimensionsShorthandProvider()
+    public static function createDimensionsShorthandProvider(): array
     {
         return [
             ['body {border: 1px;}', 'body {border: 1px;}'],
@@ -325,7 +325,7 @@ final class DeclarationBlockTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public static function createBackgroundShorthandProvider()
+    public static function createBackgroundShorthandProvider(): array
     {
         return [
             ['body {border: 1px;}', 'body {border: 1px;}'],


### PR DESCRIPTION
This applies the rule **ReturnTypeFromReturnDirectArrayRector**. For Details see:
https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#returntypefromreturndirectarrayrector