### PR TITLE
[CLEANUP] Rector: Add return type to function like with return new

### DIFF
--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -29,7 +29,7 @@ class Document extends CSSBlockList
      *
      * @throws SourceException
      */
-    public static function parse(ParserState $oParserState)
+    public static function parse(ParserState $oParserState): Document
     {
         $oDocument = new Document($oParserState->currentLine());
         CSSList::parseList($oParserState, $oDocument);

--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -25,8 +25,6 @@ class Document extends CSSBlockList
     }
 
     /**
-     * @return Document
-     *
      * @throws SourceException
      */
     public static function parse(ParserState $oParserState): Document

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -303,10 +303,8 @@ class OutputFormat
 
     /**
      * Creates an instance of this class without any particular formatting settings.
-     *
-     * @return self
      */
-    public static function create()
+    public static function create(): OutputFormat
     {
         return new OutputFormat();
     }

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -3,6 +3,7 @@
 namespace Sabberworm\CSS\Parsing;
 
 use Sabberworm\CSS\Comment\Comment;
+use Sabberworm\CSS\Parsing\Anchor;
 use Sabberworm\CSS\Settings;
 
 class ParserState
@@ -114,10 +115,8 @@ class ParserState
         return $this->oParserSettings;
     }
 
-    /**
-     * @return \Sabberworm\CSS\Parsing\Anchor
-     */
-    public function anchor()
+
+    public function anchor(): Anchor
     {
         return new Anchor($this->iCurrentPosition, $this);
     }

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -71,12 +71,10 @@ class Rule implements Renderable, Commentable
     }
 
     /**
-     * @return Rule
-     *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    public static function parse(ParserState $oParserState)
+    public static function parse(ParserState $oParserState): Rule
     {
         $aComments = $oParserState->consumeWhiteSpace();
         $oRule = new Rule(

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -41,7 +41,7 @@ class Settings
     /**
      * @return self new instance
      */
-    public static function create()
+    public static function create(): Settings
     {
         return new Settings();
     }

--- a/src/Value/CSSString.php
+++ b/src/Value/CSSString.php
@@ -31,13 +31,11 @@ class CSSString extends PrimitiveValue
     }
 
     /**
-     * @return CSSString
-     *
      * @throws SourceException
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    public static function parse(ParserState $oParserState)
+    public static function parse(ParserState $oParserState): CSSString
     {
         $sBegin = $oParserState->peek();
         $sQuote = null;

--- a/src/Value/CalcFunction.php
+++ b/src/Value/CalcFunction.php
@@ -22,12 +22,10 @@ class CalcFunction extends CSSFunction
      * @param ParserState $oParserState
      * @param bool $bIgnoreCase
      *
-     * @return CalcFunction
-     *
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
      */
-    public static function parse(ParserState $oParserState, $bIgnoreCase = false)
+    public static function parse(ParserState $oParserState, $bIgnoreCase = false): CalcFunction
     {
         $aOperators = ['+', '-', '*', '/'];
         $sFunction = $oParserState->parseIdentifier();

--- a/src/Value/LineName.php
+++ b/src/Value/LineName.php
@@ -19,12 +19,10 @@ class LineName extends ValueList
     }
 
     /**
-     * @return LineName
-     *
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
      */
-    public static function parse(ParserState $oParserState)
+    public static function parse(ParserState $oParserState): LineName
     {
         $oParserState->consume('[');
         $oParserState->consumeWhiteSpace();

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -71,12 +71,10 @@ class Size extends PrimitiveValue
     /**
      * @param bool $bIsColorComponent
      *
-     * @return Size
-     *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    public static function parse(ParserState $oParserState, $bIsColorComponent = false)
+    public static function parse(ParserState $oParserState, $bIsColorComponent = false): Size
     {
         $sSize = '';
         if ($oParserState->comes('-')) {

--- a/src/Value/URL.php
+++ b/src/Value/URL.php
@@ -28,13 +28,11 @@ class URL extends PrimitiveValue
     }
 
     /**
-     * @return URL
-     *
      * @throws SourceException
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    public static function parse(ParserState $oParserState)
+    public static function parse(ParserState $oParserState): URL
     {
         $oAnchor = $oParserState->anchor();
         $sIdentifier = '';

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -6,6 +6,7 @@ use Sabberworm\CSS\Parsing\ParserState;
 use Sabberworm\CSS\Parsing\SourceException;
 use Sabberworm\CSS\Parsing\UnexpectedEOFException;
 use Sabberworm\CSS\Parsing\UnexpectedTokenException;
+use Sabberworm\CSS\Value\CSSFunction;
 use Sabberworm\CSS\Renderable;
 
 /**
@@ -170,12 +171,10 @@ abstract class Value implements Renderable
     }
 
     /**
-     * @return CSSFunction
-     *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    private static function parseMicrosoftFilter(ParserState $oParserState)
+    private static function parseMicrosoftFilter(ParserState $oParserState): CSSFunction
     {
         $sFunction = $oParserState->consumeUntil('(', false, true);
         $aArguments = Value::parseValue($oParserState, [',', '=']);


### PR DESCRIPTION
This applies the rule **ReturnTypeFromReturnNewRector**. For Details see:
https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#returntypefromreturnnewrector