### PR TITLE
[CLEANUP] Rector: Add return type void to function like without any return

### DIFF
--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -57,12 +57,10 @@ abstract class CSSList implements Renderable, Commentable
     }
 
     /**
-     * @return void
-     *
      * @throws UnexpectedTokenException
      * @throws SourceException
      */
-    public static function parseList(ParserState $oParserState, CSSList $oList)
+    public static function parseList(ParserState $oParserState, CSSList $oList): void
     {
         $bIsRoot = $oList instanceof Document;
         if (is_string($oParserState)) {
@@ -260,10 +258,8 @@ abstract class CSSList implements Renderable, Commentable
      * Prepends an item to the list of contents.
      *
      * @param RuleSet|CSSList|Import|Charset $oItem
-     *
-     * @return void
      */
-    public function prepend($oItem)
+    public function prepend($oItem): void
     {
         array_unshift($this->aContents, $oItem);
     }
@@ -272,10 +268,8 @@ abstract class CSSList implements Renderable, Commentable
      * Appends an item to the list of contents.
      *
      * @param RuleSet|CSSList|Import|Charset $oItem
-     *
-     * @return void
      */
-    public function append($oItem)
+    public function append($oItem): void
     {
         $this->aContents[] = $oItem;
     }
@@ -286,10 +280,8 @@ abstract class CSSList implements Renderable, Commentable
      * @param int $iOffset
      * @param int $iLength
      * @param array<int, RuleSet|CSSList|Import|Charset> $mReplacement
-     *
-     * @return void
      */
-    public function splice($iOffset, $iLength = null, $mReplacement = null)
+    public function splice($iOffset, $iLength = null, $mReplacement = null): void
     {
         array_splice($this->aContents, $iOffset, $iLength, $mReplacement);
     }
@@ -355,7 +347,7 @@ abstract class CSSList implements Renderable, Commentable
     /**
      * @param array<int, RuleSet|Import|Charset|CSSList> $aContents
      */
-    public function setContents(array $aContents)
+    public function setContents(array $aContents): void
     {
         $this->aContents = [];
         foreach ($aContents as $content) {
@@ -368,10 +360,8 @@ abstract class CSSList implements Renderable, Commentable
      *
      * @param DeclarationBlock|array<array-key, Selector>|string $mSelector the selectors to match
      * @param bool $bRemoveAll whether to stop at the first declaration block found or remove all blocks
-     *
-     * @return void
      */
-    public function removeDeclarationBlockBySelector($mSelector, $bRemoveAll = false)
+    public function removeDeclarationBlockBySelector($mSelector, $bRemoveAll = false): void
     {
         if ($mSelector instanceof DeclarationBlock) {
             $mSelector = $mSelector->getSelectors();
@@ -466,10 +456,8 @@ abstract class CSSList implements Renderable, Commentable
 
     /**
      * @param array<array-key, Comment> $aComments
-     *
-     * @return void
      */
-    public function addComments(array $aComments)
+    public function addComments(array $aComments): void
     {
         $this->aComments = array_merge($this->aComments, $aComments);
     }
@@ -484,10 +472,8 @@ abstract class CSSList implements Renderable, Commentable
 
     /**
      * @param array<array-key, Comment> $aComments
-     *
-     * @return void
      */
-    public function setComments(array $aComments)
+    public function setComments(array $aComments): void
     {
         $this->aComments = $aComments;
     }

--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -113,11 +113,9 @@ class Document extends CSSBlockList
     /**
      * Expands all shorthand properties to their long value.
      *
-     * @return void
-     *
      * @deprecated This will be removed without substitution in version 10.0.
      */
-    public function expandShorthands()
+    public function expandShorthands(): void
     {
         foreach ($this->getAllDeclarationBlocks() as $oDeclaration) {
             $oDeclaration->expandShorthands();
@@ -127,11 +125,9 @@ class Document extends CSSBlockList
     /**
      * Create shorthands properties whenever possible.
      *
-     * @return void
-     *
      * @deprecated This will be removed without substitution in version 10.0.
      */
-    public function createShorthands()
+    public function createShorthands(): void
     {
         foreach ($this->getAllDeclarationBlocks() as $oDeclaration) {
             $oDeclaration->createShorthands();

--- a/src/CSSList/KeyFrame.php
+++ b/src/CSSList/KeyFrame.php
@@ -30,7 +30,7 @@ class KeyFrame extends CSSList implements AtRule
     /**
      * @param string $vendorKeyFrame
      */
-    public function setVendorKeyFrame($vendorKeyFrame)
+    public function setVendorKeyFrame($vendorKeyFrame): void
     {
         $this->vendorKeyFrame = $vendorKeyFrame;
     }
@@ -46,7 +46,7 @@ class KeyFrame extends CSSList implements AtRule
     /**
      * @param string $animationName
      */
-    public function setAnimationName($animationName)
+    public function setAnimationName($animationName): void
     {
         $this->animationName = $animationName;
     }

--- a/src/Comment/Comment.php
+++ b/src/Comment/Comment.php
@@ -45,10 +45,8 @@ class Comment implements Renderable
 
     /**
      * @param string $sComment
-     *
-     * @return void
      */
-    public function setComment($sComment)
+    public function setComment($sComment): void
     {
         $this->sComment = $sComment;
     }

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -274,10 +274,7 @@ class OutputFormat
         return $this->oNextLevelFormat;
     }
 
-    /**
-     * @return void
-     */
-    public function beLenient()
+    public function beLenient(): void
     {
         $this->bIgnoreExceptions = true;
     }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -33,20 +33,16 @@ class Parser
      * Sets the charset to be used if the CSS does not contain an `@charset` declaration.
      *
      * @param string $sCharset
-     *
-     * @return void
      */
-    public function setCharset($sCharset)
+    public function setCharset($sCharset): void
     {
         $this->oParserState->setCharset($sCharset);
     }
 
     /**
      * Returns the charset that is used if the CSS does not contain an `@charset` declaration.
-     *
-     * @return void
      */
-    public function getCharset()
+    public function getCharset(): void
     {
         // Note: The `return` statement is missing here. This is a bug that needs to be fixed.
         $this->oParserState->getCharset();

--- a/src/Parsing/Anchor.php
+++ b/src/Parsing/Anchor.php
@@ -24,10 +24,7 @@ class Anchor
         $this->oParserState = $oParserState;
     }
 
-    /**
-     * @return void
-     */
-    public function backtrack()
+    public function backtrack(): void
     {
         $this->oParserState->setPosition($this->iPosition);
     }

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -69,10 +69,8 @@ class ParserState
      * Sets the charset to be used if the CSS does not contain an `@charset` declaration.
      *
      * @param string $sCharset
-     *
-     * @return void
      */
-    public function setCharset($sCharset)
+    public function setCharset($sCharset): void
     {
         $this->sCharset = $sCharset;
         $this->aText = $this->strsplit($this->sText);
@@ -123,10 +121,8 @@ class ParserState
 
     /**
      * @param int $iPosition
-     *
-     * @return void
      */
-    public function setPosition($iPosition)
+    public function setPosition($iPosition): void
     {
         $this->iCurrentPosition = $iPosition;
     }
@@ -426,10 +422,8 @@ class ParserState
 
     /**
      * @param int $iAmount
-     *
-     * @return void
      */
-    public function backtrack($iAmount)
+    public function backtrack($iAmount): void
     {
         $this->iCurrentPosition -= $iAmount;
     }

--- a/src/Property/CSSNamespace.php
+++ b/src/Property/CSSNamespace.php
@@ -83,20 +83,16 @@ class CSSNamespace implements AtRule
 
     /**
      * @param string $mUrl
-     *
-     * @return void
      */
-    public function setUrl($mUrl)
+    public function setUrl($mUrl): void
     {
         $this->mUrl = $mUrl;
     }
 
     /**
      * @param string $sPrefix
-     *
-     * @return void
      */
-    public function setPrefix($sPrefix)
+    public function setPrefix($sPrefix): void
     {
         $this->sPrefix = $sPrefix;
     }
@@ -123,10 +119,8 @@ class CSSNamespace implements AtRule
 
     /**
      * @param array<array-key, Comment> $aComments
-     *
-     * @return void
      */
-    public function addComments(array $aComments)
+    public function addComments(array $aComments): void
     {
         $this->aComments = array_merge($this->aComments, $aComments);
     }
@@ -141,10 +135,8 @@ class CSSNamespace implements AtRule
 
     /**
      * @param array<array-key, Comment> $aComments
-     *
-     * @return void
      */
-    public function setComments(array $aComments)
+    public function setComments(array $aComments): void
     {
         $this->aComments = $aComments;
     }

--- a/src/Property/Charset.php
+++ b/src/Property/Charset.php
@@ -55,7 +55,7 @@ class Charset implements AtRule
      *
      * @return void
      */
-    public function setCharset($sCharset)
+    public function setCharset($sCharset): void
     {
         $sCharset = $sCharset instanceof CSSString ? $sCharset : new CSSString($sCharset);
         $this->oCharset = $sCharset;
@@ -100,7 +100,7 @@ class Charset implements AtRule
      *
      * @return void
      */
-    public function addComments(array $aComments)
+    public function addComments(array $aComments): void
     {
         $this->aComments = array_merge($this->aComments, $aComments);
     }
@@ -118,7 +118,7 @@ class Charset implements AtRule
      *
      * @return void
      */
-    public function setComments(array $aComments)
+    public function setComments(array $aComments): void
     {
         $this->aComments = $aComments;
     }

--- a/src/Property/Import.php
+++ b/src/Property/Import.php
@@ -54,10 +54,8 @@ class Import implements AtRule
 
     /**
      * @param URL $oLocation
-     *
-     * @return void
      */
-    public function setLocation($oLocation)
+    public function setLocation($oLocation): void
     {
         $this->oLocation = $oLocation;
     }
@@ -103,10 +101,8 @@ class Import implements AtRule
 
     /**
      * @param array<array-key, Comment> $aComments
-     *
-     * @return void
      */
-    public function addComments(array $aComments)
+    public function addComments(array $aComments): void
     {
         $this->aComments = array_merge($this->aComments, $aComments);
     }
@@ -121,10 +117,8 @@ class Import implements AtRule
 
     /**
      * @param array<array-key, Comment> $aComments
-     *
-     * @return void
      */
-    public function setComments(array $aComments)
+    public function setComments(array $aComments): void
     {
         $this->aComments = $aComments;
     }

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -107,7 +107,7 @@ class Selector
      *
      * @return void
      */
-    public function setSelector($sSelector)
+    public function setSelector($sSelector): void
     {
         $this->sSelector = trim($sSelector);
         $this->iSpecificity = null;

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -142,10 +142,8 @@ class Rule implements Renderable, Commentable
     /**
      * @param int $iLine
      * @param int $iColumn
-     *
-     * @return void
      */
-    public function setPosition($iLine, $iColumn)
+    public function setPosition($iLine, $iColumn): void
     {
         $this->iColNo = $iColumn;
         $this->iLineNo = $iLine;
@@ -153,10 +151,8 @@ class Rule implements Renderable, Commentable
 
     /**
      * @param string $sRule
-     *
-     * @return void
      */
-    public function setRule($sRule)
+    public function setRule($sRule): void
     {
         $this->sRule = $sRule;
     }
@@ -179,10 +175,8 @@ class Rule implements Renderable, Commentable
 
     /**
      * @param RuleValueList|string|null $mValue
-     *
-     * @return void
      */
-    public function setValue($mValue)
+    public function setValue($mValue): void
     {
         $this->mValue = $mValue;
     }
@@ -193,10 +187,8 @@ class Rule implements Renderable, Commentable
      *
      * @param RuleValueList|array<int, RuleValueList> $mValue
      * @param string $sType
-     *
-     * @return void
      */
-    public function addValue($mValue, $sType = ' ')
+    public function addValue($mValue, $sType = ' '): void
     {
         if (!is_array($mValue)) {
             $mValue = [$mValue];
@@ -215,10 +207,8 @@ class Rule implements Renderable, Commentable
 
     /**
      * @param int $iModifier
-     *
-     * @return void
      */
-    public function addIeHack($iModifier)
+    public function addIeHack($iModifier): void
     {
         $this->aIeHack[] = $iModifier;
     }
@@ -228,7 +218,7 @@ class Rule implements Renderable, Commentable
      *
      * @return void
      */
-    public function setIeHack(array $aModifiers)
+    public function setIeHack(array $aModifiers): void
     {
         $this->aIeHack = $aModifiers;
     }
@@ -243,10 +233,8 @@ class Rule implements Renderable, Commentable
 
     /**
      * @param bool $bIsImportant
-     *
-     * @return void
      */
-    public function setIsImportant($bIsImportant)
+    public function setIsImportant($bIsImportant): void
     {
         $this->bIsImportant = $bIsImportant;
     }
@@ -287,10 +275,8 @@ class Rule implements Renderable, Commentable
 
     /**
      * @param array<array-key, Comment> $aComments
-     *
-     * @return void
      */
-    public function addComments(array $aComments)
+    public function addComments(array $aComments): void
     {
         $this->aComments = array_merge($this->aComments, $aComments);
     }
@@ -305,10 +291,8 @@ class Rule implements Renderable, Commentable
 
     /**
      * @param array<array-key, Comment> $aComments
-     *
-     * @return void
      */
-    public function setComments(array $aComments)
+    public function setComments(array $aComments): void
     {
         $this->aComments = $aComments;
     }

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -93,7 +93,7 @@ class DeclarationBlock extends RuleSet
      *
      * @throws UnexpectedTokenException
      */
-    public function setSelectors($mSelector, $oList = null)
+    public function setSelectors($mSelector, $oList = null): void
     {
         if (is_array($mSelector)) {
             $this->aSelectors = $mSelector;
@@ -155,11 +155,9 @@ class DeclarationBlock extends RuleSet
     /**
      * Splits shorthand declarations (e.g. `margin` or `font`) into their constituent parts.
      *
-     * @return void
-     *
      * @deprecated This will be removed without substitution in version 10.0.
      */
-    public function expandShorthands()
+    public function expandShorthands(): void
     {
         // border must be expanded before dimensions
         $this->expandBorderShorthand();
@@ -172,11 +170,9 @@ class DeclarationBlock extends RuleSet
     /**
      * Creates shorthand declarations (e.g. `margin` or `font`) whenever possible.
      *
-     * @return void
-     *
      * @deprecated This will be removed without substitution in version 10.0.
      */
-    public function createShorthands()
+    public function createShorthands(): void
     {
         $this->createBackgroundShorthand();
         $this->createDimensionsShorthand();
@@ -193,11 +189,9 @@ class DeclarationBlock extends RuleSet
      *
      * Multiple borders are not yet supported as of 3.
      *
-     * @return void
-     *
      * @deprecated This will be removed without substitution in version 10.0.
      */
-    public function expandBorderShorthand()
+    public function expandBorderShorthand(): void
     {
         $aBorderRules = [
             'border',
@@ -256,11 +250,9 @@ class DeclarationBlock extends RuleSet
      *
      * Handles `margin`, `padding`, `border-color`, `border-style` and `border-width`.
      *
-     * @return void
-     *
      * @deprecated This will be removed without substitution in version 10.0.
      */
-    public function expandDimensionsShorthand()
+    public function expandDimensionsShorthand(): void
     {
         $aExpansions = [
             'margin' => 'margin-%s',
@@ -318,11 +310,9 @@ class DeclarationBlock extends RuleSet
      * (e.g. `font: 300 italic 11px/14px verdana, helvetica, sans-serif;`)
      * into their constituent parts.
      *
-     * @return void
-     *
      * @deprecated This will be removed without substitution in version 10.0.
      */
-    public function expandFontShorthand()
+    public function expandFontShorthand(): void
     {
         $aRules = $this->getRulesAssoc();
         if (!isset($aRules['font'])) {
@@ -390,11 +380,9 @@ class DeclarationBlock extends RuleSet
      *
      * @see http://www.w3.org/TR/21/colors.html#propdef-background
      *
-     * @return void
-     *
      * @deprecated This will be removed without substitution in version 10.0.
      */
-    public function expandBackgroundShorthand()
+    public function expandBackgroundShorthand(): void
     {
         $aRules = $this->getRulesAssoc();
         if (!isset($aRules['background'])) {
@@ -464,11 +452,9 @@ class DeclarationBlock extends RuleSet
     }
 
     /**
-     * @return void
-     *
      * @deprecated This will be removed without substitution in version 10.0.
      */
-    public function expandListStyleShorthand()
+    public function expandListStyleShorthand(): void
     {
         $aListProperties = [
             'list-style-type' => 'disc',
@@ -549,11 +535,9 @@ class DeclarationBlock extends RuleSet
      * @param array<array-key, string> $aProperties
      * @param string $sShorthand
      *
-     * @return void
-     *
      * @deprecated This will be removed without substitution in version 10.0.
      */
-    public function createShorthandProperties(array $aProperties, $sShorthand)
+    public function createShorthandProperties(array $aProperties, $sShorthand): void
     {
         $aRules = $this->getRulesAssoc();
         $oRule = null;
@@ -587,11 +571,9 @@ class DeclarationBlock extends RuleSet
     }
 
     /**
-     * @return void
-     *
      * @deprecated This will be removed without substitution in version 10.0.
      */
-    public function createBackgroundShorthand()
+    public function createBackgroundShorthand(): void
     {
         $aProperties = [
             'background-color',
@@ -604,11 +586,9 @@ class DeclarationBlock extends RuleSet
     }
 
     /**
-     * @return void
-     *
      * @deprecated This will be removed without substitution in version 10.0.
      */
-    public function createListStyleShorthand()
+    public function createListStyleShorthand(): void
     {
         $aProperties = [
             'list-style-type',
@@ -623,11 +603,9 @@ class DeclarationBlock extends RuleSet
      *
      * Should be run after `create_dimensions_shorthand`!
      *
-     * @return void
-     *
      * @deprecated This will be removed without substitution in version 10.0.
      */
-    public function createBorderShorthand()
+    public function createBorderShorthand(): void
     {
         $aProperties = [
             'border-width',
@@ -642,11 +620,9 @@ class DeclarationBlock extends RuleSet
      * (margin, padding, border-color, border-style and border-width)
      * and converts them into shorthand CSS properties.
      *
-     * @return void
-     *
      * @deprecated This will be removed without substitution in version 10.0.
      */
-    public function createDimensionsShorthand()
+    public function createDimensionsShorthand(): void
     {
         $aPositions = ['top', 'right', 'bottom', 'left'];
         $aExpansions = [
@@ -718,11 +694,9 @@ class DeclarationBlock extends RuleSet
      *
      * At least `font-size` AND `font-family` must be present in order to create a shorthand declaration.
      *
-     * @return void
-     *
      * @deprecated This will be removed without substitution in version 10.0.
      */
-    public function createFontShorthand()
+    public function createFontShorthand(): void
     {
         $aFontProperties = [
             'font-style',

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -48,12 +48,10 @@ abstract class RuleSet implements Renderable, Commentable
     }
 
     /**
-     * @return void
-     *
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
      */
-    public static function parseRuleSet(ParserState $oParserState, RuleSet $oRuleSet)
+    public static function parseRuleSet(ParserState $oParserState, RuleSet $oRuleSet): void
     {
         while ($oParserState->comes(';')) {
             $oParserState->consume(';');
@@ -99,10 +97,8 @@ abstract class RuleSet implements Renderable, Commentable
 
     /**
      * @param Rule|null $oSibling
-     *
-     * @return void
      */
-    public function addRule(Rule $oRule, Rule $oSibling = null)
+    public function addRule(Rule $oRule, Rule $oSibling = null): void
     {
         $sRule = $oRule->getRule();
         if (!isset($this->aRules[$sRule])) {
@@ -180,10 +176,8 @@ abstract class RuleSet implements Renderable, Commentable
      * Overrides all the rules of this set.
      *
      * @param array<array-key, Rule> $aRules The rules to override with.
-     *
-     * @return void
      */
-    public function setRules(array $aRules)
+    public function setRules(array $aRules): void
     {
         $this->aRules = [];
         foreach ($aRules as $rule) {
@@ -229,10 +223,8 @@ abstract class RuleSet implements Renderable, Commentable
      *        pattern to remove. If $mRule is null, all rules are removed. If the pattern ends in a dash,
      *        all rules starting with the pattern are removed as well as one matching the pattern with the dash
      *        excluded. Passing a Rule behaves matches by identity.
-     *
-     * @return void
      */
-    public function removeRule($mRule)
+    public function removeRule($mRule): void
     {
         if ($mRule instanceof Rule) {
             $sRule = $mRule->getRule();
@@ -304,10 +296,8 @@ abstract class RuleSet implements Renderable, Commentable
 
     /**
      * @param array<string, Comment> $aComments
-     *
-     * @return void
      */
-    public function addComments(array $aComments)
+    public function addComments(array $aComments): void
     {
         $this->aComments = array_merge($this->aComments, $aComments);
     }
@@ -322,10 +312,8 @@ abstract class RuleSet implements Renderable, Commentable
 
     /**
      * @param array<string, Comment> $aComments
-     *
-     * @return void
      */
-    public function setComments(array $aComments)
+    public function setComments(array $aComments): void
     {
         $this->aComments = $aComments;
     }

--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -63,10 +63,8 @@ class CSSFunction extends ValueList
 
     /**
      * @param string $sName
-     *
-     * @return void
      */
-    public function setName($sName)
+    public function setName($sName): void
     {
         $this->sName = $sName;
     }

--- a/src/Value/CSSString.php
+++ b/src/Value/CSSString.php
@@ -72,10 +72,8 @@ class CSSString extends PrimitiveValue
 
     /**
      * @param string $sString
-     *
-     * @return void
      */
-    public function setString($sString)
+    public function setString($sString): void
     {
         $this->sString = $sString;
     }

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -134,10 +134,8 @@ class Color extends CSSFunction
 
     /**
      * @param array<int, Value|string> $aColor
-     *
-     * @return void
      */
-    public function setColor(array $aColor)
+    public function setColor(array $aColor): void
     {
         $this->setName(implode('', array_keys($aColor)));
         $this->aComponents = $aColor;

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -132,10 +132,8 @@ class Size extends PrimitiveValue
 
     /**
      * @param string $sUnit
-     *
-     * @return void
      */
-    public function setUnit($sUnit)
+    public function setUnit($sUnit): void
     {
         $this->sUnit = $sUnit;
     }
@@ -151,7 +149,7 @@ class Size extends PrimitiveValue
     /**
      * @param float|int|string $fSize
      */
-    public function setSize($fSize)
+    public function setSize($fSize): void
     {
         $this->fSize = (float) $fSize;
     }

--- a/src/Value/URL.php
+++ b/src/Value/URL.php
@@ -59,10 +59,7 @@ class URL extends PrimitiveValue
         return $oResult;
     }
 
-    /**
-     * @return void
-     */
-    public function setURL(CSSString $oURL)
+    public function setURL(CSSString $oURL): void
     {
         $this->oURL = $oURL;
     }

--- a/src/Value/ValueList.php
+++ b/src/Value/ValueList.php
@@ -39,10 +39,8 @@ abstract class ValueList extends Value
 
     /**
      * @param Value|string $mComponent
-     *
-     * @return void
      */
-    public function addListComponent($mComponent)
+    public function addListComponent($mComponent): void
     {
         $this->aComponents[] = $mComponent;
     }
@@ -57,10 +55,8 @@ abstract class ValueList extends Value
 
     /**
      * @param array<int, Value|string> $aComponents
-     *
-     * @return void
      */
-    public function setListComponents(array $aComponents)
+    public function setListComponents(array $aComponents): void
     {
         $this->aComponents = $aComponents;
     }
@@ -75,10 +71,8 @@ abstract class ValueList extends Value
 
     /**
      * @param string $sSeparator
-     *
-     * @return void
      */
-    public function setListSeparator($sSeparator)
+    public function setListSeparator($sSeparator): void
     {
         $this->sSeparator = $sSeparator;
     }

--- a/tests/CSSList/DocumentTest.php
+++ b/tests/CSSList/DocumentTest.php
@@ -89,7 +89,7 @@ final class DocumentTest extends TestCase
     /**
      * @test
      */
-    public function insertContentBeforeInsertsContentBeforeSibbling()
+    public function insertContentBeforeInsertsContentBeforeSibbling(): void
     {
         $bogusOne = new DeclarationBlock();
         $bogusOne->setSelectors('.bogus-one');
@@ -115,7 +115,7 @@ final class DocumentTest extends TestCase
     /**
      * @test
      */
-    public function insertContentBeforeAppendsIfSibblingNotFound()
+    public function insertContentBeforeAppendsIfSibblingNotFound(): void
     {
         $bogusOne = new DeclarationBlock();
         $bogusOne->setSelectors('.bogus-one');

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1241,7 +1241,7 @@ body {background-color: red;}';
         self::assertSame($sExpected, $oDoc->render());
     }
 
-    public function escapedSpecialCaseTokens()
+    public function escapedSpecialCaseTokens(): void
     {
         $oDoc = $this->parsedStructureForFile('escaped-tokens');
         $contents = $oDoc->getContents();


### PR DESCRIPTION
This applies the rule **AddVoidReturnTypeWhereNoReturnRector**. For Details see:
https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#addvoidreturntypewherenoreturnrector