### PR TITLE
[CLEANUP] Extract CSSFunction methods parseName and parseArguments

### DIFF
--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -34,21 +34,42 @@ class CSSFunction extends ValueList
     }
 
     /**
-     * @param ParserState $oParserState
-     * @param bool $bIgnoreCase
+     * @throws SourceException
+     * @throws UnexpectedEOFException
+     * @throws UnexpectedTokenException
+     */
+    public static function parse(ParserState $oParserState, bool $bIgnoreCase = false): CSSFunction
+    {
+        $sName = self::parseName($oParserState, $bIgnoreCase);
+        $oParserState->consume('(');
+        $mArguments = self::parseArguments($oParserState);
+
+        $oResult = new CSSFunction($sName, $mArguments, ',', $oParserState->currentLine());
+        $oParserState->consume(')');
+
+        return $oResult;
+    }
+
+    /**
+     * @throws SourceException
+     * @throws UnexpectedEOFException
+     * @throws UnexpectedTokenException
+     */
+    private static function parseName(ParserState $oParserState, bool $bIgnoreCase = false): string
+    {
+        return $oParserState->parseIdentifier($bIgnoreCase);
+    }
+
+    /**
+     * @return Value|string
      *
      * @throws SourceException
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    public static function parse(ParserState $oParserState, $bIgnoreCase = false): CSSFunction
+    private static function parseArguments(ParserState $oParserState)
     {
-        $mResult = $oParserState->parseIdentifier($bIgnoreCase);
-        $oParserState->consume('(');
-        $aArguments = Value::parseValue($oParserState, ['=', ' ', ',']);
-        $mResult = new CSSFunction($mResult, $aArguments, ',', $oParserState->currentLine());
-        $oParserState->consume(')');
-        return $mResult;
+        return Value::parseValue($oParserState, ['=', ' ', ',']);
     }
 
     /**

--- a/src/Value/CalcFunction.php
+++ b/src/Value/CalcFunction.php
@@ -19,13 +19,10 @@ class CalcFunction extends CSSFunction
     private const T_OPERATOR = 2;
 
     /**
-     * @param ParserState $oParserState
-     * @param bool $bIgnoreCase
-     *
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
      */
-    public static function parse(ParserState $oParserState, $bIgnoreCase = false): CSSFunction
+    public static function parse(ParserState $oParserState, bool $bIgnoreCase = false): CSSFunction
     {
         $aOperators = ['+', '-', '*', '/'];
         $sFunction = $oParserState->parseIdentifier();

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -23,13 +23,10 @@ class Color extends CSSFunction
     }
 
     /**
-     * @param ParserState $oParserState
-     * @param bool $bIgnoreCase
-     *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    public static function parse(ParserState $oParserState, $bIgnoreCase = false): CSSFunction
+    public static function parse(ParserState $oParserState, bool $bIgnoreCase = false): CSSFunction
     {
         $aColor = [];
         if ($oParserState->comes('#')) {


### PR DESCRIPTION
Also
- Update the `parse` function signature to use PHP7 type hints;
- Remove subsequently redundant DocBlock entries;
- Ditto for same-named method in subclass to avoid contravariance.

This is the refactoring change from #390.