### PR TITLE
[CLEANUP] Rector: Add strict return type based native function or class method return

### DIFF
--- a/src/OutputFormatter.php
+++ b/src/OutputFormatter.php
@@ -36,66 +36,42 @@ class OutputFormatter
         return $this->prepareSpace($sSpaceString);
     }
 
-    /**
-     * @return string
-     */
-    public function spaceAfterRuleName()
+    public function spaceAfterRuleName(): string
     {
         return $this->space('AfterRuleName');
     }
 
-    /**
-     * @return string
-     */
-    public function spaceBeforeRules()
+    public function spaceBeforeRules(): string
     {
         return $this->space('BeforeRules');
     }
 
-    /**
-     * @return string
-     */
-    public function spaceAfterRules()
+    public function spaceAfterRules(): string
     {
         return $this->space('AfterRules');
     }
 
-    /**
-     * @return string
-     */
-    public function spaceBetweenRules()
+    public function spaceBetweenRules(): string
     {
         return $this->space('BetweenRules');
     }
 
-    /**
-     * @return string
-     */
-    public function spaceBeforeBlocks()
+    public function spaceBeforeBlocks(): string
     {
         return $this->space('BeforeBlocks');
     }
 
-    /**
-     * @return string
-     */
-    public function spaceAfterBlocks()
+    public function spaceAfterBlocks(): string
     {
         return $this->space('AfterBlocks');
     }
 
-    /**
-     * @return string
-     */
-    public function spaceBetweenBlocks()
+    public function spaceBetweenBlocks(): string
     {
         return $this->space('BetweenBlocks');
     }
 
-    /**
-     * @return string
-     */
-    public function spaceBeforeSelectorSeparator()
+    public function spaceBeforeSelectorSeparator(): string
     {
         return $this->space('BeforeSelectorSeparator');
     }
@@ -103,7 +79,7 @@ class OutputFormatter
     /**
      * @return string
      */
-    public function spaceAfterSelectorSeparator()
+    public function spaceAfterSelectorSeparator(): string
     {
         return $this->space('AfterSelectorSeparator');
     }
@@ -111,9 +87,8 @@ class OutputFormatter
     /**
      * @param string $sSeparator
      *
-     * @return string
      */
-    public function spaceBeforeListArgumentSeparator($sSeparator)
+    public function spaceBeforeListArgumentSeparator($sSeparator): string
     {
         return $this->space('BeforeListArgumentSeparator', $sSeparator);
     }
@@ -121,17 +96,13 @@ class OutputFormatter
     /**
      * @param string $sSeparator
      *
-     * @return string
      */
-    public function spaceAfterListArgumentSeparator($sSeparator)
+    public function spaceAfterListArgumentSeparator($sSeparator): string
     {
         return $this->space('AfterListArgumentSeparator', $sSeparator);
     }
 
-    /**
-     * @return string
-     */
-    public function spaceBeforeOpeningBrace()
+    public function spaceBeforeOpeningBrace(): string
     {
         return $this->space('BeforeOpeningBrace');
     }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -51,11 +51,9 @@ class Parser
     /**
      * Parses the CSS provided to the constructor and creates a `Document` from it.
      *
-     * @return Document
-     *
      * @throws SourceException
      */
-    public function parse()
+    public function parse(): Document
     {
         return Document::parse($this->oParserState);
     }

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -308,12 +308,10 @@ class ParserState
      * @param string $mExpression
      * @param int|null $iMaxLength
      *
-     * @return string
-     *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    public function consumeExpression($mExpression, $iMaxLength = null)
+    public function consumeExpression($mExpression, $iMaxLength = null): string
     {
         $aMatches = null;
         $sInput = $iMaxLength !== null ? $this->peek($iMaxLength) : $this->inputLeft();

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1004,10 +1004,8 @@ body {background-color: red;}';
      *
      * @param string $sFileName
      * @param Settings|null $oSettings
-     *
-     * @return Document parsed document
      */
-    public static function parsedStructureForFile($sFileName, $oSettings = null)
+    public static function parsedStructureForFile($sFileName, $oSettings = null): Document
     {
         $sFile = __DIR__ . "/fixtures/$sFileName.css";
         $oParser = new Parser(file_get_contents($sFile), $oSettings);


### PR DESCRIPTION
This applies the rule **ReturnTypeFromStrictNativeCallRector**. For Details see:
https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#returntypefromstrictnativecallrector

~This PR is based on #602.~