### PR TITLE
[CLEANUP] Rector: Add missing return type declaration based on parent class method

### DIFF
--- a/src/CSSList/AtRuleBlockList.php
+++ b/src/CSSList/AtRuleBlockList.php
@@ -48,10 +48,7 @@ class AtRuleBlockList extends CSSBlockList implements AtRule
         return $this->sArgs;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }

--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -394,10 +394,7 @@ abstract class CSSList implements Renderable, Commentable
         }
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }

--- a/src/CSSList/KeyFrame.php
+++ b/src/CSSList/KeyFrame.php
@@ -59,10 +59,7 @@ class KeyFrame extends CSSList implements AtRule
         return $this->animationName;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }

--- a/src/Comment/Comment.php
+++ b/src/Comment/Comment.php
@@ -51,10 +51,7 @@ class Comment implements Renderable
         $this->sComment = $sComment;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }

--- a/src/Property/CSSNamespace.php
+++ b/src/Property/CSSNamespace.php
@@ -51,10 +51,7 @@ class CSSNamespace implements AtRule
         return $this->iLineNo;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }

--- a/src/Property/Charset.php
+++ b/src/Property/Charset.php
@@ -69,10 +69,7 @@ class Charset implements AtRule
         return $this->oCharset->getString();
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }

--- a/src/Property/Import.php
+++ b/src/Property/Import.php
@@ -68,10 +68,7 @@ class Import implements AtRule
         return $this->oLocation;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -113,10 +113,7 @@ class Selector
         $this->iSpecificity = null;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getSelector();
     }

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -247,10 +247,7 @@ class Rule implements Renderable, Commentable
         return $this->bIsImportant;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }

--- a/src/RuleSet/AtRuleSet.php
+++ b/src/RuleSet/AtRuleSet.php
@@ -51,10 +51,7 @@ class AtRuleSet extends RuleSet implements AtRule
         return $this->sArgs;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -775,11 +775,9 @@ class DeclarationBlock extends RuleSet
     }
 
     /**
-     * @return string
-     *
      * @throws OutputException
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -252,10 +252,7 @@ abstract class RuleSet implements Renderable, Commentable
         }
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }

--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -96,10 +96,7 @@ class CSSFunction extends ValueList
         return $this->aComponents;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }

--- a/src/Value/CSSString.php
+++ b/src/Value/CSSString.php
@@ -86,10 +86,7 @@ class CSSString extends PrimitiveValue
         return $this->sString;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -144,10 +144,7 @@ class Color extends CSSFunction
         return $this->getName();
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }

--- a/src/Value/LineName.php
+++ b/src/Value/LineName.php
@@ -45,10 +45,7 @@ class LineName extends ValueList
         return new LineName($aNames, $oParserState->currentLine());
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -194,10 +194,7 @@ class Size extends PrimitiveValue
         return false;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }

--- a/src/Value/URL.php
+++ b/src/Value/URL.php
@@ -72,10 +72,7 @@ class URL extends PrimitiveValue
         return $this->oURL;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }

--- a/src/Value/ValueList.php
+++ b/src/Value/ValueList.php
@@ -77,10 +77,7 @@ abstract class ValueList extends Value
         $this->sSeparator = $sSeparator;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render(new OutputFormat());
     }


### PR DESCRIPTION
This applies the rule **AddReturnTypeDeclarationBasedOnParentClassMethodRector**. For Details see:
https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#addreturntypedeclarationbasedonparentclassmethodrector
