### PR TITLE
[BUGFIX] Fix undefined local variable in `CalcFunction::parse()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Fix undefined local variable in `CalcFunction::parse()` (#593)
+
 ## 8.5.1
 
 ### Fixed

--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -10,8 +10,3 @@ parameters:
 			count: 2
 			path: ../src/RuleSet/DeclarationBlock.php
 
-		-
-			message: "#^Variable \\$oVal might not be defined\\.$#"
-			count: 1
-			path: ../src/Value/CalcFunction.php
-

--- a/src/Value/CalcFunction.php
+++ b/src/Value/CalcFunction.php
@@ -91,7 +91,7 @@ class CalcFunction extends CSSFunction
                         sprintf(
                             'Next token was expected to be an operand of type %s. Instead "%s" was found.',
                             implode(', ', $aOperators),
-                            $oVal
+                            $oParserState->peek()
                         ),
                         '',
                         'custom',


### PR DESCRIPTION
This is the 8.x backport of #593.

Fixes #585