### PR TITLE
[TASK] Test parsing arithmetic operators in clamp function

### DIFF
--- a/tests/Value/ValueTest.php
+++ b/tests/Value/ValueTest.php
@@ -72,6 +72,10 @@ final class ValueTest extends TestCase
                 'to be parsed' => 'max(300px, %s);',
                 'expected' => 'max(300px,%s)',
             ],
+            'clamp' => [
+                'to be parsed' => 'clamp(2.19rem, %s, 2.5rem);',
+                'expected' => 'clamp(2.19rem,%s,2.5rem)',
+            ],
         ];
     }
 


### PR DESCRIPTION
Closes #619.

The test passes, whereas without the change from #607, it does not.