### PR TITLE
[FEATURE] Support arithmetic operators in CSS functions (#607)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Support arithmetic operators in CSS function arguments (#607)
 - Add support for inserting an item in a CSS list (#545)
-
 - Add support for the `dvh`, `lvh` and `svh` length units (#415)
 
 ### Changed

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -163,7 +163,16 @@ abstract class Value implements Renderable
         } elseif ($oParserState->comes("U+")) {
             $oValue = self::parseUnicodeRangeValue($oParserState);
         } else {
-            $oValue = self::parseIdentifierOrFunction($oParserState);
+            $sNextChar = $oParserState->peek(1);
+            try {
+                $oValue = self::parseIdentifierOrFunction($oParserState);
+            } catch (UnexpectedTokenException $e) {
+                if (\in_array($sNextChar, ['+', '-', '*', '/'], true)) {
+                    $oValue = $oParserState->consume(1);
+                } else {
+                    throw $e;
+                }
+            }
         }
         $oParserState->consumeWhiteSpace();
         return $oValue;

--- a/tests/Value/ValueTest.php
+++ b/tests/Value/ValueTest.php
@@ -15,14 +15,14 @@ final class ValueTest extends TestCase
     /**
      * @return array<string, array{0: string}>
      */
-    public static function provideArithmeticOperator(): array
+    public static function provideArithmeticOperator()
     {
         $units = ['+', '-', '*', '/'];
 
         return \array_combine(
             $units,
             \array_map(
-                function (string $unit): array {
+                function (string $unit) {
                     return [$unit];
                 },
                 $units
@@ -35,7 +35,7 @@ final class ValueTest extends TestCase
      *
      * @dataProvider provideArithmeticOperator
      */
-    public function parsesArithmeticInFunctions(string $operator): void
+    public function parsesArithmeticInFunctions(string $operator)
     {
         $subject = Value::parseValue(new ParserState('max(300px, 50vh ' . $operator . ' 10px);', Settings::create()));
 
@@ -47,7 +47,7 @@ final class ValueTest extends TestCase
      * The first datum is a template for the parser (using `sprintf` insertion marker `%s` for some expression).
      * The second is for the expected result, which may have whitespace and trailing semicolon removed.
      */
-    public static function provideCssFunctionTemplates(): array
+    public static function provideCssFunctionTemplates()
     {
         return [
             'calc' => [
@@ -69,7 +69,7 @@ final class ValueTest extends TestCase
     public function parsesArithmeticWithMultipleOperatorsInFunctions(
         string $parserTemplate,
         string $expectedResultTemplate
-    ): void {
+    ) {
         static $expression = '300px + 10% + 10vw';
 
         $subject = Value::parseValue(new ParserState(\sprintf($parserTemplate, $expression), Settings::create()));
@@ -80,7 +80,7 @@ final class ValueTest extends TestCase
     /**
      * @return array<string, array{0: string, 1: string}>
      */
-    public static function provideMalformedLengthOperands(): array
+    public static function provideMalformedLengthOperands()
     {
         return [
             'LHS missing number' => ['vh', '10px'],
@@ -95,7 +95,7 @@ final class ValueTest extends TestCase
      *
      * @dataProvider provideMalformedLengthOperands
      */
-    public function parsesArithmeticWithMalformedOperandsInFunctions(string $leftOperand, string $rightOperand): void
+    public function parsesArithmeticWithMalformedOperandsInFunctions(string $leftOperand, string $rightOperand)
     {
         $subject = Value::parseValue(new ParserState(
             'max(300px, ' . $leftOperand . ' + ' . $rightOperand . ');',

--- a/tests/Value/ValueTest.php
+++ b/tests/Value/ValueTest.php
@@ -22,7 +22,7 @@ final class ValueTest extends TestCase
         return \array_combine(
             $units,
             \array_map(
-                function (string $unit) {
+                function ($unit) {
                     return [$unit];
                 },
                 $units
@@ -35,7 +35,7 @@ final class ValueTest extends TestCase
      *
      * @dataProvider provideArithmeticOperator
      */
-    public function parsesArithmeticInFunctions(string $operator)
+    public function parsesArithmeticInFunctions($operator)
     {
         $subject = Value::parseValue(new ParserState('max(300px, 50vh ' . $operator . ' 10px);', Settings::create()));
 
@@ -67,8 +67,8 @@ final class ValueTest extends TestCase
      * @dataProvider provideCssFunctionTemplates
      */
     public function parsesArithmeticWithMultipleOperatorsInFunctions(
-        string $parserTemplate,
-        string $expectedResultTemplate
+        $parserTemplate,
+        $expectedResultTemplate
     ) {
         static $expression = '300px + 10% + 10vw';
 
@@ -95,7 +95,7 @@ final class ValueTest extends TestCase
      *
      * @dataProvider provideMalformedLengthOperands
      */
-    public function parsesArithmeticWithMalformedOperandsInFunctions(string $leftOperand, string $rightOperand)
+    public function parsesArithmeticWithMalformedOperandsInFunctions($leftOperand, $rightOperand)
     {
         $subject = Value::parseValue(new ParserState(
             'max(300px, ' . $leftOperand . ' + ' . $rightOperand . ');',

--- a/tests/Value/ValueTest.php
+++ b/tests/Value/ValueTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabberworm\CSS\Tests\Value;
+
+use PHPUnit\Framework\TestCase;
+use Sabberworm\CSS\Parsing\ParserState;
+use Sabberworm\CSS\Settings;
+use Sabberworm\CSS\Value\Value;
+
+/**
+ * @covers \Sabberworm\CSS\Value\Value
+ */
+final class ValueTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function provideArithmeticOperator(): array
+    {
+        $units = ['+', '-', '*', '/'];
+
+        return \array_combine(
+            $units,
+            \array_map(
+                function (string $unit): array {
+                    return [$unit];
+                },
+                $units
+            )
+        );
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideArithmeticOperator
+     */
+    public function parsesArithmeticInFunctions(string $operator): void
+    {
+        $subject = Value::parseValue(new ParserState('max(300px, 50vh ' . $operator . ' 10px);', Settings::create()));
+
+        self::assertSame('max(300px,50vh ' . $operator . ' 10px)', (string) $subject);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     * The first datum is a template for the parser (using `sprintf` insertion marker `%s` for some expression).
+     * The second is for the expected result, which may have whitespace and trailing semicolon removed.
+     */
+    public static function provideCssFunctionTemplates(): array
+    {
+        return [
+            'calc' => [
+                'to be parsed' => 'calc(%s);',
+                'expected' => 'calc(%s)',
+            ],
+            'max' => [
+                'to be parsed' => 'max(300px, %s);',
+                'expected' => 'max(300px,%s)',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideCssFunctionTemplates
+     */
+    public function parsesArithmeticWithMultipleOperatorsInFunctions(
+        string $parserTemplate,
+        string $expectedResultTemplate
+    ): void {
+        static $expression = '300px + 10% + 10vw';
+
+        $subject = Value::parseValue(new ParserState(\sprintf($parserTemplate, $expression), Settings::create()));
+
+        self::assertSame(\sprintf($expectedResultTemplate, $expression), (string) $subject);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function provideMalformedLengthOperands(): array
+    {
+        return [
+            'LHS missing number' => ['vh', '10px'],
+            'RHS missing number' => ['50vh', 'px'],
+            'LHS missing unit' => ['50', '10px'],
+            'RHS missing unit' => ['50vh', '10'],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideMalformedLengthOperands
+     */
+    public function parsesArithmeticWithMalformedOperandsInFunctions(string $leftOperand, string $rightOperand): void
+    {
+        $subject = Value::parseValue(new ParserState(
+            'max(300px, ' . $leftOperand . ' + ' . $rightOperand . ');',
+            Settings::create()
+        ));
+
+        self::assertSame('max(300px,' . $leftOperand . ' + ' . $rightOperand . ')', (string) $subject);
+    }
+}

--- a/tests/Value/ValueTest.php
+++ b/tests/Value/ValueTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Sabberworm\CSS\Tests\Value;
 
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
This is the enhancement from #390.

`calc` was already supported.