### PR TITLE
[FEATURE] Add support for the `dvh`, `lvh` and `svh` length units (#415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Add support for the `dvh`, `lvh` and `svh` length units (#415)
+
 ### Changed
 
 ### Deprecated

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -19,7 +19,12 @@ class Size extends PrimitiveValue
      *
      * @internal
      */
-    const ABSOLUTE_SIZE_UNITS = ['px', 'cm', 'mm', 'mozmm', 'in', 'pt', 'pc', 'vh', 'vw', 'vmin', 'vmax', 'rem'];
+    const ABSOLUTE_SIZE_UNITS = [
+        'px', 'pt', 'pc',
+        'cm', 'mm', 'mozmm', 'in',
+        'vh', 'dvh', 'svh', 'lvh',
+        'vw', 'vmin', 'vmax', 'rem',
+    ];
 
     /**
      * @var array<int, string>

--- a/tests/Value/SizeTest.php
+++ b/tests/Value/SizeTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Sabberworm\CSS\Tests\Value;
+
+use PHPUnit\Framework\TestCase;
+use Sabberworm\CSS\Parsing\ParserState;
+use Sabberworm\CSS\Settings;
+use Sabberworm\CSS\Value\Size;
+
+/**
+ * @covers \Sabberworm\CSS\Value\Size
+ */
+final class SizeTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function provideUnit(): array
+    {
+        $units = [
+            'px', 'pt', 'pc',
+            'cm', 'mm', 'mozmm', 'in',
+            'vh', 'dvh', 'svh', 'lvh',
+            'vw', 'vmin', 'vmax', 'rem',
+            '%', 'em', 'ex', 'ch', 'fr',
+            'deg', 'grad', 'rad', 's', 'ms', 'turn', 'Hz', 'kHz',
+        ];
+
+        return \array_combine(
+            $units,
+            \array_map(
+                function (string $unit): array {
+                    return [$unit];
+                },
+                $units
+            )
+        );
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideUnit
+     */
+    public function parsesUnit(string $unit): void
+    {
+        $subject = Size::parse(new ParserState('1' . $unit, Settings::create()));
+
+        self::assertSame($unit, $subject->getUnit());
+    }
+}

--- a/tests/Value/SizeTest.php
+++ b/tests/Value/SizeTest.php
@@ -15,7 +15,7 @@ final class SizeTest extends TestCase
     /**
      * @return array<string, array{0: string}>
      */
-    public static function provideUnit(): array
+    public static function provideUnit()
     {
         $units = [
             'px', 'pt', 'pc',
@@ -29,7 +29,7 @@ final class SizeTest extends TestCase
         return \array_combine(
             $units,
             \array_map(
-                function (string $unit): array {
+                function ($unit) {
                     return [$unit];
                 },
                 $units
@@ -42,7 +42,7 @@ final class SizeTest extends TestCase
      *
      * @dataProvider provideUnit
      */
-    public function parsesUnit(string $unit): void
+    public function parsesUnit($unit)
     {
         $subject = Size::parse(new ParserState('1' . $unit, Settings::create()));
 


### PR DESCRIPTION
Fixes #412

For now, the `TestCase` just tests that all the unit values are parsed. (Other tests can be added here, but are beyond the scope of this change.)