### PR TITLE
[TASK] Drop surplus empty lines from PHPDoc

### DIFF
--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -100,7 +100,6 @@ class Document extends CSSBlockList
      *
      * @return array<int, Selector>
      * @example `getSelectorsBySpecificity('>= 100')`
-     *
      */
     public function getSelectorsBySpecificity($sSpecificitySearch = null)
     {

--- a/src/OutputFormatter.php
+++ b/src/OutputFormatter.php
@@ -86,7 +86,6 @@ class OutputFormatter
 
     /**
      * @param string $sSeparator
-     *
      */
     public function spaceBeforeListArgumentSeparator($sSeparator): string
     {
@@ -95,7 +94,6 @@ class OutputFormatter
 
     /**
      * @param string $sSeparator
-     *
      */
     public function spaceAfterListArgumentSeparator($sSeparator): string
     {
@@ -180,7 +178,6 @@ class OutputFormatter
     }
 
     /**
-     *
      * @param array<Commentable> $aComments
      *
      * @return string


### PR DESCRIPTION
This was done using the `phpdoc_trim` PHP-CS-Fixer rule.