### PR TITLE
[CLEANUP] Sort the types in union type PHPDoc annotations

### DIFF
--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -97,7 +97,7 @@ abstract class CSSList implements Renderable, Commentable
     }
 
     /**
-     * @return AtRuleBlockList|KeyFrame|Charset|CSSNamespace|Import|AtRuleSet|DeclarationBlock|null|false
+     * @return AtRuleBlockList|KeyFrame|Charset|CSSNamespace|Import|AtRuleSet|DeclarationBlock|false|null
      *
      * @throws SourceException
      * @throws UnexpectedEOFException


### PR DESCRIPTION
This was done using the `phpdoc_types_order` PHP-CS-Fixer rule.