### PR TITLE
[CLEANUP] Always escape backslashes in strings

### DIFF
--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -144,7 +144,7 @@ class ParserState
         }
         $sCharacter = null;
         while (!$this->isEnd() && ($sCharacter = $this->parseCharacter(true)) !== null) {
-            if (\preg_match('/[a-zA-Z0-9\x{00A0}-\x{FFFF}_-]/Sux', $sCharacter)) {
+            if (\preg_match('/[a-zA-Z0-9\\x{00A0}-\\x{FFFF}_-]/Sux', $sCharacter)) {
                 $sResult .= $sCharacter;
             } else {
                 $sResult .= '\\' . $sCharacter;
@@ -169,13 +169,13 @@ class ParserState
         if ($this->peek() === '\\') {
             if (
                 $bIsForIdentifier && $this->oParserSettings->bLenientParsing
-                && ($this->comes('\0') || $this->comes('\9'))
+                && ($this->comes('\\0') || $this->comes('\\9'))
             ) {
                 // Non-strings can contain \0 or \9 which is an IE hack supported in lenient parsing.
                 return null;
             }
             $this->consume('\\');
-            if ($this->comes('\n') || $this->comes('\r')) {
+            if ($this->comes('\\n') || $this->comes('\\r')) {
                 return '';
             }
             if (\preg_match('/[0-9a-fA-F]/Su', $this->peek()) === 0) {
@@ -185,7 +185,7 @@ class ParserState
             if ($this->strlen($sUnicode) < 6) {
                 // Consume whitespace after incomplete unicode escape
                 if (\preg_match('/\\s/isSu', $this->peek())) {
-                    if ($this->comes('\r\n')) {
+                    if ($this->comes('\\r\\n')) {
                         $this->consume(2);
                     } else {
                         $this->consume(1);

--- a/src/Property/KeyframeSelector.php
+++ b/src/Property/KeyframeSelector.php
@@ -14,12 +14,12 @@ class KeyframeSelector extends Selector
     public const SELECTOR_VALIDATION_RX = '/
     ^(
         (?:
-            [a-zA-Z0-9\x{00A0}-\x{FFFF}_^$|*="\'~\[\]()\-\s\.:#+>]* # any sequence of valid unescaped characters
-            (?:\\\\.)?                                              # a single escaped character
-            (?:([\'"]).*?(?<!\\\\)\2)?                              # a quoted text like [id="example"]
+            [a-zA-Z0-9\\x{00A0}-\\x{FFFF}_^$|*="\'~\\[\\]()\\-\\s\\.:#+>]* # any sequence of valid unescaped characters
+            (?:\\\\.)?                                                     # a single escaped character
+            (?:([\'"]).*?(?<!\\\\)\\2)?                                    # a quoted text like [id="example"]
         )*
     )|
-    (\d+%)                                                          # keyframe animation progress percentage (e.g. 50%)
+    (\\d+%)                                                          # keyframe animation progress percentage (e.g. 50%)
     $
     /ux';
 }

--- a/src/Property/KeyframeSelector.php
+++ b/src/Property/KeyframeSelector.php
@@ -19,7 +19,7 @@ class KeyframeSelector extends Selector
             (?:([\'"]).*?(?<!\\\\)\\2)?                                    # a quoted text like [id="example"]
         )*
     )|
-    (\\d+%)                                                          # keyframe animation progress percentage (e.g. 50%)
+    (\\d+%)                                                                # keyframe animation progress percentage (e.g. 50%)
     $
     /ux';
 }

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -14,11 +14,11 @@ class Selector
      * @var string
      */
     private const NON_ID_ATTRIBUTES_AND_PSEUDO_CLASSES_RX = '/
-        (\.[\w]+)                   # classes
+        (\\.[\\w]+)                   # classes
         |
-        \[(\w+)                     # attributes
+        \\[(\\w+)                     # attributes
         |
-        (\:(                        # pseudo classes
+        (\\:(                        # pseudo classes
             link|visited|active
             |hover|focus
             |lang
@@ -38,9 +38,9 @@ class Selector
      * @var string
      */
     private const ELEMENTS_AND_PSEUDO_ELEMENTS_RX = '/
-        ((^|[\s\+\>\~]+)[\w]+   # elements
+        ((^|[\\s\\+\\>\\~]+)[\\w]+   # elements
         |
-        \:{1,2}(                # pseudo-elements
+        \\:{1,2}(                # pseudo-elements
             after|before|first-letter|first-line|selection
         ))
         /ix';
@@ -55,9 +55,9 @@ class Selector
     public const SELECTOR_VALIDATION_RX = '/
         ^(
             (?:
-                [a-zA-Z0-9\x{00A0}-\x{FFFF}_^$|*="\'~\[\]()\-\s\.:#+>]* # any sequence of valid unescaped characters
-                (?:\\\\.)?                                              # a single escaped character
-                (?:([\'"]).*?(?<!\\\\)\2)?                              # a quoted text like [id="example"]
+                [a-zA-Z0-9\\x{00A0}-\\x{FFFF}_^$|*="\'~\\[\\]()\\-\\s\\.:#+>]* # any sequence of valid unescaped characters
+                (?:\\\\.)?                                                     # a single escaped character
+                (?:([\'"]).*?(?<!\\\\)\\2)?                                    # a quoted text like [id="example"]
             )*
         )$
         /ux';

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -18,7 +18,7 @@ class Selector
         |
         \\[(\\w+)                     # attributes
         |
-        (\\:(                        # pseudo classes
+        (\\:(                         # pseudo classes
             link|visited|active
             |hover|focus
             |lang
@@ -40,7 +40,7 @@ class Selector
     private const ELEMENTS_AND_PSEUDO_ELEMENTS_RX = '/
         ((^|[\\s\\+\\>\\~]+)[\\w]+   # elements
         |
-        \\:{1,2}(                # pseudo-elements
+        \\:{1,2}(                    # pseudo-elements
             after|before|first-letter|first-line|selection
         ))
         /ix';

--- a/src/Value/CSSString.php
+++ b/src/Value/CSSString.php
@@ -94,7 +94,7 @@ class CSSString extends PrimitiveValue
     public function render(OutputFormat $oOutputFormat): string
     {
         $sString = \addslashes($this->sString);
-        $sString = \str_replace("\n", '\A', $sString);
+        $sString = \str_replace("\n", '\\A', $sString);
         return $oOutputFormat->getStringQuotingType() . $sString . $oOutputFormat->getStringQuotingType();
     }
 }

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -203,9 +203,9 @@ class Size extends PrimitiveValue
     {
         $l = \localeconv();
         $sPoint = \preg_quote($l['decimal_point'], '/');
-        $sSize = \preg_match("/[\d\.]+e[+-]?\d+/i", (string) $this->fSize)
+        $sSize = \preg_match("/[\\d\\.]+e[+-]?\\d+/i", (string) $this->fSize)
             ? \preg_replace("/$sPoint?0+$/", "", \sprintf("%f", $this->fSize)) : $this->fSize;
-        return \preg_replace(["/$sPoint/", "/^(-?)0\./"], ['.', '$1.'], $sSize)
+        return \preg_replace(["/$sPoint/", "/^(-?)0\\./"], ['.', '$1.'], $sSize)
             . ($this->sUnit ?? '');
     }
 }

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -203,7 +203,7 @@ abstract class Value implements Renderable
                 $iCodepointMaxLength = 13; // Max length is 2 six digit code points + the dash(-) between them
             }
             $sRange .= $oParserState->consume(1);
-        } while (\strlen($sRange) < $iCodepointMaxLength && \preg_match("/[A-Fa-f0-9\?-]/", $oParserState->peek()));
+        } while (\strlen($sRange) < $iCodepointMaxLength && \preg_match("/[A-Fa-f0-9\\?-]/", $oParserState->peek()));
         return "U+{$sRange}";
     }
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -202,13 +202,13 @@ final class ParserTest extends TestCase
                 self::assertSame('"¥"', $sString);
             }
             if ($sSelector == '.test-7') {
-                self::assertSame('"\A"', $sString);
+                self::assertSame('"\\A"', $sString);
             }
             if ($sSelector == '.test-8') {
-                self::assertSame('"\"\""', $sString);
+                self::assertSame('"\\"\\""', $sString);
             }
             if ($sSelector == '.test-9') {
-                self::assertSame('"\"\\\'"', $sString);
+                self::assertSame('"\\"\\\'"', $sString);
             }
             if ($sSelector == '.test-10') {
                 self::assertSame('"\\\'\\\\"', $sString);
@@ -795,8 +795,8 @@ body {background-color: red;}';
     public function selectorEscapesInFile(): void
     {
         $oDoc = self::parsedStructureForFile('selector-escapes', Settings::create()->withMultibyteSupport(true));
-        $sExpected = '#\# {color: red;}
-.col-sm-1\/5 {width: 20%;}';
+        $sExpected = '#\\# {color: red;}
+.col-sm-1\\/5 {width: 20%;}';
         self::assertSame($sExpected, $oDoc->render());
 
         $oDoc = self::parsedStructureForFile('invalid-selectors-2', Settings::create()->withMultibyteSupport(true));
@@ -815,8 +815,8 @@ body {background-color: red;}';
     public function identifierEscapesInFile(): void
     {
         $oDoc = self::parsedStructureForFile('identifier-escapes', Settings::create()->withMultibyteSupport(true));
-        $sExpected = 'div {font: 14px Font Awesome\ 5 Pro;font: 14px Font Awesome\} 5 Pro;'
-            . 'font: 14px Font Awesome\; 5 Pro;f\;ont: 14px Font Awesome\; 5 Pro;}';
+        $sExpected = 'div {font: 14px Font Awesome\\ 5 Pro;font: 14px Font Awesome\\} 5 Pro;'
+            . 'font: 14px Font Awesome\\; 5 Pro;f\\;ont: 14px Font Awesome\\; 5 Pro;}';
         self::assertSame($sExpected, $oDoc->render());
     }
 
@@ -1103,8 +1103,8 @@ body {background-color: red;}';
     public function ieHacksParsing(): void
     {
         $oDoc = self::parsedStructureForFile('ie-hacks', Settings::create()->withLenientParsing(true));
-        $sExpected = 'p {padding-right: .75rem \9;background-image: none \9;color: red \9\0;'
-            . 'background-color: red \9\0;background-color: red \9\0 !important;content: "red 	\0";content: "red઼";}';
+        $sExpected = 'p {padding-right: .75rem \\9;background-image: none \\9;color: red \\9\\0;'
+            . 'background-color: red \\9\\0;background-color: red \\9\\0 !important;content: "red 	\\0";content: "red઼";}';
         self::assertSame($sExpected, $oDoc->render());
     }
 
@@ -1246,7 +1246,7 @@ body {background-color: red;}';
         $rules = $contents[0]->getRules();
         $urlRule = $rules[0];
         $calcRule = $rules[1];
-        self::assertTrue(\is_a($urlRule->getValue(), '\Sabberworm\CSS\Value\URL'));
-        self::assertTrue(\is_a($calcRule->getValue(), '\Sabberworm\CSS\Value\CalcFunction'));
+        self::assertTrue(\is_a($urlRule->getValue(), '\\Sabberworm\\CSS\\Value\\URL'));
+        self::assertTrue(\is_a($calcRule->getValue(), '\\Sabberworm\\CSS\\Value\\CalcFunction'));
     }
 }


### PR DESCRIPTION
This was done using the `string_implicit_backslashes` PHP-CS-Fixer rule.