### PR TITLE
[TASK] Ensure PHP 8.4 compatibility for nullable parameters

### DIFF
--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -41,6 +41,10 @@ return (new \PhpCsFixer\Config())
 
             // function notation
             'native_function_invocation' => ['include' => ['@all']],
+            'nullable_type_declaration' => [
+                'syntax' => 'question_mark',
+            ],
+            'nullable_type_declaration_for_default_null_value' => true,
 
             // import
             'no_unused_imports' => true,

--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -138,7 +138,7 @@ class Document extends CSSBlockList
      *
      * @param OutputFormat|null $oOutputFormat
      */
-    public function render(OutputFormat $oOutputFormat = null): string
+    public function render(?OutputFormat $oOutputFormat = null): string
     {
         if ($oOutputFormat === null) {
             $oOutputFormat = new OutputFormat();

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -21,7 +21,7 @@ class Parser
      * @param Settings|null $oParserSettings
      * @param int $iLineNo the line number (starting from 1, not from 0)
      */
-    public function __construct($sText, Settings $oParserSettings = null, $iLineNo = 1)
+    public function __construct($sText, ?Settings $oParserSettings = null, $iLineNo = 1)
     {
         if ($oParserSettings === null) {
             $oParserSettings = Settings::create();

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -98,7 +98,7 @@ abstract class RuleSet implements Renderable, Commentable
     /**
      * @param Rule|null $oSibling
      */
-    public function addRule(Rule $oRule, Rule $oSibling = null): void
+    public function addRule(Rule $oRule, ?Rule $oSibling = null): void
     {
         $sRule = $oRule->getRule();
         if (!isset($this->aRules[$sRule])) {


### PR DESCRIPTION
Ensure that parameters that have a `null` default value also have `null` as part of their type declarations.

Also ensure a uniform notation for nullable types.

https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

Fixes #634