### PR TITLE
[CLEANUP] Move the `nullable_type_declaration` rule

### DIFF
--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -41,9 +41,6 @@ return (new \PhpCsFixer\Config())
 
             // function notation
             'native_function_invocation' => ['include' => ['@all']],
-            'nullable_type_declaration' => [
-                'syntax' => 'question_mark',
-            ],
             'nullable_type_declaration_for_default_null_value' => true,
 
             // import
@@ -54,6 +51,7 @@ return (new \PhpCsFixer\Config())
             'combine_consecutive_unsets' => true,
             'dir_constant' => true,
             'is_null' => true,
+            'nullable_type_declaration' => true,
 
             // namespace notation
             'no_leading_namespace_whitespace' => true,


### PR DESCRIPTION
It is now listed in the correct section.

Also, as we're using the default configuration for this rule, we can use `true` for this instead of duplicating the default configuration.