### PR TITLE
Escaped quotes parsing

### DIFF
--- a/src/Value/CSSString.php
+++ b/src/Value/CSSString.php
@@ -15,6 +15,8 @@ use Sabberworm\CSS\Parsing\UnexpectedTokenException;
  */
 class CSSString extends PrimitiveValue
 {
+    const PARSE_QUOTE_STRINGS = ['"', "'", '\"', "\'"];
+
     /**
      * @var string
      */
@@ -40,11 +42,12 @@ class CSSString extends PrimitiveValue
     public static function parse(ParserState $oParserState)
     {
         $sBegin = $oParserState->peek();
+        if ($sBegin === '\\') {
+            $sBegin = $oParserState->peek(2);
+        }
         $sQuote = null;
-        if ($sBegin === "'") {
-            $sQuote = "'";
-        } elseif ($sBegin === '"') {
-            $sQuote = '"';
+        if (in_array($sBegin, self::PARSE_QUOTE_STRINGS)) {
+            $sQuote = $sBegin;
         }
         if ($sQuote !== null) {
             $oParserState->consume($sQuote);

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -14,6 +14,9 @@ use Sabberworm\CSS\Renderable;
  */
 abstract class Value implements Renderable
 {
+    const PARSE_TERMINATE_STRINGS = ['}',';','!',')', '\\'];
+    const PARSE_QUOTE_STRINGS = ['"', "'", '\"', "\'"];
+
     /**
      * @var int
      */
@@ -41,12 +44,7 @@ abstract class Value implements Renderable
         $aStack = [];
         $oParserState->consumeWhiteSpace();
         //Build a list of delimiters and parsed values
-        while (
-            !($oParserState->comes('}') || $oParserState->comes(';') || $oParserState->comes('!')
-                || $oParserState->comes(')')
-                || $oParserState->comes('\\')
-                || $oParserState->isEnd())
-        ) {
+        while (self::continueParsing($oParserState)) {
             if (count($aStack) > 0) {
                 $bFoundDelimiter = false;
                 foreach ($aListDelimiters as $sDelimiter) {
@@ -154,7 +152,10 @@ abstract class Value implements Renderable
             $oValue = Size::parse($oParserState);
         } elseif ($oParserState->comes('#') || $oParserState->comes('rgb', true) || $oParserState->comes('hsl', true)) {
             $oValue = Color::parse($oParserState);
-        } elseif ($oParserState->comes("'") || $oParserState->comes('"')) {
+        } elseif (
+            in_array($oParserState->peek(), self::PARSE_QUOTE_STRINGS) 
+            || in_array($oParserState->peek(2), self::PARSE_QUOTE_STRINGS)
+        ) {
             $oValue = CSSString::parse($oParserState);
         } elseif ($oParserState->comes("progid:") && $oParserState->getSettings()->bLenientParsing) {
             $oValue = self::parseMicrosoftFilter($oParserState);
@@ -208,5 +209,23 @@ abstract class Value implements Renderable
     public function getLineNo()
     {
         return $this->iLineNo;
+    }
+
+    /**
+     * @return bool
+     *
+     * @throws UnexpectedEOFException
+     * @throws UnexpectedTokenException
+     */
+    private static function continueParsing(ParserState $oParserState)
+    {
+        if ($oParserState->isEnd()) {
+            return false;
+        }
+        $sPeekOne = $oParserState->peek();
+        if ($sPeekOne === '\\') {
+            return in_array($oParserState->peek(2), self::PARSE_QUOTE_STRINGS);
+        }
+        return !in_array($sPeekOne, self::PARSE_TERMINATE_STRINGS);
     }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1242,6 +1242,37 @@ body {background-color: red;}';
         self::assertSame($sExpected, $oDoc->render());
     }
 
+    /**
+     * @test
+     */
+    public function parseForEscapedQuotes()
+    {
+        $preParseCss = sprintf(
+            "%s%s%s%s%s%s%s",
+            '.fonts-first {font-family: Roboto, "Fira Mono", \"Liberation Serif\";}',
+            PHP_EOL,
+            ".font-second {font-family: Roboto, 'Fira Mono', \'Liberation Serif\';}",
+            PHP_EOL,
+            '.bgpic-first {background-image: url(\"pic.webp\");}',
+            PHP_EOL,
+            ".bgpic-second {background-image: url(\'pic.webp\');}"
+        );
+        $expectedCss = sprintf(
+            "%s%s%s%s%s%s%s",
+            '.fonts-first {font-family: Roboto,"Fira Mono","Liberation Serif";}',
+            PHP_EOL,
+            '.font-second {font-family: Roboto,"Fira Mono","Liberation Serif";}',
+            PHP_EOL,
+            '.bgpic-first {background-image: url("pic.webp");}',
+            PHP_EOL,
+            '.bgpic-second {background-image: url("pic.webp");}'
+        );
+        $parser = new Parser($preParseCss);
+        $document = $parser->parse();
+        $postParseCss = $document->render();
+        self::assertEquals($expectedCss, $postParseCss);
+    }
+
     public function escapedSpecialCaseTokens()
     {
         $oDoc = $this->parsedStructureForFile('escaped-tokens');


### PR DESCRIPTION
Often times font definitions include escaped quotes. Currently these are not parsed correctly. This PR resolves this.