### PR TITLE
[TASK] Switch our code coverage CI from Codacy to Coveralls

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -15,8 +15,12 @@ jobs:
         runs-on: ubuntu-22.04
 
         strategy:
+            fail-fast: false
             matrix:
-                php-version: [ '7.4' ]
+                php-version:
+                    - '7.4'
+                dependencies:
+                    - highest
 
         steps:
             - name: Checkout
@@ -30,6 +34,9 @@ jobs:
                   tools: composer:v2
                   coverage: xdebug
 
+            - name: Show the Composer version
+              run: composer --version
+
             - name: Show the Composer configuration
               run: composer config --global --list
 
@@ -37,21 +44,29 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: ~/.cache/composer
-                  key: php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}
+                  key: php${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-${{ hashFiles('**/composer.json') }}
                   restore-keys: |
-                      php${{ matrix.php-version }}-composer-
+                      php${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-
 
             - name: Install Composer dependencies
               run: |
-                  composer update --with-dependencies --no-progress;
+                  if [[ "${{ matrix.dependencies }}" == 'lowest' ]]; then
+                    DEPENDENCIES='--prefer-lowest';
+                  else
+                    DEPENDENCIES='';
+                  fi;
+                  composer install --no-progress;
+                  composer update --with-dependencies --no-progress "${DEPENDENCIES}";
                   composer show;
 
             - name: Run Tests
-              run: ./vendor/bin/phpunit --coverage-clover build/coverage/xml
+              run: composer ci:tests:coverage
 
-            - name: Upload coverage results to Codacy
+            - name: Show generated coverage files
+              run: ls -lah
+
+            - name: Upload coverage results to Coveralls
+              uses: coverallsapp/github-action@v2
               env:
-                  CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-              if: "${{ env.CODACY_PROJECT_TOKEN != '' }}"
-              run: |
-                  ./vendor/bin/codacycoverage clover build/coverage/xml
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  file: coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.php_cs.cache
 /.phpunit.result.cache
 /composer.lock
+/coverage.xml
 /phpstan.neon
 /vendor/
 !/.phive/phars.xml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # PHP CSS Parser
 
 [![Build Status](https://github.com/MyIntervals/PHP-CSS-Parser/workflows/CI/badge.svg?branch=main)](https://github.com/MyIntervals/PHP-CSS-Parser/actions/)
+[![Coverage Status](https://coveralls.io/repos/github/MyIntervals/PHP-CSS-Parser/badge.svg?branch=main)](https://coveralls.io/github/MyIntervals/PHP-CSS-Parser?branch=main)
 
 A Parser for CSS Files written in PHP. Allows extraction of CSS files into a data structure, manipulation of said structure and output as (optimized) CSS.
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "ext-iconv": "*"
     },
     "require-dev": {
-        "codacy/coverage": "^1.4.3",
         "php-parallel-lint/php-parallel-lint": "^1.4.0",
         "phpstan/extension-installer": "^1.4.2",
         "phpstan/phpstan": "^1.11.11",
@@ -83,6 +82,7 @@
         "ci:tests": [
             "@ci:tests:unit"
         ],
+        "ci:tests:coverage": "phpunit --do-not-cache-result --coverage-clover=coverage.xml",
         "ci:tests:sof": "phpunit --stop-on-failure --do-not-cache-result",
         "ci:tests:unit": "phpunit --do-not-cache-result",
         "fix:php": [
@@ -102,6 +102,7 @@
         "ci:php:rector": "Checks the code for possible code updates and refactoring.",
         "ci:static": "Runs all static code analysis checks for the code.",
         "ci:tests": "Runs all dynamic tests (i.e., currently, the unit tests).",
+        "ci:tests:coverage": "Runs the unit tests with code coverage.",
         "ci:tests:sof": "Runs the unit tests and stops at the first failure.",
         "ci:tests:unit": "Runs all unit tests.",
         "fix:php": "Autofixes all autofixable issues in the PHP code.",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,7 +2,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
     beStrictAboutChangesToGlobalState="true"
-    beStrictAboutCoversAnnotation="true"
     cacheResult="false"
     colors="true"
     forceCoversAnnotation="true"


### PR DESCRIPTION
Coveralls does not require an API key, provides a nice GitHub Action, and it can post code coverage comments to PRs.

Also add a code coverage badge to the README.

Also align the GitHub Action workflow with that of our sister project Emogrifier.

Also add a Composer script for running the tests with coverage.

Fixes #535
Fixes #299