### PR TITLE
[BUGFIX] Do not try to cover an interface in tests

### DIFF
--- a/tests/Comment/CommentTest.php
+++ b/tests/Comment/CommentTest.php
@@ -10,7 +10,6 @@ use Sabberworm\CSS\Tests\ParserTest as TestsParserTest;
 
 /**
  * @covers \Sabberworm\CSS\Comment\Comment
- * @covers \Sabberworm\CSS\Comment\Commentable
  * @covers \Sabberworm\CSS\OutputFormat
  * @covers \Sabberworm\CSS\OutputFormatter
  */


### PR DESCRIPTION
Only classes and traits can be covered by code coverage. Trying to cover an interface causes PHPUnit to issue a warning.