### PR TITLE
[BUGFIX]  Fix comment parsing to support multiple comments

### DIFF
--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -220,17 +220,25 @@ class ParserState
     }
 
     /**
-     * @return array<int, Comment>|void
+     * Consumes whitespace and comments and returns the comments.
+     * If $withoutComment is true, only whitespace is consumed.
+     *
+     * @param bool $withoutComment Do not consume comments, only whitespace.
+     *
+     * @return array<int, Comment>|void List of comments.
      *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    public function consumeWhiteSpace(): array
+    public function consumeWhiteSpace(bool $withoutComment = false): array
     {
         $aComments = [];
         do {
             while (\preg_match('/\\s/isSu', $this->peek()) === 1) {
                 $this->consume(1);
+            }
+            if ($withoutComment) {
+                break;
             }
             if ($this->oParserSettings->bLenientParsing) {
                 try {

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -105,7 +105,7 @@ class Rule implements Renderable, Commentable
         while ($oParserState->comes(';')) {
             $oParserState->consume(';');
         }
-        $oParserState->consumeWhiteSpace();
+        $oParserState->consumeWhiteSpace(true);
 
         return $oRule;
     }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1161,13 +1161,16 @@ body {background-color: red;}';
      */
     public function flatCommentExtracting(): void
     {
-        $parser = new Parser('div {/*Find Me!*/left:10px; text-align:left;}');
+        $parser = new Parser('div {/*Find Me!*/left:10px; /*Find Me Too!*/text-align:left;}');
         $doc = $parser->parse();
         $contents = $doc->getContents();
         $divRules = $contents[0]->getRules();
-        $comments = $divRules[0]->getComments();
-        self::assertCount(1, $comments);
-        self::assertSame('Find Me!', $comments[0]->getComment());
+        $rule1Comments = $divRules[0]->getComments();
+        $rule2Comments = $divRules[1]->getComments();
+        self::assertCount(1, $rule1Comments);
+        self::assertCount(1, $rule2Comments);
+        self::assertEquals('Find Me!', $rule1Comments[0]->getComment());
+        self::assertEquals('Find Me Too!', $rule2Comments[0]->getComment());
     }
 
     /**


### PR DESCRIPTION
Because of an eager consumption of whitespace, the rule parsing would swallow a trailing comment, meaning the comment for the next rule would be affected. This patch addresses this by only consuming real whitespace without comments after a rule.

Fixes #173