### PR TITLE
[FEATURE] Add consumeWhitespaceWithComments and redirect consumeWhitespace (backported)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Add `ParserState::consumeWhiteSpaceWithComments()` method (#670)
+
 ### Changed
+
+- Redirect `ParserState::consumeWhiteSpace()` to `ParserState::consumeWhiteSpaceWithComments()` (#670)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
+- Deprecate `ParserState::consumeWhiteSpace()` in favor of `ParserState::consumeWhiteSpaceWithComments()` (#670)
+
 ### Removed
 
 ### Fixed

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -226,12 +226,27 @@ class ParserState
     }
 
     /**
-     * @return array<int, Comment>|void
+     * Consumes whitespace and comments and returns a list of comments.
+     *
+     * @return list<Comment> List of comments.
      *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
     public function consumeWhiteSpace()
+    {
+        return $this->consumeWhiteSpaceWithComments();
+    }
+
+    /**
+     * Consumes whitespace and comments and returns a list of comments.
+     *
+     * @return list<Comment> List of comments.
+     *
+     * @throws UnexpectedEOFException
+     * @throws UnexpectedTokenException
+     */
+    public function consumeWhiteSpaceWithComments()
     {
         $aComments = [];
         do {

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -232,6 +232,14 @@ class ParserState
      *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @deprecated From version 9.0.0 onwards this method will be undergo a breaking
+     *      change. This method will no longer consume comments, only whitespace.
+     *      Use `ParserState::consumeWhiteSpaceWithComments` as a replacement if you
+     *      need the former behaviour of consuming whitespace and comments.
+     *
+     * @see `ParserState::consumeWhiteSpaceWithComments` for a version that also
+     *      returns comments.
      */
     public function consumeWhiteSpace()
     {


### PR DESCRIPTION
Having `consumeWhitespace` also consumes comments, and returning them was unexpected. This also "deprecates" the consumeWhitespace method and announces a breaking change for 9.0.0.