### PR TITLE
[BUGFIX] Fix comment parsing to support multiple comments (backported)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Fix comment parsing to support multiple comments (#671)
+
 ## 8.6.0
 
 ### Added

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -107,7 +107,12 @@ class Rule implements Renderable, Commentable
         while ($oParserState->comes(';')) {
             $oParserState->consume(';');
         }
-        $oParserState->consumeWhiteSpace();
+
+        // NOTE: This is a backport to fix comment parsing to support multiple
+        // comments. This will be rectified in version 9.0.0.
+        while (preg_match('/\\s/isSu', $oParserState->peek()) === 1) {
+            $oParserState->consume(1);
+        }
 
         return $oRule;
     }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1162,7 +1162,7 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function flatCommentExtracting()
+    public function flatCommentExtractingOneComment()
     {
         $parser = new Parser('div {/*Find Me!*/left:10px; text-align:left;}');
         $doc = $parser->parse();
@@ -1171,6 +1171,22 @@ body {background-color: red;}';
         $comments = $divRules[0]->getComments();
         self::assertCount(1, $comments);
         self::assertSame("Find Me!", $comments[0]->getComment());
+    }
+    /**
+     * @test
+     */
+    public function flatCommentExtractingTwoComments()
+    {
+        $parser = new Parser('div {/*Find Me!*/left:10px; /*Find Me Too!*/text-align:left;}');
+        $doc = $parser->parse();
+        $contents = $doc->getContents();
+        $divRules = $contents[0]->getRules();
+        $rule1Comments = $divRules[0]->getComments();
+        $rule2Comments = $divRules[1]->getComments();
+        self::assertCount(1, $rule1Comments);
+        self::assertCount(1, $rule2Comments);
+        self::assertEquals('Find Me!', $rule1Comments[0]->getComment());
+        self::assertEquals('Find Me Too!', $rule2Comments[0]->getComment());
     }
 
     /**


### PR DESCRIPTION
Because of an eager consumption of whitespace, the rule parsing would swallow a trailing comment, meaning the comment for the next rule would be affected. This patch addresses this by only consuming real whitespace without comments after a rule.

Fixes #173