### PR TITLE
[TASK] Also allow higher versions of PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ext-iconv": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.27"
+        "phpunit/phpunit": "^5.7.27 || ^8.5.39"
     },
     "suggest": {
         "ext-mbstring": "for parsing UTF-8 CSS"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ext-iconv": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.27 || ^8.5.39"
+        "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.39"
     },
     "suggest": {
         "ext-mbstring": "for parsing UTF-8 CSS"


### PR DESCRIPTION
This hopefully will allow us to run the unit tests for all PHP version that we claim to support, i.e., from 5.6.x to currently 8.4.x.