### PR TITLE
[BUGFIX] Avoid using `setUp()` in testcases

### DIFF
--- a/tests/CSSList/DocumentTest.php
+++ b/tests/CSSList/DocumentTest.php
@@ -18,7 +18,7 @@ final class DocumentTest extends TestCase
      */
     private $subject;
 
-    protected function setUp()
+    private function setUpTestcase()
     {
         $this->subject = new Document();
     }
@@ -28,6 +28,8 @@ final class DocumentTest extends TestCase
      */
     public function implementsRenderable()
     {
+        $this->setUpTestcase();
+
         self::assertInstanceOf(Renderable::class, $this->subject);
     }
 
@@ -36,6 +38,8 @@ final class DocumentTest extends TestCase
      */
     public function implementsCommentable()
     {
+        $this->setUpTestcase();
+
         self::assertInstanceOf(Commentable::class, $this->subject);
     }
 
@@ -44,6 +48,8 @@ final class DocumentTest extends TestCase
      */
     public function getContentsInitiallyReturnsEmptyArray()
     {
+        $this->setUpTestcase();
+
         self::assertSame([], $this->subject->getContents());
     }
 
@@ -68,6 +74,8 @@ final class DocumentTest extends TestCase
      */
     public function setContentsSetsContents(array $contents)
     {
+        $this->setUpTestcase();
+
         $this->subject->setContents($contents);
 
         self::assertSame($contents, $this->subject->getContents());
@@ -78,6 +86,8 @@ final class DocumentTest extends TestCase
      */
     public function setContentsReplacesContentsSetInPreviousCall()
     {
+        $this->setUpTestcase();
+
         $contents2 = [new DeclarationBlock()];
 
         $this->subject->setContents([new DeclarationBlock()]);
@@ -91,6 +101,8 @@ final class DocumentTest extends TestCase
      */
     public function insertContentBeforeInsertsContentBeforeSibbling()
     {
+        $this->setUpTestcase();
+
         $bogusOne = new DeclarationBlock();
         $bogusOne->setSelectors('.bogus-one');
         $bogusTwo = new DeclarationBlock();
@@ -117,6 +129,8 @@ final class DocumentTest extends TestCase
      */
     public function insertContentBeforeAppendsIfSibblingNotFound()
     {
+        $this->setUpTestcase();
+
         $bogusOne = new DeclarationBlock();
         $bogusOne->setSelectors('.bogus-one');
         $bogusTwo = new DeclarationBlock();

--- a/tests/CSSList/KeyFrameTest.php
+++ b/tests/CSSList/KeyFrameTest.php
@@ -18,7 +18,7 @@ final class KeyFrameTest extends TestCase
      */
     protected $subject;
 
-    protected function setUp()
+    private function setUpTestcase()
     {
         $this->subject = new KeyFrame();
     }
@@ -28,6 +28,8 @@ final class KeyFrameTest extends TestCase
      */
     public function implementsAtRule()
     {
+        $this->setUpTestcase();
+
         self::assertInstanceOf(AtRule::class, $this->subject);
     }
 
@@ -36,6 +38,8 @@ final class KeyFrameTest extends TestCase
      */
     public function implementsRenderable()
     {
+        $this->setUpTestcase();
+
         self::assertInstanceOf(Renderable::class, $this->subject);
     }
 
@@ -44,6 +48,8 @@ final class KeyFrameTest extends TestCase
      */
     public function implementsCommentable()
     {
+        $this->setUpTestcase();
+
         self::assertInstanceOf(Commentable::class, $this->subject);
     }
 }

--- a/tests/OutputFormatTest.php
+++ b/tests/OutputFormatTest.php
@@ -43,7 +43,7 @@ EOT;
      */
     private $oDocument;
 
-    protected function setUp()
+    private function setUpTestcase()
     {
         $this->oParser = new Parser(self::TEST_CSS);
         $this->oDocument = $this->oParser->parse();
@@ -54,6 +54,8 @@ EOT;
      */
     public function plain()
     {
+        $this->setUpTestcase();
+
         self::assertSame(
             '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white;}
 @media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff;}}',
@@ -66,6 +68,8 @@ EOT;
      */
     public function compact()
     {
+        $this->setUpTestcase();
+
         self::assertSame(
             '.main,.test{font:italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background:white;}'
             . '@media screen{.main{background-size:100% 100%;font-size:1.3em;background-color:#fff;}}',
@@ -78,6 +82,8 @@ EOT;
      */
     public function pretty()
     {
+        $this->setUpTestcase();
+
         self::assertSame(self::TEST_CSS, $this->oDocument->render(OutputFormat::createPretty()));
     }
 
@@ -86,6 +92,8 @@ EOT;
      */
     public function spaceAfterListArgumentSeparator()
     {
+        $this->setUpTestcase();
+
         self::assertSame(
             '.main, .test {font: italic   normal   bold   16px/  1.2   '
             . '"Helvetica",  Verdana,  sans-serif;background: white;}'
@@ -99,6 +107,8 @@ EOT;
      */
     public function spaceAfterListArgumentSeparatorComplex()
     {
+        $this->setUpTestcase();
+
         self::assertSame(
             '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",	Verdana,	sans-serif;background: white;}'
             . "\n@media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff;}}",
@@ -116,6 +126,8 @@ EOT;
      */
     public function spaceAfterSelectorSeparator()
     {
+        $this->setUpTestcase();
+
         self::assertSame(
             '.main,
 .test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white;}
@@ -129,6 +141,8 @@ EOT;
      */
     public function stringQuotingType()
     {
+        $this->setUpTestcase();
+
         self::assertSame(
             '.main, .test {font: italic normal bold 16px/1.2 \'Helvetica\',Verdana,sans-serif;background: white;}
 @media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff;}}',
@@ -141,6 +155,8 @@ EOT;
      */
     public function rGBHashNotation()
     {
+        $this->setUpTestcase();
+
         self::assertSame(
             '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white;}
 @media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: rgb(255,255,255);}}',
@@ -153,6 +169,8 @@ EOT;
      */
     public function semicolonAfterLastRule()
     {
+        $this->setUpTestcase();
+
         self::assertSame(
             '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white}
 @media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff}}',
@@ -165,6 +183,8 @@ EOT;
      */
     public function spaceAfterRuleName()
     {
+        $this->setUpTestcase();
+
         self::assertSame(
             '.main, .test {font:	italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background:	white;}
 @media screen {.main {background-size:	100% 100%;font-size:	1.3em;background-color:	#fff;}}',
@@ -177,6 +197,8 @@ EOT;
      */
     public function spaceRules()
     {
+        $this->setUpTestcase();
+
         self::assertSame('.main, .test {
 	font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;
 	background: white;
@@ -193,6 +215,8 @@ EOT;
      */
     public function spaceBlocks()
     {
+        $this->setUpTestcase();
+
         self::assertSame('
 .main, .test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white;}
 @media screen {
@@ -206,6 +230,8 @@ EOT;
      */
     public function spaceBoth()
     {
+        $this->setUpTestcase();
+
         self::assertSame('
 .main, .test {
 	font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;
@@ -226,6 +252,8 @@ EOT;
      */
     public function spaceBetweenBlocks()
     {
+        $this->setUpTestcase();
+
         self::assertSame(
             '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white;}'
             . '@media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff;}}',
@@ -238,6 +266,8 @@ EOT;
      */
     public function indentation()
     {
+        $this->setUpTestcase();
+
         self::assertSame('
 .main, .test {
 font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;
@@ -261,6 +291,8 @@ background-color: #fff;
      */
     public function spaceBeforeBraces()
     {
+        $this->setUpTestcase();
+
         self::assertSame(
             '.main, .test{font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white;}
 @media screen{.main{background-size: 100% 100%;font-size: 1.3em;background-color: #fff;}}',
@@ -273,6 +305,8 @@ background-color: #fff;
      */
     public function ignoreExceptionsOff()
     {
+        $this->setUpTestcase();
+
         $this->expectException(OutputException::class);
 
         $aBlocks = $this->oDocument->getAllDeclarationBlocks();
@@ -292,6 +326,8 @@ background-color: #fff;
      */
     public function ignoreExceptionsOn()
     {
+        $this->setUpTestcase();
+
         $aBlocks = $this->oDocument->getAllDeclarationBlocks();
         $oFirstBlock = $aBlocks[0];
         $oFirstBlock->removeSelector('.main');


### PR DESCRIPTION
If we want to work both with PHPUnit 5.x and 8.x, we cannot use PHPUnit's `setUp()` method: This method would need to have a `: void` return type declaration for PHPUnit 8.x, which is not possible with PHP 5.6 (the lowest version we support).