### PR TITLE
[TASK] Be less strict about the `@covers` annotation

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,7 +2,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
     beStrictAboutChangesToGlobalState="true"
-    beStrictAboutCoversAnnotation="true"
     cacheResult="false"
     colors="true"
     forceCoversAnnotation="true"


### PR DESCRIPTION
We still want to require the `@covers` annotation to be used for testcase (`forceCoversAnnotation="true"`), but we also want to be able to indirectly execute code that is not referenced via an `@covers` annotation.