### PR TITLE
[TASK] Drop the highest/lowest Composer version switch

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -19,8 +19,6 @@ jobs:
             matrix:
                 php-version:
                     - '7.4'
-                dependencies:
-                    - highest
 
         steps:
             - name: Checkout
@@ -44,19 +42,13 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: ~/.cache/composer
-                  key: php${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-${{ hashFiles('**/composer.json') }}
+                  key: php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}
                   restore-keys: |
-                      php${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-
+                      php${{ matrix.php-version }}-composer-
 
             - name: Install Composer dependencies
               run: |
-                  if [[ "${{ matrix.dependencies }}" == 'lowest' ]]; then
-                    DEPENDENCIES='--prefer-lowest';
-                  else
-                    DEPENDENCIES='';
-                  fi;
-                  composer install --no-progress;
-                  composer update --with-dependencies --no-progress "${DEPENDENCIES}";
+                  composer update --with-dependencies --no-progress;
                   composer show;
 
             - name: Run Tests


### PR DESCRIPTION
As we don't have any direct production dependencies, it does not make sense to test both with highest and lowest Composer versions on CI.

We accidentally added this highest/lowest switch with the new coverage job. This commit removes this again, allowing for sharing the Composer caches with the main CI job.