### PR TITLE
[TASK] Deprecate `Parser::setCharset()` and `Parser::getCharset()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
+- Deprecate `Parser::setCharset()` and `Parser::getCharset()` (#703)
+
 ### Removed
 
 ### Fixed

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -35,6 +35,8 @@ class Parser
      * @param string $sCharset
      *
      * @return void
+     *
+     * @deprecated will be removed in version 9.0.0 with #687
      */
     public function setCharset($sCharset)
     {
@@ -45,6 +47,8 @@ class Parser
      * Returns the charset that is used if the CSS does not contain an `@charset` declaration.
      *
      * @return void
+     *
+     * @deprecated will be removed in version 9.0.0 with #687
      */
     public function getCharset()
     {


### PR DESCRIPTION
This is the backport of #688, which fixed #681.