### PR TITLE
[TASK] Use fixed versions of the development dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,12 @@
         "ext-iconv": "*"
     },
     "require-dev": {
-        "php-parallel-lint/php-parallel-lint": "^1.4.0",
-        "phpstan/extension-installer": "^1.4.3",
-        "phpstan/phpstan": "^1.12.1",
-        "phpstan/phpstan-phpunit": "^1.4.0",
-        "phpunit/phpunit": "^8.5.38",
-        "rector/rector": "^1.2.4"
+        "php-parallel-lint/php-parallel-lint": "1.4.0",
+        "phpstan/extension-installer": "1.4.3",
+        "phpstan/phpstan": "1.12.1",
+        "phpstan/phpstan-phpunit": "1.4.0",
+        "phpunit/phpunit": "8.5.38",
+        "rector/rector": "1.2.4"
     },
     "suggest": {
         "ext-mbstring": "for parsing UTF-8 CSS"


### PR DESCRIPTION
We don't want to have sudden build failures when a new version of a development dependency gets released.

Instead, we'll keep having automatic Dependabot updates for our dependencies that will allow us to see the effects of each update before switchting to a new version of a dependency.