### PR TITLE
[TASK] Mark parsing-internal classes and methods as `@internal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Mark parsing-internal classes and methods as `@internal` (#711)
 - Block installations on unsupported higher PHP versions (#691)
 
 ### Deprecated

--- a/src/Parsing/Anchor.php
+++ b/src/Parsing/Anchor.php
@@ -2,6 +2,9 @@
 
 namespace Sabberworm\CSS\Parsing;
 
+/**
+ * @internal
+ */
 class Anchor
 {
     /**

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -5,6 +5,9 @@ namespace Sabberworm\CSS\Parsing;
 use Sabberworm\CSS\Comment\Comment;
 use Sabberworm\CSS\Settings;
 
+/**
+ * @internal
+ */
 class ParserState
 {
     /**


### PR DESCRIPTION
Code that uses this library is not expected to call internal parsing functionality. Communicate this with the corresponding `@internal` annotation.

This allows us to boldly refactor the parser code.

This is the backport of #674.

Part of #668