### PR TITLE
[TASK] State since which version code is `@internal`/`@deprecated`

### DIFF
--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -129,7 +129,7 @@ class Document extends CSSBlockList
      *
      * @return void
      *
-     * @deprecated This will be removed without substitution in version 9.0 in #511.
+     * @deprecated since 8.7.0, will be removed without substitution in version 9.0 in #511
      */
     public function expandShorthands()
     {
@@ -143,7 +143,7 @@ class Document extends CSSBlockList
      *
      * @return void
      *
-     * @deprecated This will be removed without substitution in version 9.0 in #511.
+     * @deprecated since 8.7.0, will be removed without substitution in version 9.0 in #511
      */
     public function createShorthands()
     {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -36,7 +36,7 @@ class Parser
      *
      * @return void
      *
-     * @deprecated will be removed in version 9.0.0 with #687
+     * @deprecated since 8.7.0, will be removed in version 9.0.0 with #687
      */
     public function setCharset($sCharset)
     {
@@ -48,7 +48,7 @@ class Parser
      *
      * @return void
      *
-     * @deprecated will be removed in version 9.0.0 with #687
+     * @deprecated since 8.7.0, will be removed in version 9.0.0 with #687
      */
     public function getCharset()
     {

--- a/src/Parsing/Anchor.php
+++ b/src/Parsing/Anchor.php
@@ -3,7 +3,7 @@
 namespace Sabberworm\CSS\Parsing;
 
 /**
- * @internal
+ * @internal since 8.7.0
  */
 class Anchor
 {

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -6,14 +6,14 @@ use Sabberworm\CSS\Comment\Comment;
 use Sabberworm\CSS\Settings;
 
 /**
- * @internal
+ * @internal since 8.7.0
  */
 class ParserState
 {
     /**
      * @var null
      *
-     * @internal
+     * @internal since 8.5.2
      */
     const EOF = null;
 

--- a/src/Property/AtRule.php
+++ b/src/Property/AtRule.php
@@ -13,7 +13,7 @@ interface AtRule extends Renderable, Commentable
      *
      * @var string
      *
-     * @internal
+     * @internal since 8.5.2
      */
     const BLOCK_RULES = 'media/document/supports/region-style/font-feature-values';
 
@@ -22,7 +22,7 @@ interface AtRule extends Renderable, Commentable
      *
      * @var string
      *
-     * @internal
+     * @internal since 8.5.2
      */
     const SET_RULES = 'font-face/counter-style/page/swash/styleset/annotation';
 

--- a/src/Property/KeyframeSelector.php
+++ b/src/Property/KeyframeSelector.php
@@ -9,7 +9,7 @@ class KeyframeSelector extends Selector
      *
      * @var string
      *
-     * @internal
+     * @internal since 8.5.2
      */
     const SELECTOR_VALIDATION_RX = '/
     ^(

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -54,7 +54,7 @@ class Selector
      *
      * @var string
      *
-     * @internal
+     * @internal since 8.5.2
      */
     const SELECTOR_VALIDATION_RX = '/
         ^(

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -182,7 +182,7 @@ class DeclarationBlock extends RuleSet
      *
      * @return void
      *
-     * @deprecated This will be removed without substitution in version 9.0 in #511.
+     * @deprecated since 8.7.0, will be removed without substitution in version 9.0 in #511
      */
     public function expandShorthands()
     {
@@ -199,7 +199,7 @@ class DeclarationBlock extends RuleSet
      *
      * @return void
      *
-     * @deprecated This will be removed without substitution in version 9.0 in #511.
+     * @deprecated since 8.7.0, will be removed without substitution in version 9.0 in #511
      */
     public function createShorthands()
     {
@@ -220,7 +220,7 @@ class DeclarationBlock extends RuleSet
      *
      * @return void
      *
-     * @deprecated This will be removed without substitution in version 9.0 in #511.
+     * @deprecated since 8.7.0, will be removed without substitution in version 9.0 in #511
      */
     public function expandBorderShorthand()
     {
@@ -283,7 +283,7 @@ class DeclarationBlock extends RuleSet
      *
      * @return void
      *
-     * @deprecated This will be removed without substitution in version 9.0 in #511.
+     * @deprecated since 8.7.0, will be removed without substitution in version 9.0 in #511
      */
     public function expandDimensionsShorthand()
     {
@@ -345,7 +345,7 @@ class DeclarationBlock extends RuleSet
      *
      * @return void
      *
-     * @deprecated This will be removed without substitution in version 9.0 in #511.
+     * @deprecated since 8.7.0, will be removed without substitution in version 9.0 in #511
      */
     public function expandFontShorthand()
     {
@@ -417,7 +417,7 @@ class DeclarationBlock extends RuleSet
      *
      * @return void
      *
-     * @deprecated This will be removed without substitution in version 9.0 in #511.
+     * @deprecated since 8.7.0, will be removed without substitution in version 9.0 in #511
      */
     public function expandBackgroundShorthand()
     {
@@ -491,7 +491,7 @@ class DeclarationBlock extends RuleSet
     /**
      * @return void
      *
-     * @deprecated This will be removed without substitution in version 9.0 in #511.
+     * @deprecated since 8.7.0, will be removed without substitution in version 9.0 in #511
      */
     public function expandListStyleShorthand()
     {
@@ -576,7 +576,7 @@ class DeclarationBlock extends RuleSet
      *
      * @return void
      *
-     * @deprecated This will be removed without substitution in version 9.0 in #511.
+     * @deprecated since 8.7.0, will be removed without substitution in version 9.0 in #511
      */
     public function createShorthandProperties(array $aProperties, $sShorthand)
     {
@@ -614,7 +614,7 @@ class DeclarationBlock extends RuleSet
     /**
      * @return void
      *
-     * @deprecated This will be removed without substitution in version 9.0 in #511.
+     * @deprecated since 8.7.0, will be removed without substitution in version 9.0 in #511
      */
     public function createBackgroundShorthand()
     {
@@ -631,7 +631,7 @@ class DeclarationBlock extends RuleSet
     /**
      * @return void
      *
-     * @deprecated This will be removed without substitution in version 9.0 in #511.
+     * @deprecated since 8.7.0, will be removed without substitution in version 9.0 in #511
      */
     public function createListStyleShorthand()
     {
@@ -650,7 +650,7 @@ class DeclarationBlock extends RuleSet
      *
      * @return void
      *
-     * @deprecated This will be removed without substitution in version 9.0 in #511.
+     * @deprecated since 8.7.0, will be removed without substitution in version 9.0 in #511
      */
     public function createBorderShorthand()
     {
@@ -669,7 +669,7 @@ class DeclarationBlock extends RuleSet
      *
      * @return void
      *
-     * @deprecated This will be removed without substitution in version 9.0 in #511.
+     * @deprecated since 8.7.0, will be removed without substitution in version 9.0 in #511
      */
     public function createDimensionsShorthand()
     {
@@ -745,7 +745,7 @@ class DeclarationBlock extends RuleSet
      *
      * @return void
      *
-     * @deprecated This will be removed without substitution in version 9.0 in #511.
+     * @deprecated since 8.7.0, will be removed without substitution in version 9.0 in #511
      */
     public function createFontShorthand()
     {


### PR DESCRIPTION
This will help us avoid breaking things in backports.

This is the v8.x backport of #722.