### PR TITLE
[TASK] Use fixed PHPUnit versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ext-iconv": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.40"
+        "phpunit/phpunit": "5.7.27 || 6.5.14 || 7.5.20 || 8.5.40"
     },
     "suggest": {
         "ext-mbstring": "for parsing UTF-8 CSS"


### PR DESCRIPTION
This avoids build breakage when a new version of PHPUnit gets released.