### PR TITLE
Mark Exception Classes as Final

### DIFF
--- a/src/Parsing/OutputException.php
+++ b/src/Parsing/OutputException.php
@@ -7,7 +7,7 @@ namespace Sabberworm\CSS\Parsing;
 /**
  * Thrown if the CSS parser attempts to print something invalid.
  */
-class OutputException extends SourceException
+final class OutputException extends SourceException
 {
     /**
      * @param string $sMessage

--- a/src/Parsing/UnexpectedEOFException.php
+++ b/src/Parsing/UnexpectedEOFException.php
@@ -9,4 +9,4 @@ namespace Sabberworm\CSS\Parsing;
  *
  * Extends `UnexpectedTokenException` in order to preserve backwards compatibility.
  */
-class UnexpectedEOFException extends UnexpectedTokenException {}
+final class UnexpectedEOFException extends UnexpectedTokenException {}


### PR DESCRIPTION
This pull request addresses issue [#709](https://github.com/MyIntervals/PHP-CSS-Parser/issues/709) by marking certain exception classes final in the `src/Parsing` directory. 

The most important changes are as follows:

Class modifications:

* `src/Parsing/OutputException.php`: Changed the `OutputException` class to be final.
* `src/Parsing/UnexpectedEOFException.php`: Changed the `UnexpectedEOFException` class to be final.

Note: 

* skipped `SourceException` because `OutputException` extends `SourceException`
* skipped `UnexpectedTokenException` because `UnexpectedEOFException` extends `UnexpectedTokenException` 