### PR TITLE
[TASK] Add some more tests for parsing comments

### DIFF
--- a/tests/RuleSet/DeclarationBlockTest.php
+++ b/tests/RuleSet/DeclarationBlockTest.php
@@ -3,8 +3,10 @@
 namespace Sabberworm\CSS\Tests\RuleSet;
 
 use PHPUnit\Framework\TestCase;
+use Sabberworm\CSS\OutputFormat;
 use Sabberworm\CSS\Parser;
 use Sabberworm\CSS\Rule\Rule;
+use Sabberworm\CSS\Settings as ParserSettings;
 use Sabberworm\CSS\Value\Size;
 
 /**
@@ -449,5 +451,60 @@ final class DeclarationBlockTest extends TestCase
             ],
             array_map('strval', $oDeclaration->getRulesAssoc())
         );
+    }
+
+    /**
+     * @return array<string, array{0: non-empty-string, 1: non-empty-string}>
+     */
+    public static function declarationBlocksWithCommentsProvider()
+    {
+        return [
+            'CSS comments with one asterisk' => ['p {color: #000;/* black */}', 'p {color: #000;}'],
+            'CSS comments with two asterisks' => ['p {color: #000;/** black */}', 'p {color: #000;}'],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param string $cssWithComments
+     * @param string $cssWithoutComments
+     *
+     * @dataProvider declarationBlocksWithCommentsProvider
+     */
+    public function canRemoveCommentsFromRulesUsingLenientParsing(
+        $cssWithComments,
+        $cssWithoutComments
+    ) {
+        $parserSettings = ParserSettings::create()->withLenientParsing(true);
+        $document = (new Parser($cssWithComments, $parserSettings))->parse();
+
+        $outputFormat = (new OutputFormat())->setRenderComments(false);
+        $renderedDocument = $document->render($outputFormat);
+
+        self::assertSame($cssWithoutComments, $renderedDocument);
+    }
+
+    /**
+     * @test
+     *
+     * @param string $cssWithComments
+     * @param string $cssWithoutComments
+     *
+     * @dataProvider declarationBlocksWithCommentsProvider
+     */
+    public function canRemoveCommentsFromRulesUsingStrictParsing(
+        $cssWithComments,
+        $cssWithoutComments
+    ) {
+        self::markTestSkipped('This currently crashes, and we need to fix it.');
+
+        $parserSettings = ParserSettings::create()->withLenientParsing(false);
+        $document = (new Parser($cssWithComments, $parserSettings))->parse();
+
+        $outputFormat = (new OutputFormat())->setRenderComments(false);
+        $renderedDocument = $document->render($outputFormat);
+
+        self::assertSame($cssWithoutComments, $renderedDocument);
     }
 }


### PR DESCRIPTION
Also add a skipped test for the broken behavior that currently is blocking Emogrifier.

This is the 8.x backport of #738.