### PR TITLE
[BUGFIX] Revert broken support for multiple comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,8 @@ Please also have a look at our
 
 ### Fixed
 
+- Revert broken support for multiple comments (#740)
 - Fix type errors in PHP strict mode (#664)
-- Fix comment parsing to support multiple comments (#672)
 - Fix undefined local variable in `CalcFunction::parse()` (#593)
 - Fix PHP notice caused by parsing invalid color values having less than 6
   characters (#485)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ Please also have a look at our
 
 ### Fixed
 
-- Revert broken support for multiple comments (#740)
 - Fix type errors in PHP strict mode (#664)
 - Fix undefined local variable in `CalcFunction::parse()` (#593)
 - Fix PHP notice caused by parsing invalid color values having less than 6

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -108,9 +108,7 @@ class Rule implements Renderable, Commentable
             $oParserState->consume(';');
         }
 
-        while (\preg_match('/\\s/isSu', $oParserState->peek()) === 1) {
-            $oParserState->consume(1);
-        }
+        $oParserState->consumeWhiteSpace();
 
         return $oRule;
     }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1175,6 +1175,25 @@ body {background-color: red;}';
     /**
      * @test
      */
+    public function flatCommentExtractingTwoComments(): void
+    {
+        self::markTestSkipped('This is currently broken.');
+
+        $parser = new Parser('div {/*Find Me!*/left:10px; /*Find Me Too!*/text-align:left;}');
+        $document = $parser->parse();
+        $contents = $document->getContents();
+        $divRules = $contents[0]->getRules();
+        $rule1Comments = $divRules[0]->getComments();
+        $rule2Comments = $divRules[1]->getComments();
+        self::assertCount(1, $rule1Comments);
+        self::assertCount(1, $rule2Comments);
+        self::assertEquals('Find Me!', $rule1Comments[0]->getComment());
+        self::assertEquals('Find Me Too!', $rule2Comments[0]->getComment());
+    }
+
+    /**
+     * @test
+     */
     public function topLevelCommentExtracting(): void
     {
         $parser = new Parser('/*Find Me!*/div {left:10px; text-align:left;}');

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1171,22 +1171,6 @@ body {background-color: red;}';
         self::assertCount(1, $comments);
         self::assertSame('Find Me!', $comments[0]->getComment());
     }
-    /**
-     * @test
-     */
-    public function flatCommentExtractingTwoComments(): void
-    {
-        $parser = new Parser('div {/*Find Me!*/left:10px; /*Find Me Too!*/text-align:left;}');
-        $document = $parser->parse();
-        $contents = $document->getContents();
-        $divRules = $contents[0]->getRules();
-        $rule1Comments = $divRules[0]->getComments();
-        $rule2Comments = $divRules[1]->getComments();
-        self::assertCount(1, $rule1Comments);
-        self::assertCount(1, $rule2Comments);
-        self::assertEquals('Find Me!', $rule1Comments[0]->getComment());
-        self::assertEquals('Find Me Too!', $rule2Comments[0]->getComment());
-    }
 
     /**
      * @test

--- a/tests/RuleSet/DeclarationBlockTest.php
+++ b/tests/RuleSet/DeclarationBlockTest.php
@@ -467,8 +467,6 @@ final class DeclarationBlockTest extends TestCase
         string $cssWithComments,
         string $cssWithoutComments
     ): void {
-        self::markTestSkipped('This currently crashes, and we need to fix it.');
-
         $parserSettings = ParserSettings::create()->withLenientParsing(false);
         $document = (new Parser($cssWithComments, $parserSettings))->parse();
 


### PR DESCRIPTION
This reverts e4c66f62c5df3f53f48d82cb30b20b3007af7574 (#672), which broke comment parsing in strict mode.

We'll need to re-implement support for multiple comments later in a way that does not break the existing comment parsing.