### PR TITLE
[BUGFIX] Revert broken support for multiple comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - Fix type errors in PHP strict mode (#695)
-- Fix comment parsing to support multiple comments (#671)
 
 ## 8.6.0
 

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -108,11 +108,7 @@ class Rule implements Renderable, Commentable
             $oParserState->consume(';');
         }
 
-        // NOTE: This is a backport to fix comment parsing to support multiple
-        // comments. This will be rectified in version 9.0.0.
-        while (preg_match('/\\s/isSu', $oParserState->peek()) === 1) {
-            $oParserState->consume(1);
-        }
+        $oParserState->consumeWhiteSpace();
 
         return $oRule;
     }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1172,11 +1172,14 @@ body {background-color: red;}';
         self::assertCount(1, $comments);
         self::assertSame("Find Me!", $comments[0]->getComment());
     }
+
     /**
      * @test
      */
     public function flatCommentExtractingTwoComments()
     {
+        self::markTestSkipped('This is currently broken.');
+
         $parser = new Parser('div {/*Find Me!*/left:10px; /*Find Me Too!*/text-align:left;}');
         $doc = $parser->parse();
         $contents = $doc->getContents();

--- a/tests/RuleSet/DeclarationBlockTest.php
+++ b/tests/RuleSet/DeclarationBlockTest.php
@@ -497,8 +497,6 @@ final class DeclarationBlockTest extends TestCase
         $cssWithComments,
         $cssWithoutComments
     ) {
-        self::markTestSkipped('This currently crashes, and we need to fix it.');
-
         $parserSettings = ParserSettings::create()->withLenientParsing(false);
         $document = (new Parser($cssWithComments, $parserSettings))->parse();
 


### PR DESCRIPTION
This reverts e4c66f6 (#672), which broke comment parsing in strict mode.

We'll need to re-implement support for multiple comments later in a way that does not break the existing comment parsing.

This is the v8.x backport of #740.