### PR TITLE
[BUGFIX] Avoid implicit nullable parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- Add support for PHP 8.4 (#675, #701)
+- Add support for PHP 8.4 (#675, #701, #746)
 
 ### Changed
 

--- a/src/CSSList/AtRuleBlockList.php
+++ b/src/CSSList/AtRuleBlockList.php
@@ -57,9 +57,11 @@ class AtRuleBlockList extends CSSBlockList implements AtRule
     }
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render($oOutputFormat)
     {
         $sResult = $oOutputFormat->comments($this);
         $sResult .= $oOutputFormat->sBeforeAtRuleBlock;

--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -159,7 +159,7 @@ class Document extends CSSBlockList
      *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat = null)
+    public function render($oOutputFormat = null)
     {
         if ($oOutputFormat === null) {
             $oOutputFormat = new OutputFormat();

--- a/src/CSSList/KeyFrame.php
+++ b/src/CSSList/KeyFrame.php
@@ -68,9 +68,11 @@ class KeyFrame extends CSSList implements AtRule
     }
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render($oOutputFormat)
     {
         $sResult = $oOutputFormat->comments($this);
         $sResult .= "@{$this->vendorKeyFrame} {$this->animationName}{$oOutputFormat->spaceBeforeOpeningBrace()}{";

--- a/src/Comment/Comment.php
+++ b/src/Comment/Comment.php
@@ -62,9 +62,11 @@ class Comment implements Renderable
     }
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render($oOutputFormat)
     {
         return '/*' . $this->sComment . '*/';
     }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -21,7 +21,7 @@ class Parser
      * @param Settings|null $oParserSettings
      * @param int $iLineNo the line number (starting from 1, not from 0)
      */
-    public function __construct($sText, Settings $oParserSettings = null, $iLineNo = 1)
+    public function __construct($sText, $oParserSettings = null, $iLineNo = 1)
     {
         if ($oParserSettings === null) {
             $oParserSettings = Settings::create();

--- a/src/Property/CSSNamespace.php
+++ b/src/Property/CSSNamespace.php
@@ -60,9 +60,11 @@ class CSSNamespace implements AtRule
     }
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render($oOutputFormat)
     {
         return '@namespace ' . ($this->sPrefix === null ? '' : $this->sPrefix . ' ')
             . $this->mUrl->render($oOutputFormat) . ';';

--- a/src/Property/Charset.php
+++ b/src/Property/Charset.php
@@ -78,9 +78,11 @@ class Charset implements AtRule
     }
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render($oOutputFormat)
     {
         return "{$oOutputFormat->comments($this)}@charset {$this->oCharset->render($oOutputFormat)};";
     }

--- a/src/Property/Import.php
+++ b/src/Property/Import.php
@@ -79,9 +79,11 @@ class Import implements AtRule
     }
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render($oOutputFormat)
     {
         return $oOutputFormat->comments($this) . "@import " . $this->oLocation->render($oOutputFormat)
             . ($this->sMediaQuery === null ? '' : ' ' . $this->sMediaQuery) . ';';

--- a/src/Renderable.php
+++ b/src/Renderable.php
@@ -10,9 +10,11 @@ interface Renderable
     public function __toString();
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat);
+    public function render($oOutputFormat);
 
     /**
      * @return int

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -344,9 +344,11 @@ class Rule implements Renderable, Commentable
     }
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render($oOutputFormat)
     {
         $sResult = "{$oOutputFormat->comments($this)}{$this->sRule}:{$oOutputFormat->spaceAfterRuleName()}";
         if ($this->mValue instanceof Value) { // Can also be a ValueList

--- a/src/RuleSet/AtRuleSet.php
+++ b/src/RuleSet/AtRuleSet.php
@@ -60,9 +60,11 @@ class AtRuleSet extends RuleSet implements AtRule
     }
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render($oOutputFormat)
     {
         $sResult = $oOutputFormat->comments($this);
         $sArgs = $this->sArgs;

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -836,11 +836,13 @@ class DeclarationBlock extends RuleSet
     }
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      *
      * @throws OutputException
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render($oOutputFormat)
     {
         $sResult = $oOutputFormat->comments($this);
         if (count($this->aSelectors) === 0) {

--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -88,9 +88,11 @@ class CSSFunction extends ValueList
     }
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render($oOutputFormat)
     {
         $aArguments = parent::render($oOutputFormat);
         return "{$this->sName}({$aArguments})";

--- a/src/Value/CSSString.php
+++ b/src/Value/CSSString.php
@@ -99,9 +99,11 @@ class CSSString extends PrimitiveValue
     }
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render($oOutputFormat)
     {
         $sString = addslashes($this->sString);
         $sString = str_replace("\n", '\A', $sString);

--- a/src/Value/CalcRuleValueList.php
+++ b/src/Value/CalcRuleValueList.php
@@ -15,9 +15,11 @@ class CalcRuleValueList extends RuleValueList
     }
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render($oOutputFormat)
     {
         return $oOutputFormat->implode(' ', $this->aComponents);
     }

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -160,9 +160,11 @@ class Color extends CSSFunction
     }
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render($oOutputFormat)
     {
         // Shorthand RGB color values
         if ($oOutputFormat->getRGBHashNotation() && implode('', array_keys($this->aComponents)) === 'rgb') {

--- a/src/Value/LineName.php
+++ b/src/Value/LineName.php
@@ -56,9 +56,11 @@ class LineName extends ValueList
     }
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render($oOutputFormat)
     {
         return '[' . parent::render(OutputFormat::createCompact()) . ']';
     }

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -216,9 +216,11 @@ class Size extends PrimitiveValue
     }
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render($oOutputFormat)
     {
         $l = localeconv();
         $sPoint = preg_quote($l['decimal_point'], '/');

--- a/src/Value/URL.php
+++ b/src/Value/URL.php
@@ -86,9 +86,11 @@ class URL extends PrimitiveValue
     }
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render($oOutputFormat)
     {
         return "url({$this->oURL->render($oOutputFormat)})";
     }

--- a/src/Value/ValueList.php
+++ b/src/Value/ValueList.php
@@ -93,9 +93,11 @@ abstract class ValueList extends Value
     }
 
     /**
+     * @param OutputFormat|null $oOutputFormat
+     *
      * @return string
      */
-    public function render(OutputFormat $oOutputFormat)
+    public function render($oOutputFormat)
     {
         return $oOutputFormat->implode(
             $oOutputFormat->spaceBeforeListArgumentSeparator($this->sSeparator) . $this->sSeparator


### PR DESCRIPTION
This avoids deprecation warnings in PHP 8.4.

Unfortunately, we need to remove the native type declaration for this to keep supporting PHP down to version 5.6.