### PR TITLE
[CLEANUP] Autoformat the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,13 +28,15 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## 8.6.0
 
 ### Added
+
 - Support arithmetic operators in CSS function arguments (#607)
 - Add support for inserting an item in a CSS list (#545)
 - Add support for the `dvh`, `lvh` and `svh` length units (#415)
 
 ### Changed
 
-- Improve performance of Value::parseValue with many delimiters by refactoring to remove array_search() (#413)
+- Improve performance of Value::parseValue with many delimiters by refactoring
+  to remove `array_search()` (#413)
 
 ## 8.5.2
 
@@ -50,7 +52,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- Fix PHP notice caused by parsing invalid color values having less than 6 characters (#485)
+- Fix PHP notice caused by parsing invalid color values having less than
+  6 characters (#485)
 - Fix (regression) failure to parse at-rules with strict parsing (#456)
 
 ## 8.5.0
@@ -75,7 +78,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 * Support for PHP 8.x
 * PHPDoc annotations
-* Allow usage of CSS variables inside color functions (by parsing them as regular functions)
+* Allow usage of CSS variables inside color functions (by parsing them as
+  regular functions)
 * Use PSR-12 code style
 * *No deprecations*
 
@@ -90,7 +94,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Allow a file to end after an `@import`
 * Preserve case of CSS variables as specced
 * Allow identifiers to use escapes the same way as strings
-* No longer use `eval` for the comparison in `getSelectorsBySpecificity`, in case it gets passed untrusted input (CVE-2020-13756). Also fixed in 8.3.1, 8.2.1, 8.1.1, 8.0.1, 7.0.4, 6.0.2, 5.2.1, 5.1.3, 5.0.9, 4.0.1, 3.0.1, 2.0.1, 1.0.1.
+* No longer use `eval` for the comparison in `getSelectorsBySpecificity`, in
+  case it gets passed untrusted input (CVE-2020-13756). Also fixed in 8.3.1,
+  8.2.1, 8.1.1, 8.0.1, 7.0.4, 6.0.2, 5.2.1, 5.1.3, 5.0.9, 4.0.1, 3.0.1, 2.0.1,
+  1.0.1.
 * Prevent an infinite loop when parsing invalid grid line names
 * Remove invalid unit `vm`
 * Retain rule order after expanding shorthands
@@ -102,11 +109,16 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## 8.3.0 (2019-02-22)
 
-* Refactor parsing logic to mostly reside in the class files whose data structure is to be parsed (this should eventually allow us to unit-test specific parts of the parsing logic individually).
-* Fix error in parsing `calc` expessions when the first operand is a negative number, thanks to @raxbg.
-* Support parsing CSS4 colors in hex notation with alpha values, thanks to @raxbg.
+* Refactor parsing logic to mostly reside in the class files whose data
+  structure is to be parsed (this should eventually allow us to unit-test
+  specific parts of the parsing logic individually).
+* Fix error in parsing `calc` expessions when the first operand is a negative
+  number, thanks to @raxbg.
+* Support parsing CSS4 colors in hex notation with alpha values, thanks to
+  @raxbg.
 * Swallow more errors in lenient mode, thanks to @raxbg.
-* Allow specifying arbitrary strings to output before and after declaration blocks, thanks to @westonruter.
+* Allow specifying arbitrary strings to output before and after declaration
+  blocks, thanks to @westonruter.
 * *No backwards-incompatible changes*
 * *No deprecations*
 
@@ -114,16 +126,20 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 * Support parsing `calc()`, thanks to @raxbg.
 * Support parsing grid-lines, again thanks to @raxbg.
-* Support parsing legacy IE filters (`progid:`) in lenient mode, thanks to @FMCorz
+* Support parsing legacy IE filters (`progid:`) in lenient mode, thanks to
+  @FMCorz
 * Performance improvements parsing large files, again thanks to @FMCorz
 * *No backwards-incompatible changes*
 * *No deprecations*
 
 ## 8.1.0 (2016-07-19)
 
-* Comments are no longer silently ignored but stored with the object with which they appear (no render support, though). Thanks to @FMCorz.
-* The IE hacks using `\0` and `\9` can now be parsed (and rendered) in lenient mode. Thanks (again) to @FMCorz.
-* Media queries with or without spaces before the query are parsed. Still no *real* parsing support, though. Sorry…
+* Comments are no longer silently ignored but stored with the object with which
+  they appear (no render support, though). Thanks to @FMCorz.
+* The IE hacks using `\0` and `\9` can now be parsed (and rendered) in lenient
+  mode. Thanks (again) to @FMCorz.
+* Media queries with or without spaces before the query are parsed. Still no
+  *real* parsing support, though. Sorry…
 * PHPUnit is now listed as a dev-dependency in composer.json.
 * *No backwards-incompatible changes*
 * *No deprecations*
@@ -135,7 +151,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Backwards-incompatible changes
 
-* Unrecoverable parser errors throw an exception of type `Sabberworm\CSS\Parsing\SourceException` instead of `\Exception`.
+* Unrecoverable parser errors throw an exception of type
+  `Sabberworm\CSS\Parsing\SourceException` instead of `\Exception`.
 
 ## 7.0.3 (2016-04-27)
 
@@ -145,7 +162,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## 7.0.2 (2016-02-11)
 
-* 150 time performance boost thanks to @[ossinkine](https://github.com/ossinkine)
+* 150 time performance boost thanks
+  to @[ossinkine](https://github.com/ossinkine)
 * *No backwards-incompatible changes*
 * *No deprecations*
 
@@ -162,7 +180,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Backwards-incompatible changes
 
-* The `Sabberworm\CSS\Value\String` class has been renamed to `Sabberworm\CSS\Value\CSSString`.
+* The `Sabberworm\CSS\Value\String` class has been renamed to
+  `Sabberworm\CSS\Value\CSSString`.
 
 ## 6.0.1 (2015-08-24)
 
@@ -176,22 +195,27 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecations
 
-* The parse() method replaces __toString with an optional argument (instance of the OutputFormat class)
+* The parse() method replaces __toString with an optional argument (instance of
+  the OutputFormat class)
 
 ## 5.2.0 (2014-06-30)
 
-* Support removing a selector from a declaration block using `$oBlock->removeSelector($mSelector)`
-* Introduce a specialized exception (Sabberworm\CSS\Parsing\OuputException) for exceptions during output rendering
+* Support removing a selector from a declaration block using
+  `$oBlock->removeSelector($mSelector)`
+* Introduce a specialized exception (Sabberworm\CSS\Parsing\OuputException) for
+  exceptions during output rendering
 
 * *No deprecations*
 
 #### Backwards-incompatible changes
 
-* Outputting a declaration block that has no selectors throws an OuputException instead of outputting an invalid ` {…}` into the CSS document.
+* Outputting a declaration block that has no selectors throws an OuputException
+  instead of outputting an invalid ` {…}` into the CSS document.
 
 ## 5.1.2 (2013-10-30)
 
-* Remove the use of consumeUntil in comment parsing. This makes it possible to parse comments such as `/** Perfectly valid **/`
+* Remove the use of consumeUntil in comment parsing. This makes it possible to
+  parse comments such as `/** Perfectly valid **/`
 * Add fr relative size unit
 * Fix some issues with HHVM
 * *No backwards-incompatible changes*
@@ -206,13 +230,15 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## 5.1.0 (2013-10-24)
 
 * Performance enhancements by Michael M Slusarz
-* More rescue entry points for lenient parsing (unexpected tokens between declaration blocks and unclosed comments)
+* More rescue entry points for lenient parsing (unexpected tokens between
+  declaration blocks and unclosed comments)
 * *No backwards-incompatible changes*
 * *No deprecations*
 
 ## 5.0.8 (2013-08-15)
 
-* Make default settings’ multibyte parsing option dependent on whether or not the mbstring extension is actually installed.
+* Make default settings’ multibyte parsing option dependent on whether or not
+  the mbstring extension is actually installed.
 * *No backwards-incompatible changes*
 * *No deprecations*
 
@@ -230,7 +256,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## 5.0.5 (2013-04-17)
 
-* Initial support for lenient parsing (setting this parser option will catch some exceptions internally and recover the parser’s state as neatly as possible).
+* Initial support for lenient parsing (setting this parser option will catch
+  some exceptions internally and recover the parser’s state as neatly as
+  possible).
 * *No backwards-incompatible changes*
 * *No deprecations*
 
@@ -267,18 +295,22 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Backwards-incompatible changes
 
-* `Sabberworm\CSS\Value\Color`’s `__toString` method overrides `CSSList`’s to maybe return something other than `type(value, …)` (see above).
+* `Sabberworm\CSS\Value\Color`’s `__toString` method overrides `CSSList`’s to
+  maybe return something other than `type(value, …)` (see above).
 
 ## 4.0.0 (2013-03-19)
 
 * Support for more @-rules
-* Generic interface `Sabberworm\CSS\Property\AtRule`, implemented by all @-rule classes
+* Generic interface `Sabberworm\CSS\Property\AtRule`, implemented by all @-rule
+  classes
 * *No deprecations*
 
 ### Backwards-incompatible changes
 
 * `Sabberworm\CSS\RuleSet\AtRule` renamed to `Sabberworm\CSS\RuleSet\AtRuleSet`
-* `Sabberworm\CSS\CSSList\MediaQuery` renamed to `Sabberworm\CSS\RuleSet\CSSList\AtRuleBlockList` with differing semantics and API (which also works for other block-list-based @-rules like `@supports`).
+* `Sabberworm\CSS\CSSList\MediaQuery` renamed to
+  `Sabberworm\CSS\RuleSet\CSSList\AtRuleBlockList` with differing semantics and
+  API (which also works for other block-list-based @-rules like `@supports`).
 
 ## 3.0.0 (2013-03-06)
 
@@ -287,10 +319,18 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Backwards-incompatible changes
 
-* All properties (like whether or not to use `mb_`-functions, which default charset to use and – new – whether or not to be forgiving when parsing) are now encapsulated in an instance of `Sabberworm\CSS\Settings` which can be passed as the second argument to `Sabberworm\CSS\Parser->__construct()`.
-* Specifying a charset as the second argument to `Sabberworm\CSS\Parser->__construct()` is no longer supported. Use `Sabberworm\CSS\Settings::create()->withDefaultCharset('some-charset')` instead.
-* Setting `Sabberworm\CSS\Parser->bUseMbFunctions` has no effect. Use `Sabberworm\CSS\Settings::create()->withMultibyteSupport(true/false)` instead.
-* `Sabberworm\CSS\Parser->parse()` may throw a `Sabberworm\CSS\Parsing\UnexpectedTokenException` when in strict parsing mode.
+* All properties (like whether or not to use `mb_`-functions, which default
+  charset to use and – new – whether or not to be forgiving when parsing) are
+  now encapsulated in an instance of `Sabberworm\CSS\Settings` which can be
+  passed as the second argument to `Sabberworm\CSS\Parser->__construct()`.
+* Specifying a charset as the second argument to
+  `Sabberworm\CSS\Parser->__construct()` is no longer supported. Use
+  `Sabberworm\CSS\Settings::create()->withDefaultCharset('some-charset')`
+  instead.
+* Setting `Sabberworm\CSS\Parser->bUseMbFunctions` has no effect. Use
+  `Sabberworm\CSS\Settings::create()->withMultibyteSupport(true/false)` instead.
+* `Sabberworm\CSS\Parser->parse()` may throw a
+  `Sabberworm\CSS\Parsing\UnexpectedTokenException` when in strict parsing mode.
 
 ## 2.0.0 (2013-01-29)
 
@@ -298,8 +338,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Backwards-incompatible changes
 
-* `Sabberworm\CSS\RuleSet->getRules()` returns an index-based array instead of an associative array. Use `Sabberworm\CSS\RuleSet->getRulesAssoc()` (which eliminates duplicate rules and lets the later rule of the same name win).
-* `Sabberworm\CSS\RuleSet->removeRule()` works as it did before except when passed an instance of `Sabberworm\CSS\Rule\Rule`, in which case it would only remove the exact rule given instead of all the rules of the same type. To get the old behaviour, use `Sabberworm\CSS\RuleSet->removeRule($oRule->getRule()`;
+* `Sabberworm\CSS\RuleSet->getRules()` returns an index-based array instead of
+  an associative array. Use `Sabberworm\CSS\RuleSet->getRulesAssoc()` (which
+  eliminates duplicate rules and lets the later rule of the same name win).
+* `Sabberworm\CSS\RuleSet->removeRule()` works as it did before except when
+  passed an instance of `Sabberworm\CSS\Rule\Rule`, in which case it would only
+  remove the exact rule given instead of all the rules of the same type. To get
+  the old behaviour, use `Sabberworm\CSS\RuleSet->removeRule($oRule->getRule()`;
 
 ## 1.0
 


### PR DESCRIPTION
This allows autoformatting the changelog after adding new entries possible without introducing unrelated changes.

This is the v8.x backport of #718.