### PR TITLE
[BUGFIX] Fix another implictly nullable parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- Add support for PHP 8.4 (#675, #701, #746)
+- Add support for PHP 8.4 (#675, #701, #746, #751)
 
 ### Changed
 

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -102,7 +102,7 @@ abstract class RuleSet implements Renderable, Commentable
      *
      * @return void
      */
-    public function addRule(Rule $oRule, Rule $oSibling = null)
+    public function addRule(Rule $oRule, $oSibling = null)
     {
         $sRule = $oRule->getRule();
         if (!isset($this->aRules[$sRule])) {


### PR DESCRIPTION
This fixes compatibility with PHP 8.4.

This is the last part of the v8.x backport of #643.