### PR TITLE
[TASK] Prepare for non-PHP-checks on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,9 @@ jobs:
             fail-fast: false
             matrix:
                 command:
-                    - fixer
-                    - stan
-                    - rector
+                    - php:fixer
+                    - php:stan
+                    - php:rector
                 php-version:
                     - '8.3'
 
@@ -142,4 +142,4 @@ jobs:
                   phive --no-progress install --trust-gpg-keys BBAB5DF0A0D6672989CF1869E82B2FB314E9906E
 
             - name: Run Command
-              run: composer ci:php:${{ matrix.command }}
+              run: composer ci:${{ matrix.command }}


### PR DESCRIPTION
Following this change in Emogrifier and preparing for the addition of composer-normalize:

https://github.com/MyIntervals/emogrifier/pull/1363