### PR TITLE
[TASK] Allow `assertInstanceOf` calls in tests

### DIFF
--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -19,3 +19,8 @@ parameters:
     null_over_false: true
     narrow_param: true
     narrow_return: true
+
+  ignoreErrors:
+    -
+      message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) .* will always evaluate to#'
+      path: '../tests/'


### PR DESCRIPTION
We find those checks useful.