### PR TITLE
[TASK] Drop redundant PHPStan configuration options

### DIFF
--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -8,10 +8,6 @@ parameters:
 
   level: 1
 
-  scanDirectories:
-    - %currentWorkingDirectory%/bin/
-    - %currentWorkingDirectory%/src/
-    - %currentWorkingDirectory%/tests/
   paths:
     - %currentWorkingDirectory%/bin/
     - %currentWorkingDirectory%/src/


### PR DESCRIPTION
`scanDirectories` is not needed when `paths` is set.