### PR TITLE
[TASK] Allow generating an empty PHPStan baseline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         ],
         "fix:php:fixer": "\"./.phive/php-cs-fixer\" --config=config/php-cs-fixer.php fix bin src tests",
         "fix:php:rector": "rector --config=config/rector.php",
-        "phpstan:baseline": "phpstan --configuration=config/phpstan.neon --generate-baseline=config/phpstan-baseline.neon"
+        "phpstan:baseline": "phpstan --configuration=config/phpstan.neon --generate-baseline=config/phpstan-baseline.neon --allow-empty-baseline"
     },
     "scripts-descriptions": {
         "ci": "Runs all dynamic and static code checks.",


### PR DESCRIPTION
We're not there yet, but we want to be prepared for when we are.

This follows what we have in our sister project.