### PR TITLE
[BUGFIX] Parse `@font-face` src property as comma-delimited list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Parse `@font-face` `src` property as comma-delimited list (#794)
+
 ## 8.7.0: Add support for PHP 8.4
 
 ### Added

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -114,16 +114,26 @@ class Rule implements Renderable, Commentable
     }
 
     /**
+     * Returns a list of delimiters (or separators).
+     * The first item is the innermost separator (or, put another way, the highest-precedence operator).
+     * The sequence continues to the outermost separator (or lowest-precedence operator).
+     *
      * @param string $sRule
      *
-     * @return array<int, string>
+     * @return list<non-empty-string>
      */
     private static function listDelimiterForRule($sRule)
     {
         if (preg_match('/^font($|-)/', $sRule)) {
             return [',', '/', ' '];
         }
-        return [',', ' ', '/'];
+
+        switch ($sRule) {
+            case 'src':
+                return [' ', ','];
+            default:
+                return [',', ' ', '/'];
+        }
     }
 
     /**

--- a/tests/Unit/Rule/RuleTest.php
+++ b/tests/Unit/Rule/RuleTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Sabberworm\CSS\Tests\Unit\Rule;
+
+use PHPUnit\Framework\TestCase;
+use Sabberworm\CSS\Parsing\ParserState;
+use Sabberworm\CSS\Settings;
+use Sabberworm\CSS\Rule\Rule;
+use Sabberworm\CSS\Value\RuleValueList;
+use Sabberworm\CSS\Value\Value;
+use Sabberworm\CSS\Value\ValueList;
+
+/**
+ * @covers \Sabberworm\CSS\Rule\Rule
+ */
+final class RuleTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: string, 1: list<class-string>}>
+     */
+    public static function provideRulesAndExpectedParsedValueListTypes()
+    {
+        return [
+            'src (e.g. in @font-face)' => [
+                "
+                    src: url('../fonts/open-sans-italic-300.woff2') format('woff2'),
+                         url('../fonts/open-sans-italic-300.ttf') format('truetype');
+                ",
+                [RuleValueList::class, RuleValueList::class],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param string $rule
+     * @param list<class-string> $expectedTypeClassnames
+     *
+     * @dataProvider provideRulesAndExpectedParsedValueListTypes
+     */
+    public function parsesValuesIntoExpectedTypeList($rule, array $expectedTypeClassnames)
+    {
+        $subject = Rule::parse(new ParserState($rule, Settings::create()));
+
+        $value = $subject->getValue();
+        self::assertInstanceOf(ValueList::class, $value);
+
+        $actualClassnames = \array_map(
+            /**
+             * @param Value|string $component
+             * @return string
+             */
+            static function ($component) {
+                return \is_string($component) ? 'string' : \get_class($component);
+            },
+            $value->getListComponents()
+        );
+
+        self::assertSame($expectedTypeClassnames, $actualClassnames);
+    }
+}


### PR DESCRIPTION
Fixes #789.

Also adds an initial `TestCase` for `Rule/Rule`.

This is the 8.x backport of #790.