### PR TITLE
[FEATURE] Support rgba and rgb (etc.) being aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Please also have a look at our
 
 ### Added
 
+- Partial support for CSS Color Module Level 4 syntax:
+  - `rgb` and `rgba`, and `hsl` and `hsla` are now aliases (#797}
 - Add official support for PHP 8.4 (#657)
 - Support arithmetic operators in CSS function arguments (#607)
 - Add support for inserting an item in a CSS list (#545)

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -72,23 +72,48 @@ class Color extends CSSFunction
             $oParserState->consumeWhiteSpace();
             $oParserState->consume('(');
 
+            // CSS Color Module Level 4 says that `rgb` and `rgba` are now aliases; likewise `hsl` and `hsla`.
+            // So, attempt to parse with the `a`, and allow for it not being there.
+            switch ($sColorMode) {
+                case 'rgb':
+                case 'hsl':
+                    $colorModeForParsing = $sColorMode . 'a';
+                    $mayHaveOptionalAlpha = true;
+                    break;
+                case 'rgba':
+                case 'hsla':
+                    $colorModeForParsing = $sColorMode;
+                    $mayHaveOptionalAlpha = true;
+                    break;
+                default:
+                    $colorModeForParsing = $sColorMode;
+                    $mayHaveOptionalAlpha = false;
+                    break;
+            }
+
             $bContainsVar = false;
-            $iLength = $oParserState->strlen($sColorMode);
+            $iLength = $oParserState->strlen($colorModeForParsing);
             for ($i = 0; $i < $iLength; ++$i) {
                 $oParserState->consumeWhiteSpace();
                 if ($oParserState->comes('var')) {
-                    $aColor[$sColorMode[$i]] = CSSFunction::parseIdentifierOrFunction($oParserState);
+                    $aColor[$colorModeForParsing[$i]] = CSSFunction::parseIdentifierOrFunction($oParserState);
                     $bContainsVar = true;
                 } else {
-                    $aColor[$sColorMode[$i]] = Size::parse($oParserState, true);
+                    $aColor[$colorModeForParsing[$i]] = Size::parse($oParserState, true);
                 }
 
-                if ($bContainsVar && $oParserState->comes(')')) {
-                    // With a var argument the function can have fewer arguments
+                // This must be done first, to consume comments as well, so that the `comes` test will work.
+                $oParserState->consumeWhiteSpace();
+
+                // With a var argument, the function can have fewer arguments.
+                // And as of CSS Color Module Level 4, the alpha argument is optional.
+                $canCloseNow =
+                    $bContainsVar ||
+                    $mayHaveOptionalAlpha && $i >= $iLength - 2;
+                if ($canCloseNow && $oParserState->comes(')')) {
                     break;
                 }
 
-                $oParserState->consumeWhiteSpace();
                 if ($i < ($iLength - 1)) {
                     $oParserState->consume(',');
                 }

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -83,8 +83,8 @@ class Color extends CSSFunction
                     $colorModeForParsing = 'hsla';
                     $mayHaveOptionalAlpha = true;
                     break;
-                // These two cases are handled identically.
                 case 'rgba':
+                    // This is handled identically to the following case.
                 case 'hsla':
                     $colorModeForParsing = $sColorMode;
                     $mayHaveOptionalAlpha = true;
@@ -112,7 +112,7 @@ class Color extends CSSFunction
                 // And as of CSS Color Module Level 4, the alpha argument is optional.
                 $canCloseNow =
                     $bContainsVar ||
-                    $mayHaveOptionalAlpha && $i >= $iLength - 2;
+                    ($mayHaveOptionalAlpha && $i >= $iLength - 2);
                 if ($canCloseNow && $oParserState->comes(')')) {
                     break;
                 }

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -76,10 +76,14 @@ class Color extends CSSFunction
             // So, attempt to parse with the `a`, and allow for it not being there.
             switch ($sColorMode) {
                 case 'rgb':
-                case 'hsl':
-                    $colorModeForParsing = $sColorMode . 'a';
+                    $colorModeForParsing = 'rgba';
                     $mayHaveOptionalAlpha = true;
                     break;
+                case 'hsl':
+                    $colorModeForParsing = 'hsla';
+                    $mayHaveOptionalAlpha = true;
+                    break;
+                // These two cases are handled identically.
                 case 'rgba':
                 case 'hsla':
                     $colorModeForParsing = $sColorMode;
@@ -88,7 +92,6 @@ class Color extends CSSFunction
                 default:
                     $colorModeForParsing = $sColorMode;
                     $mayHaveOptionalAlpha = false;
-                    break;
             }
 
             $bContainsVar = false;
@@ -105,7 +108,7 @@ class Color extends CSSFunction
                 // This must be done first, to consume comments as well, so that the `comes` test will work.
                 $oParserState->consumeWhiteSpace();
 
-                // With a var argument, the function can have fewer arguments.
+                // With a `var` argument, the function can have fewer arguments.
                 // And as of CSS Color Module Level 4, the alpha argument is optional.
                 $canCloseNow =
                     $bContainsVar ||

--- a/tests/Unit/Value/ColorTest.php
+++ b/tests/Unit/Value/ColorTest.php
@@ -62,15 +62,15 @@ final class ColorTest extends TestCase
                 'rgba(0, 119, 0, 50%)',
                 'rgba(0,119,0,50%)',
             ],
-            /*
             'legacy rgb as rgba' => [
                 'rgba(0, 119, 0)',
-                'rgb(0,119,0)',
+                '#070',
             ],
             'legacy rgba as rgb' => [
                 'rgb(0, 119, 0, 0.5)',
                 'rgba(0,119,0,.5)',
             ],
+            /*
             'modern rgb' => [
                 'rgb(0 119 0)',
                 'rgb(0,119,0)',
@@ -112,16 +112,14 @@ final class ColorTest extends TestCase
                 'hsla(120, 100%, 25%, 50%)',
                 'hsla(120,100%,25%,50%)',
             ],
-            /*
             'legacy hsl as hsla' => [
                 'hsla(120, 100%, 25%)',
                 'hsl(120,100%,25%)',
             ],
             'legacy hsla as hsl' => [
                 'hsl(120, 100%, 25%, 0.5)',
-                'hsla(120,100%,25%,0.5)',
+                'hsla(120,100%,25%,.5)',
             ],
-            //*/
         ];
     }
 


### PR DESCRIPTION
As of CSS Color Module Level 4, `rgba` is an alias of `rgb`; likewise, `hsla` is an alias of `hsl`.

This change allows any of the above color functions to contain either three or four arguments, with alpha assumed as the fourth, and allowed to be absent.