### PR TITLE
[TASK] Disable PHP CS Fixer `statement_indentation` rule

### DIFF
--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -96,5 +96,8 @@ return (new \PhpCsFixer\Config())
             // string notation
             'single_quote' => true,
             'string_implicit_backslashes' => ['single_quoted' => 'escape'],
+
+            // whitespace
+            'statement_indentation' => false,
         ]
     );


### PR DESCRIPTION
Unfortunately, this has been broken for comments preceding a `case` within a `switch` since PHP CS Fixer version 3.9.1.

See
- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6572
- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6490
- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6490#issuecomment-1874110032
- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7624

A configuration option `stick_comment_to_next_continuous_control_statement` was added, but this has not yet been extended to cover `case` within a `switch`.

So, for the time being, we cannot use this rule if we want to comment `case`s within a `swtich`.