### PR TITLE
[TASK] Use native `void` return type declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Please also have a look at our
 
 ### Changed
 
+- Use more native type declarations and strict mode
+  (#641, #772, #774, #778, #804)
 - Mark parsing-internal classes and methods as `@internal` (#674)
 - Block installations on unsupported higher PHP versions (#691)
 - Improve performance of `Value::parseValue` with many delimiters by refactoring

--- a/src/CSSList/CSSBlockList.php
+++ b/src/CSSList/CSSBlockList.php
@@ -30,10 +30,8 @@ abstract class CSSBlockList extends CSSList
 
     /**
      * @param array<int, DeclarationBlock> $aResult
-     *
-     * @return void
      */
-    protected function allDeclarationBlocks(array &$aResult)
+    protected function allDeclarationBlocks(array &$aResult): void
     {
         foreach ($this->aContents as $mContent) {
             if ($mContent instanceof DeclarationBlock) {
@@ -46,10 +44,8 @@ abstract class CSSBlockList extends CSSList
 
     /**
      * @param array<int, RuleSet> $aResult
-     *
-     * @return void
      */
-    protected function allRuleSets(array &$aResult)
+    protected function allRuleSets(array &$aResult): void
     {
         foreach ($this->aContents as $mContent) {
             if ($mContent instanceof RuleSet) {
@@ -65,11 +61,13 @@ abstract class CSSBlockList extends CSSList
      * @param array<int, Value> $aResult
      * @param string|null $sSearchString
      * @param bool $bSearchInFunctionArguments
-     *
-     * @return void
      */
-    protected function allValues($oElement, array &$aResult, $sSearchString = null, $bSearchInFunctionArguments = false)
-    {
+    protected function allValues(
+        $oElement,
+        array &$aResult,
+        $sSearchString = null,
+        $bSearchInFunctionArguments = false
+    ): void {
         if ($oElement instanceof CSSBlockList) {
             foreach ($oElement->getContents() as $oContent) {
                 $this->allValues($oContent, $aResult, $sSearchString, $bSearchInFunctionArguments);
@@ -95,10 +93,8 @@ abstract class CSSBlockList extends CSSList
     /**
      * @param array<int, Selector> $aResult
      * @param string|null $sSpecificitySearch
-     *
-     * @return void
      */
-    protected function allSelectors(array &$aResult, $sSpecificitySearch = null)
+    protected function allSelectors(array &$aResult, $sSpecificitySearch = null): void
     {
         /** @var array<int, DeclarationBlock> $aDeclarationBlocks */
         $aDeclarationBlocks = [];

--- a/src/Comment/Commentable.php
+++ b/src/Comment/Commentable.php
@@ -8,10 +8,8 @@ interface Commentable
 {
     /**
      * @param array<array-key, Comment> $aComments
-     *
-     * @return void
      */
-    public function addComments(array $aComments);
+    public function addComments(array $aComments): void;
 
     /**
      * @return array<array-key, Comment>
@@ -20,8 +18,6 @@ interface Commentable
 
     /**
      * @param array<array-key, Comment> $aComments
-     *
-     * @return void
      */
-    public function setComments(array $aComments);
+    public function setComments(array $aComments): void;
 }

--- a/src/Property/Charset.php
+++ b/src/Property/Charset.php
@@ -54,8 +54,6 @@ class Charset implements AtRule
 
     /**
      * @param string|CSSString $oCharset
-     *
-     * @return void
      */
     public function setCharset($sCharset): void
     {
@@ -96,8 +94,6 @@ class Charset implements AtRule
 
     /**
      * @param array<array-key, Comment> $aComments
-     *
-     * @return void
      */
     public function addComments(array $aComments): void
     {
@@ -114,8 +110,6 @@ class Charset implements AtRule
 
     /**
      * @param array<array-key, Comment> $aComments
-     *
-     * @return void
      */
     public function setComments(array $aComments): void
     {

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -106,8 +106,6 @@ class Selector
 
     /**
      * @param string $sSelector
-     *
-     * @return void
      */
     public function setSelector($sSelector): void
     {

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -228,8 +228,6 @@ class Rule implements Renderable, Commentable
 
     /**
      * @param array<int, int> $aModifiers
-     *
-     * @return void
      */
     public function setIeHack(array $aModifiers): void
     {


### PR DESCRIPTION
Also include previous changes for adding native type declarations or strict mode into the changelog.