### PR TITLE
[TASK] Avoid using `@covers` annotations referencing methods

### DIFF
--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -12,9 +12,3 @@ parameters:
 			count: 2
 			path: ../src/RuleSet/DeclarationBlock.php
 
-		-
-			message: '#^@covers value \\Sabberworm\\CSS\\Value\\Value\:\:parseValue\(\) references an invalid method\.$#'
-			identifier: phpunit.coversMethod
-			count: 2
-			path: ../tests/ParserTest.php
-

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -26,16 +26,17 @@ use Sabberworm\CSS\Value\Size;
 use Sabberworm\CSS\Value\URL;
 
 /**
+ * @covers \Sabberworm\CSS\CSSList\Document
  * @covers \Sabberworm\CSS\Parser
- * @covers \Sabberworm\CSS\CSSList\Document::parse
- * @covers \Sabberworm\CSS\Rule\Rule::parse
- * @covers \Sabberworm\CSS\RuleSet\DeclarationBlock::parse
- * @covers \Sabberworm\CSS\Value\CalcFunction::parse
- * @covers \Sabberworm\CSS\Value\Color::parse
- * @covers \Sabberworm\CSS\Value\CSSString::parse
- * @covers \Sabberworm\CSS\Value\LineName::parse
- * @covers \Sabberworm\CSS\Value\Size::parse
- * @covers \Sabberworm\CSS\Value\URL::parse
+ * @covers \Sabberworm\CSS\RuleSet\DeclarationBlock
+ * @covers \Sabberworm\CSS\Rule\Rule
+ * @covers \Sabberworm\CSS\Value\CSSString
+ * @covers \Sabberworm\CSS\Value\CalcFunction
+ * @covers \Sabberworm\CSS\Value\Color
+ * @covers \Sabberworm\CSS\Value\LineName
+ * @covers \Sabberworm\CSS\Value\Size
+ * @covers \Sabberworm\CSS\Value\URL
+ * @covers \Sabberworm\CSS\Value\Value
  */
 final class ParserTest extends TestCase
 {
@@ -971,8 +972,6 @@ body {background-color: red;}';
     /**
      * Ensure that a missing property value raises an exception.
      *
-     * @covers \Sabberworm\CSS\Value\Value::parseValue()
-     *
      * @test
      */
     public function missingPropertyValueStrict(): void
@@ -984,8 +983,6 @@ body {background-color: red;}';
 
     /**
      * Ensure that a missing property value is ignored when in lenient parsing mode.
-     *
-     * @covers \Sabberworm\CSS\Value\Value::parseValue()
      *
      * @test
      */

--- a/tests/RuleSet/LenientParsingTest.php
+++ b/tests/RuleSet/LenientParsingTest.php
@@ -11,16 +11,16 @@ use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 use Sabberworm\CSS\Settings;
 
 /**
+ * @covers \Sabberworm\CSS\CSSList\Document
  * @covers \Sabberworm\CSS\Parser
- * @covers \Sabberworm\CSS\CSSList\Document::parse
- * @covers \Sabberworm\CSS\Rule\Rule::parse
- * @covers \Sabberworm\CSS\RuleSet\DeclarationBlock::parse
- * @covers \Sabberworm\CSS\Value\CalcFunction::parse
- * @covers \Sabberworm\CSS\Value\Color::parse
- * @covers \Sabberworm\CSS\Value\CSSString::parse
- * @covers \Sabberworm\CSS\Value\LineName::parse
- * @covers \Sabberworm\CSS\Value\Size::parse
- * @covers \Sabberworm\CSS\Value\URL::parse
+ * @covers \Sabberworm\CSS\RuleSet\DeclarationBlock
+ * @covers \Sabberworm\CSS\Rule\Rule
+ * @covers \Sabberworm\CSS\Value\CSSString
+ * @covers \Sabberworm\CSS\Value\CalcFunction
+ * @covers \Sabberworm\CSS\Value\Color
+ * @covers \Sabberworm\CSS\Value\LineName
+ * @covers \Sabberworm\CSS\Value\Size
+ * @covers \Sabberworm\CSS\Value\URL
  */
 final class LenientParsingTest extends TestCase
 {


### PR DESCRIPTION
According to the PHPUnit documentation [1], `@covers` annotations are only recommended to reference classes (and global functions), but not methods from classes.

Also sort the `@covers` annotations.

Note: This will probably artificially increase our calculated code coverage numbers until we migrate our tests to more focused unit tests.

Closes #809

[1] https://docs.phpunit.de/en/8.5/annotations.html#covers