### PR TITLE
[CLEANUP] Use spaces for indenting the fixture CSS files

### DIFF
--- a/tests/fixtures/-fault-tolerance.css
+++ b/tests/fixtures/-fault-tolerance.css
@@ -1,15 +1,15 @@
 .test1 {
-	//gaga: hello;
+    //gaga: hello;
 }
 
 .test2 {
-	*hello: 1;
-	hello: 2.2;
-	hello: 2000000000000.2;
+    *hello: 1;
+    hello: 2.2;
+    hello: 2000000000000.2;
 }
 
 #test {
-	#hello: 1}
+    #hello: 1}
 
 #test2 {
-	help: none;
+    help: none;

--- a/tests/fixtures/1readme.css
+++ b/tests/fixtures/1readme.css
@@ -4,7 +4,7 @@
   font-family: "CrassRoots";
   src: url("../media/cr.ttf")
 }
-	
+
 html, body {
-	font-size: 1.6em
+    font-size: 1.6em
 }

--- a/tests/fixtures/2readme.css
+++ b/tests/fixtures/2readme.css
@@ -1,5 +1,5 @@
 #header {
-	margin: 10px 2em 1cm 2%;
-	font-family: Verdana, Helvetica, "Gill Sans", sans-serif;
-	color: red !important;
+    margin: 10px 2em 1cm 2%;
+    font-family: Verdana, Helvetica, "Gill Sans", sans-serif;
+    color: red !important;
 }

--- a/tests/fixtures/atrules.css
+++ b/tests/fixtures/atrules.css
@@ -1,28 +1,28 @@
 @charset "utf-8";
 
 @font-face {
-	font-family: "CrassRoots";
-	src: url("../media/cr.ttf")
+    font-family: "CrassRoots";
+    src: url("../media/cr.ttf")
 }
 
 html, body {
-	font-size: -0.6em
+    font-size: -0.6em
 }
 
 @keyframes mymove {
-	from { top: 0px; }
-	to { top: 200px; }
+    from { top: 0px; }
+    to { top: 200px; }
 }
 
 @-moz-keyframes some-move {
-	from { top: 0px; }
-	to { top: 200px; }
+    from { top: 0px; }
+    to { top: 200px; }
 }
 
 @supports ( (perspective: 10px) or (-moz-perspective: 10px) or (-webkit-perspective: 10px) or (-ms-perspective: 10px) or (-o-perspective: 10px) ) {
-	body {
-		font-family: 'Helvetica';
-	}
+    body {
+        font-family: 'Helvetica';
+    }
 }
 
 @page :pseudo-class {

--- a/tests/fixtures/calc.css
+++ b/tests/fixtures/calc.css
@@ -1,7 +1,7 @@
 div { width: calc(100% / 4); }
 div { margin-top: calc(-120% - 4px); }
 div {
-	height: -webkit-calc(9/16 * 100%)!important;
-	width: -moz-calc((50px - 50%)*2);
+    height: -webkit-calc(9/16 * 100%)!important;
+    width: -moz-calc((50px - 50%)*2);
 }
 div { width: calc(50% - ( ( 4% ) * 0.5 ) ); }

--- a/tests/fixtures/case-insensitivity.css
+++ b/tests/fixtures/case-insensitivity.css
@@ -6,10 +6,10 @@
 }
 
 #myid {
-	CaSe: insensitive !imPORTANT;
-	frequency: 30hz;
-	font-size: 1EM;
-	color: RGB(255, 255, 0);
-	color: hSL(40, 40%, 30%);
-	font-Family: Arial; /* The value needs to remain capitalized */
+    CaSe: insensitive !imPORTANT;
+    frequency: 30hz;
+    font-size: 1EM;
+    color: RGB(255, 255, 0);
+    color: hSL(40, 40%, 30%);
+    font-Family: Arial; /* The value needs to remain capitalized */
 }

--- a/tests/fixtures/colortest.css
+++ b/tests/fixtures/colortest.css
@@ -1,29 +1,29 @@
 #mine {
-	color: red;
-	border-color: rgb(10, 100, 230);
-	border-color: rgba(10, 100, 231, 0.3);
-	outline-color: #222;
-	background-color: #232323;
+    color: red;
+    border-color: rgb(10, 100, 230);
+    border-color: rgba(10, 100, 231, 0.3);
+    outline-color: #222;
+    background-color: #232323;
 }
 
 #yours {
-	background-color: hsl(220, 10%, 220%);
-	background-color: hsla(220, 10%, 220%, 0.3);
-	outline-color: #22;
+    background-color: hsl(220, 10%, 220%);
+    background-color: hsla(220, 10%, 220%, 0.3);
+    outline-color: #22;
 }
 
 #variables {
-	background-color: rgb(var(--some-rgb));
-	background-color: rgb(var(--r), var(--g), var(--b));
-	background-color: rgb(255, var(--g), var(--b));
-	background-color: rgb(255, 255, var(--b));
-	background-color: rgb(255, var(--rg));
+    background-color: rgb(var(--some-rgb));
+    background-color: rgb(var(--r), var(--g), var(--b));
+    background-color: rgb(255, var(--g), var(--b));
+    background-color: rgb(255, 255, var(--b));
+    background-color: rgb(255, var(--rg));
 
-	background-color: hsl(var(--some-hsl));
+    background-color: hsl(var(--some-hsl));
 }
 
 #variables-alpha {
-	background-color: rgba(var(--some-rgb), 0.1);
-	background-color: rgba(var(--some-rg), 255, 0.1);
-	background-color: hsla(var(--some-hsl), 0.1);
+    background-color: rgba(var(--some-rgb), 0.1);
+    background-color: rgba(var(--some-rg), 255, 0.1);
+    background-color: hsla(var(--some-hsl), 0.1);
 }

--- a/tests/fixtures/escaped-tokens.css
+++ b/tests/fixtures/escaped-tokens.css
@@ -2,6 +2,6 @@
  * Special case function-like tokens, with an escape backslash followed by a non-newline and non-hex digit character, should be parsed as the appropriate \Sabberworm\CSS\Value\ type
  */
 body {
-	background: u\rl("//example.org/picture.jpg");
-	height: ca\lc(100% - 1px);
-} 
+    background: u\rl("//example.org/picture.jpg");
+    height: ca\lc(100% - 1px);
+}

--- a/tests/fixtures/ie.css
+++ b/tests/fixtures/ie.css
@@ -1,6 +1,6 @@
 .nav-thumb-wrapper:hover img, a.activeSlide img {
-	filter: alpha(opacity=100);
-	-moz-opacity: 1;
-	-khtml-opacity: 1;
-	opacity: 1;
-}	
+    filter: alpha(opacity=100);
+    -moz-opacity: 1;
+    -khtml-opacity: 1;
+    opacity: 1;
+}

--- a/tests/fixtures/inner-color.css
+++ b/tests/fixtures/inner-color.css
@@ -1,3 +1,3 @@
 test {
-	background: -webkit-gradient(linear, 0 0, 0 bottom, from(#006cad), to(hsl(202, 100%, 49%)));
+    background: -webkit-gradient(linear, 0 0, 0 bottom, from(#006cad), to(hsl(202, 100%, 49%)));
 }

--- a/tests/fixtures/missing-property-value.css
+++ b/tests/fixtures/missing-property-value.css
@@ -1,4 +1,4 @@
 div {
-	display: inline-block;
-	display:
+    display: inline-block;
+    display:
 }

--- a/tests/fixtures/namespaces.css
+++ b/tests/fixtures/namespaces.css
@@ -10,9 +10,9 @@
 
 
 foo|test {
-	gaga: 1;
+    gaga: 1;
 }
 
 |test {
-	gaga: 2;
+    gaga: 2;
 }

--- a/tests/fixtures/nested.css
+++ b/tests/fixtures/nested.css
@@ -1,17 +1,17 @@
 html {
-	some: -test(val1);
+    some: -test(val1);
 }
 
 html {
-	some-other: -test(val1);
+    some-other: -test(val1);
 }
 
 @media screen {
-	html {
-		some: -test(val2);
-	}
+    html {
+        some: -test(val2);
+    }
 }
 
 #unrelated {
-	other: yes;
+    other: yes;
 }

--- a/tests/fixtures/slashed.css
+++ b/tests/fixtures/slashed.css
@@ -1,4 +1,4 @@
 .test {
-	font: 12px/1.5 Verdana, Arial, sans-serif;
-	border-radius: 5px 10px 5px 10px / 10px 5px 10px 5px;
+    font: 12px/1.5 Verdana, Arial, sans-serif;
+    border-radius: 5px 10px 5px 10px / 10px 5px 10px 5px;
 }

--- a/tests/fixtures/specificity.css
+++ b/tests/fixtures/specificity.css
@@ -3,5 +3,5 @@
 .help:hover,
 li.green,
 ol li::before {
-	font-family: Helvetica;
+    font-family: Helvetica;
 }

--- a/tests/fixtures/url.css
+++ b/tests/fixtures/url.css
@@ -1,4 +1,4 @@
 body { background: #FFFFFF url("https://somesite.com/images/someimage.gif") repeat top center; }
 body {
-	background-url: url("https://somesite.com/images/someimage.gif");
+    background-url: url("https://somesite.com/images/someimage.gif");
 }

--- a/tests/fixtures/values.css
+++ b/tests/fixtures/values.css
@@ -1,15 +1,15 @@
 #header {
-	margin: 10px 2em 1cm 2%;
-	font-family: Verdana, Helvetica, "Gill Sans", sans-serif;
-	font-size: 10px;
-	color: red !important;
-	background-color: green;
-	background-color: rgba(0,128,0,0.7);
-	frequency: 30Hz;
+    margin: 10px 2em 1cm 2%;
+    font-family: Verdana, Helvetica, "Gill Sans", sans-serif;
+    font-size: 10px;
+    color: red !important;
+    background-color: green;
+    background-color: rgba(0,128,0,0.7);
+    frequency: 30Hz;
     transform: rotate(1turn);
 }
 
 body {
-	color: green;
-	font: 75% "Lucida Grande", "Trebuchet MS", Verdana, sans-serif;
+    color: green;
+    font: 75% "Lucida Grande", "Trebuchet MS", Verdana, sans-serif;
 }

--- a/tests/fixtures/whitespace.css
+++ b/tests/fixtures/whitespace.css
@@ -1,3 +1,3 @@
 .test {
-	background-image : url ( 4px ) ;
+    background-image : url ( 4px ) ;
 }


### PR DESCRIPTION
This makes editing the fixture files a bit easier as all other files in this project also use spaces for indentation, not tabs.

Note: This has no effect on CSS is rendered (which still defaults to tabs at the moment).