### PR TITLE
[BUGFIX] Correct type annotation for `ValueList` components

### DIFF
--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -20,7 +20,7 @@ class CSSFunction extends ValueList
 
     /**
      * @param string $sName
-     * @param RuleValueList|array<int, Value|string> $aArguments
+     * @param RuleValueList|array<array-key, Value|string> $aArguments
      * @param string $sSeparator
      * @param int $iLineNo
      */
@@ -91,7 +91,7 @@ class CSSFunction extends ValueList
     }
 
     /**
-     * @return array<int, Value|string>
+     * @return array<array-key, Value|string>
      */
     public function getArguments()
     {

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -16,7 +16,7 @@ use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 class Color extends CSSFunction
 {
     /**
-     * @param array<int, Value|string> $colorValues
+     * @param array<array-key, Value|string> $colorValues
      * @param int $lineNumber
      */
     public function __construct(array $colorValues, $lineNumber = 0)
@@ -193,7 +193,7 @@ class Color extends CSSFunction
     }
 
     /**
-     * @return array<int, Value|string>
+     * @return array<array-key, Value|string>
      */
     public function getColor()
     {
@@ -201,7 +201,7 @@ class Color extends CSSFunction
     }
 
     /**
-     * @param array<int, Value|string> $colorValues
+     * @param array<array-key, Value|string> $colorValues
      */
     public function setColor(array $colorValues): void
     {

--- a/src/Value/ValueList.php
+++ b/src/Value/ValueList.php
@@ -15,7 +15,7 @@ use Sabberworm\CSS\OutputFormat;
 abstract class ValueList extends Value
 {
     /**
-     * @var array<int, Value|string>
+     * @var array<array-key, Value|string>
      */
     protected $aComponents;
 
@@ -25,7 +25,7 @@ abstract class ValueList extends Value
     protected $sSeparator;
 
     /**
-     * @param array<int, Value|string>|Value|string $aComponents
+     * @param array<array-key, Value|string>|Value|string $aComponents
      * @param string $sSeparator
      * @param int $iLineNo
      */
@@ -48,7 +48,7 @@ abstract class ValueList extends Value
     }
 
     /**
-     * @return array<int, Value|string>
+     * @return array<array-key, Value|string>
      */
     public function getListComponents()
     {
@@ -56,7 +56,7 @@ abstract class ValueList extends Value
     }
 
     /**
-     * @param array<int, Value|string> $aComponents
+     * @param array<array-key, Value|string> $aComponents
      */
     public function setListComponents(array $aComponents): void
     {


### PR DESCRIPTION
The `Color` class uses this property (`aComponents`) as an associative array. Therefore all related type annotations need `array-key` rather than `int` for the array key type.