### PR TITLE
[BUGFIX] Create `Size` with correct types in `expandBackgroundShorthand`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Create `Size` with correct types in `expandBackgroundShorthand` (#814)
 - Parse `@font-face` `src` property as comma-delimited list (#794)
 
 ## 8.7.0: Add support for PHP 8.4

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -432,8 +432,8 @@ class DeclarationBlock extends RuleSet
             'background-repeat' => ['repeat'],
             'background-attachment' => ['scroll'],
             'background-position' => [
-                new Size(0, '%', null, false, $this->iLineNo),
-                new Size(0, '%', null, false, $this->iLineNo),
+                new Size(0, '%', false, $this->iLineNo),
+                new Size(0, '%', false, $this->iLineNo),
             ],
         ];
         $mRuleValue = $oRule->getValue();


### PR DESCRIPTION
This is the v8.x backport of #814.