### PR TITLE
[CLEANUP] Avoid Hungarian notation for `oParserState`

### DIFF
--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -29,10 +29,10 @@ class Document extends CSSBlockList
     /**
      * @throws SourceException
      */
-    public static function parse(ParserState $oParserState): Document
+    public static function parse(ParserState $parserState): Document
     {
-        $oDocument = new Document($oParserState->currentLine());
-        CSSList::parseList($oParserState, $oDocument);
+        $oDocument = new Document($parserState->currentLine());
+        CSSList::parseList($parserState, $oDocument);
         return $oDocument;
     }
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -16,7 +16,7 @@ class Parser
     /**
      * @var ParserState
      */
-    private $oParserState;
+    private $parserState;
 
     /**
      * @param string $sText the complete CSS as text (i.e., usually the contents of a CSS file)
@@ -28,7 +28,7 @@ class Parser
         if ($oParserSettings === null) {
             $oParserSettings = Settings::create();
         }
-        $this->oParserState = new ParserState($sText, $oParserSettings, $lineNumber);
+        $this->parserState = new ParserState($sText, $oParserSettings, $lineNumber);
     }
 
     /**
@@ -38,6 +38,6 @@ class Parser
      */
     public function parse(): Document
     {
-        return Document::parse($this->oParserState);
+        return Document::parse($this->parserState);
     }
 }

--- a/src/Parsing/Anchor.php
+++ b/src/Parsing/Anchor.php
@@ -17,19 +17,19 @@ class Anchor
     /**
      * @var ParserState
      */
-    private $oParserState;
+    private $parserState;
 
     /**
      * @param int $iPosition
      */
-    public function __construct($iPosition, ParserState $oParserState)
+    public function __construct($iPosition, ParserState $parserState)
     {
         $this->iPosition = $iPosition;
-        $this->oParserState = $oParserState;
+        $this->parserState = $parserState;
     }
 
     public function backtrack(): void
     {
-        $this->oParserState->setPosition($this->iPosition);
+        $this->parserState->setPosition($this->iPosition);
     }
 }

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -76,39 +76,39 @@ class Rule implements Renderable, Commentable
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    public static function parse(ParserState $oParserState): Rule
+    public static function parse(ParserState $parserState): Rule
     {
-        $aComments = $oParserState->consumeWhiteSpace();
+        $aComments = $parserState->consumeWhiteSpace();
         $oRule = new Rule(
-            $oParserState->parseIdentifier(!$oParserState->comes('--')),
-            $oParserState->currentLine(),
-            $oParserState->currentColumn()
+            $parserState->parseIdentifier(!$parserState->comes('--')),
+            $parserState->currentLine(),
+            $parserState->currentColumn()
         );
         $oRule->setComments($aComments);
-        $oRule->addComments($oParserState->consumeWhiteSpace());
-        $oParserState->consume(':');
-        $oValue = Value::parseValue($oParserState, self::listDelimiterForRule($oRule->getRule()));
+        $oRule->addComments($parserState->consumeWhiteSpace());
+        $parserState->consume(':');
+        $oValue = Value::parseValue($parserState, self::listDelimiterForRule($oRule->getRule()));
         $oRule->setValue($oValue);
-        if ($oParserState->getSettings()->bLenientParsing) {
-            while ($oParserState->comes('\\')) {
-                $oParserState->consume('\\');
-                $oRule->addIeHack($oParserState->consume());
-                $oParserState->consumeWhiteSpace();
+        if ($parserState->getSettings()->bLenientParsing) {
+            while ($parserState->comes('\\')) {
+                $parserState->consume('\\');
+                $oRule->addIeHack($parserState->consume());
+                $parserState->consumeWhiteSpace();
             }
         }
-        $oParserState->consumeWhiteSpace();
-        if ($oParserState->comes('!')) {
-            $oParserState->consume('!');
-            $oParserState->consumeWhiteSpace();
-            $oParserState->consume('important');
+        $parserState->consumeWhiteSpace();
+        if ($parserState->comes('!')) {
+            $parserState->consume('!');
+            $parserState->consumeWhiteSpace();
+            $parserState->consume('important');
             $oRule->setIsImportant(true);
         }
-        $oParserState->consumeWhiteSpace();
-        while ($oParserState->comes(';')) {
-            $oParserState->consume(';');
+        $parserState->consumeWhiteSpace();
+        while ($parserState->comes(';')) {
+            $parserState->consume(';');
         }
 
-        $oParserState->consumeWhiteSpace();
+        $parserState->consumeWhiteSpace();
 
         return $oRule;
     }

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -52,32 +52,32 @@ class DeclarationBlock extends RuleSet
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
      */
-    public static function parse(ParserState $oParserState, $oList = null)
+    public static function parse(ParserState $parserState, $oList = null)
     {
         $aComments = [];
-        $oResult = new DeclarationBlock($oParserState->currentLine());
+        $oResult = new DeclarationBlock($parserState->currentLine());
         try {
             $aSelectorParts = [];
             $sStringWrapperChar = false;
             do {
-                $aSelectorParts[] = $oParserState->consume(1)
-                    . $oParserState->consumeUntil(['{', '}', '\'', '"'], false, false, $aComments);
-                if (\in_array($oParserState->peek(), ['\'', '"'], true) && \substr(\end($aSelectorParts), -1) != '\\') {
+                $aSelectorParts[] = $parserState->consume(1)
+                    . $parserState->consumeUntil(['{', '}', '\'', '"'], false, false, $aComments);
+                if (\in_array($parserState->peek(), ['\'', '"'], true) && \substr(\end($aSelectorParts), -1) != '\\') {
                     if ($sStringWrapperChar === false) {
-                        $sStringWrapperChar = $oParserState->peek();
-                    } elseif ($sStringWrapperChar == $oParserState->peek()) {
+                        $sStringWrapperChar = $parserState->peek();
+                    } elseif ($sStringWrapperChar == $parserState->peek()) {
                         $sStringWrapperChar = false;
                     }
                 }
-            } while (!\in_array($oParserState->peek(), ['{', '}'], true) || $sStringWrapperChar !== false);
+            } while (!\in_array($parserState->peek(), ['{', '}'], true) || $sStringWrapperChar !== false);
             $oResult->setSelectors(\implode('', $aSelectorParts), $oList);
-            if ($oParserState->comes('{')) {
-                $oParserState->consume(1);
+            if ($parserState->comes('{')) {
+                $parserState->consume(1);
             }
         } catch (UnexpectedTokenException $e) {
-            if ($oParserState->getSettings()->bLenientParsing) {
-                if (!$oParserState->comes('}')) {
-                    $oParserState->consumeUntil('}', false, true);
+            if ($parserState->getSettings()->bLenientParsing) {
+                if (!$parserState->comes('}')) {
+                    $parserState->consumeUntil('}', false, true);
                 }
                 return false;
             } else {
@@ -85,7 +85,7 @@ class DeclarationBlock extends RuleSet
             }
         }
         $oResult->setComments($aComments);
-        RuleSet::parseRuleSet($oParserState, $oResult);
+        RuleSet::parseRuleSet($parserState, $oResult);
         return $oResult;
     }
 

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -53,25 +53,25 @@ abstract class RuleSet implements Renderable, Commentable
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
      */
-    public static function parseRuleSet(ParserState $oParserState, RuleSet $oRuleSet): void
+    public static function parseRuleSet(ParserState $parserState, RuleSet $oRuleSet): void
     {
-        while ($oParserState->comes(';')) {
-            $oParserState->consume(';');
+        while ($parserState->comes(';')) {
+            $parserState->consume(';');
         }
-        while (!$oParserState->comes('}')) {
+        while (!$parserState->comes('}')) {
             $oRule = null;
-            if ($oParserState->getSettings()->bLenientParsing) {
+            if ($parserState->getSettings()->bLenientParsing) {
                 try {
-                    $oRule = Rule::parse($oParserState);
+                    $oRule = Rule::parse($parserState);
                 } catch (UnexpectedTokenException $e) {
                     try {
-                        $sConsume = $oParserState->consumeUntil(["\n", ';', '}'], true);
+                        $sConsume = $parserState->consumeUntil(["\n", ';', '}'], true);
                         // We need to “unfind” the matches to the end of the ruleSet as this will be matched later
-                        if ($oParserState->streql(\substr($sConsume, -1), '}')) {
-                            $oParserState->backtrack(1);
+                        if ($parserState->streql(\substr($sConsume, -1), '}')) {
+                            $parserState->backtrack(1);
                         } else {
-                            while ($oParserState->comes(';')) {
-                                $oParserState->consume(';');
+                            while ($parserState->comes(';')) {
+                                $parserState->consume(';');
                             }
                         }
                     } catch (UnexpectedTokenException $e) {
@@ -80,13 +80,13 @@ abstract class RuleSet implements Renderable, Commentable
                     }
                 }
             } else {
-                $oRule = Rule::parse($oParserState);
+                $oRule = Rule::parse($parserState);
             }
             if ($oRule instanceof Rule) {
                 $oRuleSet->addRule($oRule);
             }
         }
-        $oParserState->consume('}');
+        $parserState->consume('}');
     }
 
     /**

--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -40,14 +40,14 @@ class CSSFunction extends ValueList
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    public static function parse(ParserState $oParserState, bool $bIgnoreCase = false): CSSFunction
+    public static function parse(ParserState $parserState, bool $bIgnoreCase = false): CSSFunction
     {
-        $sName = self::parseName($oParserState, $bIgnoreCase);
-        $oParserState->consume('(');
-        $mArguments = self::parseArguments($oParserState);
+        $sName = self::parseName($parserState, $bIgnoreCase);
+        $parserState->consume('(');
+        $mArguments = self::parseArguments($parserState);
 
-        $oResult = new CSSFunction($sName, $mArguments, ',', $oParserState->currentLine());
-        $oParserState->consume(')');
+        $oResult = new CSSFunction($sName, $mArguments, ',', $parserState->currentLine());
+        $parserState->consume(')');
 
         return $oResult;
     }
@@ -57,9 +57,9 @@ class CSSFunction extends ValueList
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    private static function parseName(ParserState $oParserState, bool $bIgnoreCase = false): string
+    private static function parseName(ParserState $parserState, bool $bIgnoreCase = false): string
     {
-        return $oParserState->parseIdentifier($bIgnoreCase);
+        return $parserState->parseIdentifier($bIgnoreCase);
     }
 
     /**
@@ -69,9 +69,9 @@ class CSSFunction extends ValueList
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    private static function parseArguments(ParserState $oParserState)
+    private static function parseArguments(ParserState $parserState)
     {
-        return Value::parseValue($oParserState, ['=', ' ', ',']);
+        return Value::parseValue($parserState, ['=', ' ', ',']);
     }
 
     /**

--- a/src/Value/CSSString.php
+++ b/src/Value/CSSString.php
@@ -37,9 +37,9 @@ class CSSString extends PrimitiveValue
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    public static function parse(ParserState $oParserState): CSSString
+    public static function parse(ParserState $parserState): CSSString
     {
-        $sBegin = $oParserState->peek();
+        $sBegin = $parserState->peek();
         $sQuote = null;
         if ($sBegin === "'") {
             $sQuote = "'";
@@ -47,29 +47,29 @@ class CSSString extends PrimitiveValue
             $sQuote = '"';
         }
         if ($sQuote !== null) {
-            $oParserState->consume($sQuote);
+            $parserState->consume($sQuote);
         }
         $sResult = '';
         $sContent = null;
         if ($sQuote === null) {
             // Unquoted strings end in whitespace or with braces, brackets, parentheses
-            while (\preg_match('/[\\s{}()<>\\[\\]]/isu', $oParserState->peek()) !== 1) {
-                $sResult .= $oParserState->parseCharacter(false);
+            while (\preg_match('/[\\s{}()<>\\[\\]]/isu', $parserState->peek()) !== 1) {
+                $sResult .= $parserState->parseCharacter(false);
             }
         } else {
-            while (!$oParserState->comes($sQuote)) {
-                $sContent = $oParserState->parseCharacter(false);
+            while (!$parserState->comes($sQuote)) {
+                $sContent = $parserState->parseCharacter(false);
                 if ($sContent === null) {
                     throw new SourceException(
-                        "Non-well-formed quoted string {$oParserState->peek(3)}",
-                        $oParserState->currentLine()
+                        "Non-well-formed quoted string {$parserState->peek(3)}",
+                        $parserState->currentLine()
                     );
                 }
                 $sResult .= $sContent;
             }
-            $oParserState->consume($sQuote);
+            $parserState->consume($sQuote);
         }
-        return new CSSString($sResult, $oParserState->currentLine());
+        return new CSSString($sResult, $parserState->currentLine());
     }
 
     /**

--- a/src/Value/CalcFunction.php
+++ b/src/Value/CalcFunction.php
@@ -24,80 +24,80 @@ class CalcFunction extends CSSFunction
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
      */
-    public static function parse(ParserState $oParserState, bool $bIgnoreCase = false): CSSFunction
+    public static function parse(ParserState $parserState, bool $bIgnoreCase = false): CSSFunction
     {
         $aOperators = ['+', '-', '*', '/'];
-        $sFunction = $oParserState->parseIdentifier();
-        if ($oParserState->peek() != '(') {
+        $sFunction = $parserState->parseIdentifier();
+        if ($parserState->peek() != '(') {
             // Found ; or end of line before an opening bracket
-            throw new UnexpectedTokenException('(', $oParserState->peek(), 'literal', $oParserState->currentLine());
+            throw new UnexpectedTokenException('(', $parserState->peek(), 'literal', $parserState->currentLine());
         } elseif (!\in_array($sFunction, ['calc', '-moz-calc', '-webkit-calc'], true)) {
             // Found invalid calc definition. Example calc (...
-            throw new UnexpectedTokenException('calc', $sFunction, 'literal', $oParserState->currentLine());
+            throw new UnexpectedTokenException('calc', $sFunction, 'literal', $parserState->currentLine());
         }
-        $oParserState->consume('(');
-        $oCalcList = new CalcRuleValueList($oParserState->currentLine());
-        $oList = new RuleValueList(',', $oParserState->currentLine());
+        $parserState->consume('(');
+        $oCalcList = new CalcRuleValueList($parserState->currentLine());
+        $oList = new RuleValueList(',', $parserState->currentLine());
         $iNestingLevel = 0;
         $iLastComponentType = null;
-        while (!$oParserState->comes(')') || $iNestingLevel > 0) {
-            if ($oParserState->isEnd() && $iNestingLevel === 0) {
+        while (!$parserState->comes(')') || $iNestingLevel > 0) {
+            if ($parserState->isEnd() && $iNestingLevel === 0) {
                 break;
             }
 
-            $oParserState->consumeWhiteSpace();
-            if ($oParserState->comes('(')) {
+            $parserState->consumeWhiteSpace();
+            if ($parserState->comes('(')) {
                 $iNestingLevel++;
-                $oCalcList->addListComponent($oParserState->consume(1));
-                $oParserState->consumeWhiteSpace();
+                $oCalcList->addListComponent($parserState->consume(1));
+                $parserState->consumeWhiteSpace();
                 continue;
-            } elseif ($oParserState->comes(')')) {
+            } elseif ($parserState->comes(')')) {
                 $iNestingLevel--;
-                $oCalcList->addListComponent($oParserState->consume(1));
-                $oParserState->consumeWhiteSpace();
+                $oCalcList->addListComponent($parserState->consume(1));
+                $parserState->consumeWhiteSpace();
                 continue;
             }
             if ($iLastComponentType != CalcFunction::T_OPERAND) {
-                $oVal = Value::parsePrimitiveValue($oParserState);
+                $oVal = Value::parsePrimitiveValue($parserState);
                 $oCalcList->addListComponent($oVal);
                 $iLastComponentType = CalcFunction::T_OPERAND;
             } else {
-                if (\in_array($oParserState->peek(), $aOperators, true)) {
-                    if (($oParserState->comes('-') || $oParserState->comes('+'))) {
+                if (\in_array($parserState->peek(), $aOperators, true)) {
+                    if (($parserState->comes('-') || $parserState->comes('+'))) {
                         if (
-                            $oParserState->peek(1, -1) != ' '
-                            || !($oParserState->comes('- ')
-                                || $oParserState->comes('+ '))
+                            $parserState->peek(1, -1) != ' '
+                            || !($parserState->comes('- ')
+                                || $parserState->comes('+ '))
                         ) {
                             throw new UnexpectedTokenException(
-                                " {$oParserState->peek()} ",
-                                $oParserState->peek(1, -1) . $oParserState->peek(2),
+                                " {$parserState->peek()} ",
+                                $parserState->peek(1, -1) . $parserState->peek(2),
                                 'literal',
-                                $oParserState->currentLine()
+                                $parserState->currentLine()
                             );
                         }
                     }
-                    $oCalcList->addListComponent($oParserState->consume(1));
+                    $oCalcList->addListComponent($parserState->consume(1));
                     $iLastComponentType = CalcFunction::T_OPERATOR;
                 } else {
                     throw new UnexpectedTokenException(
                         \sprintf(
                             'Next token was expected to be an operand of type %s. Instead "%s" was found.',
                             \implode(', ', $aOperators),
-                            $oParserState->peek()
+                            $parserState->peek()
                         ),
                         '',
                         'custom',
-                        $oParserState->currentLine()
+                        $parserState->currentLine()
                     );
                 }
             }
-            $oParserState->consumeWhiteSpace();
+            $parserState->consumeWhiteSpace();
         }
         $oList->addListComponent($oCalcList);
-        if (!$oParserState->isEnd()) {
-            $oParserState->consume(')');
+        if (!$parserState->isEnd()) {
+            $parserState->consume(')');
         }
-        return new CalcFunction($sFunction, $oList, ',', $oParserState->currentLine());
+        return new CalcFunction($sFunction, $oList, ',', $parserState->currentLine());
     }
 }

--- a/src/Value/LineName.php
+++ b/src/Value/LineName.php
@@ -24,27 +24,27 @@ class LineName extends ValueList
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
      */
-    public static function parse(ParserState $oParserState): LineName
+    public static function parse(ParserState $parserState): LineName
     {
-        $oParserState->consume('[');
-        $oParserState->consumeWhiteSpace();
+        $parserState->consume('[');
+        $parserState->consumeWhiteSpace();
         $aNames = [];
         do {
-            if ($oParserState->getSettings()->bLenientParsing) {
+            if ($parserState->getSettings()->bLenientParsing) {
                 try {
-                    $aNames[] = $oParserState->parseIdentifier();
+                    $aNames[] = $parserState->parseIdentifier();
                 } catch (UnexpectedTokenException $e) {
-                    if (!$oParserState->comes(']')) {
+                    if (!$parserState->comes(']')) {
                         throw $e;
                     }
                 }
             } else {
-                $aNames[] = $oParserState->parseIdentifier();
+                $aNames[] = $parserState->parseIdentifier();
             }
-            $oParserState->consumeWhiteSpace();
-        } while (!$oParserState->comes(']'));
-        $oParserState->consume(']');
-        return new LineName($aNames, $oParserState->currentLine());
+            $parserState->consumeWhiteSpace();
+        } while (!$parserState->comes(']'));
+        $parserState->consume(']');
+        return new LineName($aNames, $parserState->currentLine());
     }
 
     public function __toString(): string

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -87,39 +87,39 @@ class Size extends PrimitiveValue
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    public static function parse(ParserState $oParserState, $bIsColorComponent = false): Size
+    public static function parse(ParserState $parserState, $bIsColorComponent = false): Size
     {
         $sSize = '';
-        if ($oParserState->comes('-')) {
-            $sSize .= $oParserState->consume('-');
+        if ($parserState->comes('-')) {
+            $sSize .= $parserState->consume('-');
         }
-        while (\is_numeric($oParserState->peek()) || $oParserState->comes('.') || $oParserState->comes('e', true)) {
-            if ($oParserState->comes('.')) {
-                $sSize .= $oParserState->consume('.');
-            } elseif ($oParserState->comes('e', true)) {
-                $sLookahead = $oParserState->peek(1, 1);
+        while (\is_numeric($parserState->peek()) || $parserState->comes('.') || $parserState->comes('e', true)) {
+            if ($parserState->comes('.')) {
+                $sSize .= $parserState->consume('.');
+            } elseif ($parserState->comes('e', true)) {
+                $sLookahead = $parserState->peek(1, 1);
                 if (\is_numeric($sLookahead) || $sLookahead === '+' || $sLookahead === '-') {
-                    $sSize .= $oParserState->consume(2);
+                    $sSize .= $parserState->consume(2);
                 } else {
                     break; // Reached the unit part of the number like "em" or "ex"
                 }
             } else {
-                $sSize .= $oParserState->consume(1);
+                $sSize .= $parserState->consume(1);
             }
         }
 
         $sUnit = null;
         $aSizeUnits = self::getSizeUnits();
         foreach ($aSizeUnits as $iLength => &$aValues) {
-            $sKey = \strtolower($oParserState->peek($iLength));
+            $sKey = \strtolower($parserState->peek($iLength));
             if (\array_key_exists($sKey, $aValues)) {
                 if (($sUnit = $aValues[$sKey]) !== null) {
-                    $oParserState->consume($iLength);
+                    $parserState->consume($iLength);
                     break;
                 }
             }
         }
-        return new Size((float) $sSize, $sUnit, $bIsColorComponent, $oParserState->currentLine());
+        return new Size((float) $sSize, $sUnit, $bIsColorComponent, $parserState->currentLine());
     }
 
     /**

--- a/src/Value/URL.php
+++ b/src/Value/URL.php
@@ -34,29 +34,29 @@ class URL extends PrimitiveValue
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    public static function parse(ParserState $oParserState): URL
+    public static function parse(ParserState $parserState): URL
     {
-        $oAnchor = $oParserState->anchor();
+        $oAnchor = $parserState->anchor();
         $sIdentifier = '';
         for ($i = 0; $i < 3; $i++) {
-            $sChar = $oParserState->parseCharacter(true);
+            $sChar = $parserState->parseCharacter(true);
             if ($sChar === null) {
                 break;
             }
             $sIdentifier .= $sChar;
         }
-        $bUseUrl = $oParserState->streql($sIdentifier, 'url');
+        $bUseUrl = $parserState->streql($sIdentifier, 'url');
         if ($bUseUrl) {
-            $oParserState->consumeWhiteSpace();
-            $oParserState->consume('(');
+            $parserState->consumeWhiteSpace();
+            $parserState->consume('(');
         } else {
             $oAnchor->backtrack();
         }
-        $oParserState->consumeWhiteSpace();
-        $oResult = new URL(CSSString::parse($oParserState), $oParserState->currentLine());
+        $parserState->consumeWhiteSpace();
+        $oResult = new URL(CSSString::parse($parserState), $parserState->currentLine());
         if ($bUseUrl) {
-            $oParserState->consumeWhiteSpace();
-            $oParserState->consume(')');
+            $parserState->consumeWhiteSpace();
+            $parserState->consume(')');
         }
         return $oResult;
     }


### PR DESCRIPTION
Part of #756