### PR TITLE
[BUGFIX] Render RGB functions with "modern" syntax if required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please also have a look at our
 - Partial support for CSS Color Module Level 4:
     - `rgb` and `rgba`, and `hsl` and `hsla` are now aliases (#797}
     - Parse color functions that use the "modern" syntax (#800)
+    - Render RGB functions with "modern" syntax when required (#840)
 - Add a class diagram to the README (#482)
 - Add more tests (#449)
 

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -299,7 +299,7 @@ class Color extends CSSFunction
         $hasNumber = false;
         foreach ($this->aComponents as $key => $value) {
             if ($key === 'a') {
-                // ALpha can have units that don't match those of the RGB components in the "legacy" syntax.
+                // Alpha can have units that don't match those of the RGB components in the "legacy" syntax.
                 // So it is not necessary to check it.  It's also always last, hence `break` rather than `continue`.
                 break;
             }

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -303,9 +303,7 @@ class Color extends CSSFunction
      */
     private function shouldRenderInModernSyntax(): bool
     {
-        static $colorFunctionsThatWithMixedValueTypesCannotBeRenderedInLegacySyntax = ['rgb', 'rgba'];
-        $colorFunction = $this->getRealName();
-        if (!\in_array($colorFunction, $colorFunctionsThatWithMixedValueTypesCannotBeRenderedInLegacySyntax, true)) {
+        if (!$this->colorFunctionMayHaveMixedValueTypes($this->getRealName())) {
             return false;
         }
 
@@ -317,7 +315,7 @@ class Color extends CSSFunction
                 // So it is not necessary to check it.  It's also always last, hence `break` rather than `continue`.
                 break;
             }
-            if (!$value instanceof Size) {
+            if (!($value instanceof Size)) {
                 // Unexpected, unknown, or modified via the API
                 return false;
             }
@@ -334,6 +332,19 @@ class Color extends CSSFunction
         }
 
         return $hasPercentage && $hasNumber;
+    }
+
+    /**
+     * Some color functions, such as `rgb`,
+     * may have a mixture of `percentage`, `number`, or possibly other types in their arguments.
+     *
+     * Note that this excludes the alpha component, which is treated separately.
+     */
+    private function colorFunctionMayHaveMixedValueTypes(string $function): bool
+    {
+        $functionsThatMayHaveMixedValueTypes = ['rgb', 'rgba'];
+
+        return \in_array($function, $functionsThatMayHaveMixedValueTypes, true);
     }
 
     /**

--- a/tests/Unit/Value/ColorTest.php
+++ b/tests/Unit/Value/ColorTest.php
@@ -86,8 +86,6 @@ final class ColorTest extends TestCase
                 'rgb(0 119 0)',
                 '#070',
             ],
-            // The "legacy" syntax currently used for rendering does not allow a mixture of percentages and numbers.
-            /*
             'modern rgb with percentage R' => [
                 'rgb(0% 119 0)',
                 'rgb(0% 119 0)',
@@ -112,7 +110,6 @@ final class ColorTest extends TestCase
                 'rgb(0 60% 0%)',
                 'rgb(0 60% 0%)',
             ],
-            //*/
             'modern rgb with percentage components' => [
                 'rgb(0% 60% 0%)',
                 'rgb(0%,60%,0%)',
@@ -131,7 +128,6 @@ final class ColorTest extends TestCase
                 'rgb(0 119 0 / 50%)',
                 'rgba(0,119,0,50%)',
             ],
-            /*
             'modern rgba with percentage R' => [
                 'rgb(0% 119 0 / 0.5)',
                 'rgba(0% 119 0/.5)',
@@ -144,7 +140,6 @@ final class ColorTest extends TestCase
                 'rgb(0 119 0% / 0.5)',
                 'rgba(0 119 0%/.5)',
             ],
-            //*/
             'modern rgba with percentage RGB' => [
                 'rgb(0% 60% 0% / 0.5)',
                 'rgba(0%,60%,0%,.5)',


### PR DESCRIPTION
The "legacy" syntax does not allow a mixture of `percentage`s and `number`s for the red, green and blue components.
So if `rgb`/`rgba` functions that have such a mixture are rendered in the "legacy" syntax, an invalid property value will result.

An `OutputFormat` option to use the "modern" syntax throughout will be added later (see #801).