### PR TITLE
[CLEANUP] Improve readability of `instanceof` calls

### DIFF
--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -206,7 +206,7 @@ class Rule implements Renderable, Commentable
         if (!\is_array($mValue)) {
             $mValue = [$mValue];
         }
-        if (!$this->mValue instanceof RuleValueList || $this->mValue->getListSeparator() !== $sType) {
+        if (!($this->mValue instanceof RuleValueList) || $this->mValue->getListSeparator() !== $sType) {
             $mCurrentValue = $this->mValue;
             $this->mValue = new RuleValueList($sType, $this->lineNumber);
             if ($mCurrentValue) {

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -260,7 +260,7 @@ class Color extends CSSFunction
     private function allComponentsAreNumbers(): bool
     {
         foreach ($this->aComponents as $component) {
-            if (!$component instanceof Size || $component->getUnit() !== null) {
+            if (!($component instanceof Size) || $component->getUnit() !== null) {
                 return false;
             }
         }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -97,7 +97,7 @@ final class ParserTest extends TestCase
     {
         $document = self::parsedStructureForFile('colortest');
         foreach ($document->getAllRuleSets() as $ruleSet) {
-            if (!$ruleSet instanceof DeclarationBlock) {
+            if (!($ruleSet instanceof DeclarationBlock)) {
                 continue;
             }
             $selectors = $ruleSet->getSelectors();
@@ -405,7 +405,7 @@ body {color: green;}',
         self::assertSame('background-color', $backgroundHeaderRules[1]->getRule());
         $backgroundHeaderRules = $headerBlock->getRulesAssoc('background-');
         self::assertCount(1, $backgroundHeaderRules);
-        self::assertTrue($backgroundHeaderRules['background-color']->getValue() instanceof Color);
+        self::assertInstanceOf(Color::class, $backgroundHeaderRules['background-color']->getValue());
         self::assertSame('rgba', $backgroundHeaderRules['background-color']->getValue()->getColorDescription());
         $headerBlock->removeRule($backgroundHeaderRules['background-color']);
         $backgroundHeaderRules = $headerBlock->getRules('background-');


### PR DESCRIPTION
- use paranthesis for negated `instanceof` calls
- use `assertInstanceOf` in the tests