### PR TITLE
[CLEANUP] Avoid Hungarian notation for `oList` and `oListItem`

### DIFF
--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -62,9 +62,9 @@ abstract class CSSList implements Renderable, Commentable
      * @throws UnexpectedTokenException
      * @throws SourceException
      */
-    public static function parseList(ParserState $parserState, CSSList $oList): void
+    public static function parseList(ParserState $parserState, CSSList $list): void
     {
-        $bIsRoot = $oList instanceof Document;
+        $bIsRoot = $list instanceof Document;
         if (\is_string($parserState)) {
             $parserState = new ParserState($parserState, Settings::create());
         }
@@ -72,27 +72,27 @@ abstract class CSSList implements Renderable, Commentable
         $comments = [];
         while (!$parserState->isEnd()) {
             $comments = \array_merge($comments, $parserState->consumeWhiteSpace());
-            $oListItem = null;
+            $listItem = null;
             if ($bLenientParsing) {
                 try {
-                    $oListItem = self::parseListItem($parserState, $oList);
+                    $listItem = self::parseListItem($parserState, $list);
                 } catch (UnexpectedTokenException $e) {
-                    $oListItem = false;
+                    $listItem = false;
                 }
             } else {
-                $oListItem = self::parseListItem($parserState, $oList);
+                $listItem = self::parseListItem($parserState, $list);
             }
-            if ($oListItem === null) {
+            if ($listItem === null) {
                 // List parsing finished
                 return;
             }
-            if ($oListItem) {
-                $oListItem->addComments($comments);
-                $oList->append($oListItem);
+            if ($listItem) {
+                $listItem->addComments($comments);
+                $list->append($listItem);
             }
             $comments = $parserState->consumeWhiteSpace();
         }
-        $oList->addComments($comments);
+        $list->addComments($comments);
         if (!$bIsRoot && !$bLenientParsing) {
             throw new SourceException('Unexpected end of document', $parserState->currentLine());
         }
@@ -105,9 +105,9 @@ abstract class CSSList implements Renderable, Commentable
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    private static function parseListItem(ParserState $parserState, CSSList $oList)
+    private static function parseListItem(ParserState $parserState, CSSList $list)
     {
-        $bIsRoot = $oList instanceof Document;
+        $bIsRoot = $list instanceof Document;
         if ($parserState->comes('@')) {
             $oAtRule = self::parseAtRule($parserState);
             if ($oAtRule instanceof Charset) {
@@ -119,7 +119,7 @@ abstract class CSSList implements Renderable, Commentable
                         $parserState->currentLine()
                     );
                 }
-                if (\count($oList->getContents()) > 0) {
+                if (\count($list->getContents()) > 0) {
                     throw new UnexpectedTokenException(
                         '@charset must be the first parseable token in a document',
                         '',
@@ -142,7 +142,7 @@ abstract class CSSList implements Renderable, Commentable
                 return null;
             }
         } else {
-            return DeclarationBlock::parse($parserState, $oList);
+            return DeclarationBlock::parse($parserState, $list);
         }
     }
 

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -39,14 +39,14 @@ class DeclarationBlock extends RuleSet
     }
 
     /**
-     * @param CSSList|null $oList
+     * @param CSSList|null $list
      *
      * @return DeclarationBlock|false
      *
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
      */
-    public static function parse(ParserState $parserState, $oList = null)
+    public static function parse(ParserState $parserState, $list = null)
     {
         $comments = [];
         $oResult = new DeclarationBlock($parserState->currentLine());
@@ -64,7 +64,7 @@ class DeclarationBlock extends RuleSet
                     }
                 }
             } while (!\in_array($parserState->peek(), ['{', '}'], true) || $sStringWrapperChar !== false);
-            $oResult->setSelectors(\implode('', $aSelectorParts), $oList);
+            $oResult->setSelectors(\implode('', $aSelectorParts), $list);
             if ($parserState->comes('{')) {
                 $parserState->consume(1);
             }
@@ -85,11 +85,11 @@ class DeclarationBlock extends RuleSet
 
     /**
      * @param array<int, Selector|string>|string $mSelector
-     * @param CSSList|null $oList
+     * @param CSSList|null $list
      *
      * @throws UnexpectedTokenException
      */
-    public function setSelectors($mSelector, $oList = null): void
+    public function setSelectors($mSelector, $list = null): void
     {
         if (\is_array($mSelector)) {
             $this->aSelectors = $mSelector;
@@ -98,7 +98,7 @@ class DeclarationBlock extends RuleSet
         }
         foreach ($this->aSelectors as $iKey => $mSelector) {
             if (!($mSelector instanceof Selector)) {
-                if ($oList === null || !($oList instanceof KeyFrame)) {
+                if ($list === null || !($list instanceof KeyFrame)) {
                     if (!Selector::isValid($mSelector)) {
                         throw new UnexpectedTokenException(
                             "Selector did not match '" . Selector::SELECTOR_VALIDATION_RX . "'.",

--- a/src/Value/CalcFunction.php
+++ b/src/Value/CalcFunction.php
@@ -37,7 +37,7 @@ class CalcFunction extends CSSFunction
         }
         $parserState->consume('(');
         $oCalcList = new CalcRuleValueList($parserState->currentLine());
-        $oList = new RuleValueList(',', $parserState->currentLine());
+        $list = new RuleValueList(',', $parserState->currentLine());
         $iNestingLevel = 0;
         $iLastComponentType = null;
         while (!$parserState->comes(')') || $iNestingLevel > 0) {
@@ -94,10 +94,10 @@ class CalcFunction extends CSSFunction
             }
             $parserState->consumeWhiteSpace();
         }
-        $oList->addListComponent($oCalcList);
+        $list->addListComponent($oCalcList);
         if (!$parserState->isEnd()) {
             $parserState->consume(')');
         }
-        return new CalcFunction($sFunction, $oList, ',', $parserState->currentLine());
+        return new CalcFunction($sFunction, $list, ',', $parserState->currentLine());
     }
 }

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -85,11 +85,11 @@ abstract class Value implements Renderable
                         break;
                     }
                 }
-                $oList = new RuleValueList($sDelimiter, $parserState->currentLine());
+                $list = new RuleValueList($sDelimiter, $parserState->currentLine());
                 for ($i = $iStartPosition; $i - $iStartPosition < $iLength * 2; $i += 2) {
-                    $oList->addListComponent($aStack[$i]);
+                    $list->addListComponent($aStack[$i]);
                 }
-                $aNewStack[] = $oList;
+                $aNewStack[] = $list;
                 $iStartPosition += $iLength * 2 - 2;
             }
             $aStack = $aNewStack;


### PR DESCRIPTION
Part of #756