### PR TITLE
[CLEANUP] Avoid Hungarian notation for `bLenientParsing`

### DIFF
--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -68,12 +68,12 @@ abstract class CSSList implements Renderable, Commentable
         if (\is_string($parserState)) {
             $parserState = new ParserState($parserState, Settings::create());
         }
-        $bLenientParsing = $parserState->getSettings()->bLenientParsing;
+        $usesLenientParsing = $parserState->getSettings()->bLenientParsing;
         $comments = [];
         while (!$parserState->isEnd()) {
             $comments = \array_merge($comments, $parserState->consumeWhiteSpace());
             $listItem = null;
-            if ($bLenientParsing) {
+            if ($usesLenientParsing) {
                 try {
                     $listItem = self::parseListItem($parserState, $list);
                 } catch (UnexpectedTokenException $e) {
@@ -93,7 +93,7 @@ abstract class CSSList implements Renderable, Commentable
             $comments = $parserState->consumeWhiteSpace();
         }
         $list->addComments($comments);
-        if (!$bIsRoot && !$bLenientParsing) {
+        if (!$bIsRoot && !$usesLenientParsing) {
             throw new SourceException('Unexpected end of document', $parserState->currentLine());
         }
     }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -80,13 +80,13 @@ class Settings
     /**
      * Configures whether the parser should silently ignore invalid rules.
      *
-     * @param bool $bLenientParsing
+     * @param bool $usesLenientParsing
      *
      * @return $this fluent interface
      */
-    public function withLenientParsing($bLenientParsing = true): self
+    public function withLenientParsing($usesLenientParsing = true): self
     {
-        $this->bLenientParsing = $bLenientParsing;
+        $this->bLenientParsing = $usesLenientParsing;
         return $this;
     }
 


### PR DESCRIPTION
Keep the name of the public property in `Settings` unchanged, though, as it currently probably is part of the API.

Part of #756.