### PR TITLE
[CLEANUP] Avoid Hungarian notation for `oResult`

### DIFF
--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -177,14 +177,14 @@ abstract class CSSList implements Renderable, Commentable
             $parserState->consumeUntil([';', ParserState::EOF], true, true);
             return new Charset($oCharsetString, $iIdentifierLineNum);
         } elseif (self::identifierIs($identifier, 'keyframes')) {
-            $oResult = new KeyFrame($iIdentifierLineNum);
-            $oResult->setVendorKeyFrame($identifier);
-            $oResult->setAnimationName(\trim($parserState->consumeUntil('{', false, true)));
-            CSSList::parseList($parserState, $oResult);
+            $result = new KeyFrame($iIdentifierLineNum);
+            $result->setVendorKeyFrame($identifier);
+            $result->setAnimationName(\trim($parserState->consumeUntil('{', false, true)));
+            CSSList::parseList($parserState, $result);
             if ($parserState->comes('}')) {
                 $parserState->consume('}');
             }
-            return $oResult;
+            return $result;
         } elseif ($identifier === 'namespace') {
             $sPrefix = null;
             $mUrl = Value::parsePrimitiveValue($parserState);

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -49,7 +49,7 @@ class DeclarationBlock extends RuleSet
     public static function parse(ParserState $parserState, $list = null)
     {
         $comments = [];
-        $oResult = new DeclarationBlock($parserState->currentLine());
+        $result = new DeclarationBlock($parserState->currentLine());
         try {
             $aSelectorParts = [];
             $sStringWrapperChar = false;
@@ -64,7 +64,7 @@ class DeclarationBlock extends RuleSet
                     }
                 }
             } while (!\in_array($parserState->peek(), ['{', '}'], true) || $sStringWrapperChar !== false);
-            $oResult->setSelectors(\implode('', $aSelectorParts), $list);
+            $result->setSelectors(\implode('', $aSelectorParts), $list);
             if ($parserState->comes('{')) {
                 $parserState->consume(1);
             }
@@ -78,9 +78,9 @@ class DeclarationBlock extends RuleSet
                 throw $e;
             }
         }
-        $oResult->setComments($comments);
-        RuleSet::parseRuleSet($parserState, $oResult);
-        return $oResult;
+        $result->setComments($comments);
+        RuleSet::parseRuleSet($parserState, $result);
+        return $result;
     }
 
     /**

--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -46,10 +46,10 @@ class CSSFunction extends ValueList
         $parserState->consume('(');
         $mArguments = self::parseArguments($parserState);
 
-        $oResult = new CSSFunction($sName, $mArguments, ',', $parserState->currentLine());
+        $result = new CSSFunction($sName, $mArguments, ',', $parserState->currentLine());
         $parserState->consume(')');
 
-        return $oResult;
+        return $result;
     }
 
     /**

--- a/src/Value/URL.php
+++ b/src/Value/URL.php
@@ -53,12 +53,12 @@ class URL extends PrimitiveValue
             $oAnchor->backtrack();
         }
         $parserState->consumeWhiteSpace();
-        $oResult = new URL(CSSString::parse($parserState), $parserState->currentLine());
+        $result = new URL(CSSString::parse($parserState), $parserState->currentLine());
         if ($bUseUrl) {
             $parserState->consumeWhiteSpace();
             $parserState->consume(')');
         }
-        return $oResult;
+        return $result;
     }
 
     public function setURL(CSSString $oURL): void


### PR DESCRIPTION
Part of #756