### PR TITLE
[BUGFIX] Drop test that passes in the wrong type

### DIFF
--- a/tests/OutputFormatTest.php
+++ b/tests/OutputFormatTest.php
@@ -99,23 +99,6 @@ EOT;
     /**
      * @test
      */
-    public function spaceAfterListArgumentSeparatorComplex(): void
-    {
-        self::assertSame(
-            '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",	Verdana,	sans-serif;background: white;}'
-            . "\n@media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff;}}",
-            $this->document->render(OutputFormat::create()->setSpaceAfterListArgumentSeparator([
-                'default' => ' ',
-                ',' => "\t",
-                '/' => '',
-                ' ' => '',
-            ]))
-        );
-    }
-
-    /**
-     * @test
-     */
     public function spaceAfterSelectorSeparator(): void
     {
         self::assertSame(


### PR DESCRIPTION
`OutputFormat::spaceAfterListArgumentSeparator` is expected to be a string, not an array.

This was discovered by adding dedicated, strictly typed property accessors for `OutputFormat`.