### PR TITLE
[TASK] Deprecate `OutputFormat::level()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
+- Deprecate `OutputFormat::level()` (#870)
+
 ### Removed
 
 ### Fixed

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -297,6 +297,8 @@ class OutputFormat
 
     /**
      * @return int
+     *
+     * @deprecated #869 since version V8.8.0, will be removed in V9.0.0. Use `getIndentationLevel()` instead.
      */
     public function level()
     {

--- a/src/OutputFormatter.php
+++ b/src/OutputFormatter.php
@@ -250,6 +250,6 @@ class OutputFormatter
      */
     private function indent()
     {
-        return str_repeat($this->oFormat->sIndentation, $this->oFormat->level());
+        return str_repeat($this->oFormat->sIndentation, $this->oFormat->getIndentationLevel());
     }
 }


### PR DESCRIPTION
This method is redundant with the (magic) getter
`Outputformat::getIndentationLevel()`, which follows the common accessor naming conventions.