### PR TITLE
[TASK] Remove the deprecated `OutputFormat::level()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Please also have a look at our
 
 ### Removed
 
-- Remove `OutputFormat::level()` (#874))
+- Remove `OutputFormat::level()` (#874)
 - Remove expansion of shorthand properties (#838)
 - Remove `Parser::setCharset/getCharset` (#808)
 - Remove `Rule::getValues()` (#582)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Please also have a look at our
 
 ### Removed
 
+- Remove `OutputFormat::level()` (#874))
 - Remove expansion of shorthand properties (#838)
 - Remove `Parser::setCharset/getCharset` (#808)
 - Remove `Rule::getValues()` (#582)

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -288,14 +288,6 @@ class OutputFormat
     }
 
     /**
-     * @return int
-     */
-    public function level()
-    {
-        return $this->iIndentationLevel;
-    }
-
-    /**
      * Creates an instance of this class without any particular formatting settings.
      */
     public static function create(): self

--- a/src/OutputFormatter.php
+++ b/src/OutputFormatter.php
@@ -208,6 +208,6 @@ class OutputFormatter
      */
     private function indent(): string
     {
-        return \str_repeat($this->oFormat->sIndentation, $this->oFormat->level());
+        return \str_repeat($this->oFormat->sIndentation, $this->oFormat->getIndentationLevel());
     }
 }

--- a/tests/Unit/OutputFormatTest.php
+++ b/tests/Unit/OutputFormatTest.php
@@ -836,17 +836,6 @@ final class OutputFormatTest extends TestCase
     /**
      * @test
      */
-    public function levelReturnsIndentationLevel(): void
-    {
-        $value = 4;
-        $this->subject->setIndentationLevel($value);
-
-        self::assertSame($value, $this->subject->level());
-    }
-
-    /**
-     * @test
-     */
     public function createReturnsNewOutputFormatInstance(): void
     {
         self::assertInstanceOf(OutputFormat::class, OutputFormat::create());


### PR DESCRIPTION
This method is an inconsistently-named alias of
`OutputFormat::getIndentationLevel()`.

Fixes #869