### PR TITLE
[CLEANUP] Add separate `OutputFormat` properties for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please also have a look at our
 
 ### Added
 
+- `OutputFormat` properties for space around specific list separators (#880)
 - Partial support for CSS Color Module Level 4:
     - `rgb` and `rgba`, and `hsl` and `hsla` are now aliases (#797}
     - Parse color functions that use the "modern" syntax (#800)
@@ -25,6 +26,8 @@ Please also have a look at our
 - Add visibility to all class/interface constants (#469)
 
 ### Deprecated
+
+- `OutputFormat` properties for space around list separators as an array (#880)
 
 ### Removed
 

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -98,16 +98,38 @@ class OutputFormat
     public $sSpaceAfterSelectorSeparator = ' ';
 
     /**
-     * This is what’s printed after the comma of value lists
+     * This is what’s inserted before the separator in value lists, by default.
      *
-     * @var string
+     * `array` is deprecated in version 8.8.0, and will be removed in version 9.0.0.
+     * To set the spacing for specific separators, use {@see $aSpaceBeforeListArgumentSeparators} instead.
+     *
+     * @var string|array<non-empty-string, string>
      */
     public $sSpaceBeforeListArgumentSeparator = '';
 
     /**
-     * @var string
+     * Keys are separators (e.g. `,`).  Values are the space sequence to insert, or an empty string.
+     *
+     * @var array<non-empty-string, string>
+     */
+    public $aSpaceBeforeListArgumentSeparators = [];
+
+    /**
+     * This is what’s inserted after the separator in value lists, by default.
+     *
+     * `array` is deprecated in version 8.8.0, and will be removed in version 9.0.0.
+     * To set the spacing for specific separators, use {@see $aSpaceAfterListArgumentSeparators} instead.
+     *
+     * @var string|array<non-empty-string, string>
      */
     public $sSpaceAfterListArgumentSeparator = '';
+
+    /**
+     * Keys are separators (e.g. `,`).  Values are the space sequence to insert, or an empty string.
+     *
+     * @var array<non-empty-string, string>
+     */
+    public $aSpaceAfterListArgumentSeparators = [];
 
     /**
      * @var string
@@ -311,7 +333,7 @@ class OutputFormat
         $format->set('Space*Rules', "\n")
             ->set('Space*Blocks', "\n")
             ->setSpaceBetweenBlocks("\n\n")
-            ->set('SpaceAfterListArgumentSeparator', ['default' => '', ',' => ' '])
+            ->set('SpaceAfterListArgumentSeparators', [',' => ' '])
             ->setRenderComments(true);
         return $format;
     }

--- a/src/OutputFormatter.php
+++ b/src/OutputFormatter.php
@@ -91,7 +91,9 @@ class OutputFormatter
      */
     public function spaceBeforeListArgumentSeparator($sSeparator): string
     {
-        return $this->space('BeforeListArgumentSeparator', $sSeparator);
+        $spaceForSeparator = $this->oFormat->getSpaceBeforeListArgumentSeparators();
+
+        return $spaceForSeparator[$sSeparator] ?? $this->space('BeforeListArgumentSeparator', $sSeparator);
     }
 
     /**
@@ -99,7 +101,9 @@ class OutputFormatter
      */
     public function spaceAfterListArgumentSeparator($sSeparator): string
     {
-        return $this->space('AfterListArgumentSeparator', $sSeparator);
+        $spaceForSeparator = $this->oFormat->getSpaceAfterListArgumentSeparators();
+
+        return $spaceForSeparator[$sSeparator] ?? $this->space('AfterListArgumentSeparator', $sSeparator);
     }
 
     public function spaceBeforeOpeningBrace(): string

--- a/tests/OutputFormatTest.php
+++ b/tests/OutputFormatTest.php
@@ -98,8 +98,11 @@ EOT;
 
     /**
      * @test
+     *
+     * @deprecated since version 8.8.0; will be removed in version 9.0.
+     * Use `setSpaceAfterListArgumentSeparators()` to set different spacing per separator.
      */
-    public function spaceAfterListArgumentSeparatorComplex(): void
+    public function spaceAfterListArgumentSeparatorComplexDeprecated(): void
     {
         self::assertSame(
             '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",	Verdana,	sans-serif;background: white;}'
@@ -110,6 +113,26 @@ EOT;
                 '/' => '',
                 ' ' => '',
             ]))
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function spaceAfterListArgumentSeparatorComplex(): void
+    {
+        self::assertSame(
+            '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",	Verdana,	sans-serif;background: white;}'
+            . "\n@media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff;}}",
+            $this->document->render(
+                OutputFormat::create()
+                    ->setSpaceAfterListArgumentSeparator(' ')
+                    ->setSpaceAfterListArgumentSeparators([
+                        ',' => "\t",
+                        '/' => '',
+                        ' ' => '',
+                    ])
+            )
         );
     }
 

--- a/tests/Unit/OutputFormatTest.php
+++ b/tests/Unit/OutputFormatTest.php
@@ -444,6 +444,33 @@ final class OutputFormatTest extends TestCase
     /**
      * @test
      */
+    public function getSpaceBeforeListArgumentSeparatorsInitiallyReturnsEmptyArray(): void
+    {
+        self::assertSame([], $this->subject->getSpaceBeforeListArgumentSeparators());
+    }
+
+    /**
+     * @test
+     */
+    public function setSpaceBeforeListArgumentSeparatorsSetsSpaceBeforeListArgumentSeparators(): void
+    {
+        $value = ['/' => ' '];
+        $this->subject->setSpaceBeforeListArgumentSeparators($value);
+
+        self::assertSame($value, $this->subject->getSpaceBeforeListArgumentSeparators());
+    }
+
+    /**
+     * @test
+     */
+    public function setSpaceBeforeListArgumentSeparatorsProvidesFluentInterface(): void
+    {
+        self::assertSame($this->subject, $this->subject->setSpaceBeforeListArgumentSeparators([]));
+    }
+
+    /**
+     * @test
+     */
     public function getSpaceAfterListArgumentSeparatorInitiallyReturnsEmptyString(): void
     {
         self::assertSame('', $this->subject->getSpaceAfterListArgumentSeparator());
@@ -466,6 +493,33 @@ final class OutputFormatTest extends TestCase
     public function setSpaceAfterListArgumentSeparatorProvidesFluentInterface(): void
     {
         self::assertSame($this->subject, $this->subject->setSpaceAfterListArgumentSeparator(' '));
+    }
+
+    /**
+     * @test
+     */
+    public function getSpaceAfterListArgumentSeparatorsInitiallyReturnsEmptyArray(): void
+    {
+        self::assertSame([], $this->subject->getSpaceAfterListArgumentSeparators());
+    }
+
+    /**
+     * @test
+     */
+    public function setSpaceAfterListArgumentSeparatorsSetsSpaceAfterListArgumentSeparators(): void
+    {
+        $value = [',' => ' '];
+        $this->subject->setSpaceAfterListArgumentSeparators($value);
+
+        self::assertSame($value, $this->subject->getSpaceAfterListArgumentSeparators());
+    }
+
+    /**
+     * @test
+     */
+    public function setSpaceAfterListArgumentSeparatorsProvidesFluentInterface(): void
+    {
+        self::assertSame($this->subject, $this->subject->setSpaceAfterListArgumentSeparators([]));
     }
 
     /**


### PR DESCRIPTION
`SpaceBeforeListArgumentSeparators` and `SpaceAfterListArgumentSeparators` are added to allow for different spacing for different separators.

`SpaceBeforeListArgumentSeparator` and `SpaceAfterListArgumentSeparator` will specify the default spacing.  Setting these as an array is deprecated.

Resolves #866, #876, #878.