### PR TITLE
[CLEANUP] Add separate `OutputFormat` properties for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `OutputFormat` properties for space around specific list separators (#880)
+
 ### Changed
 
 ### Deprecated
 
+- `OutputFormat` properties for space around list separators as an array (#880)
 - Deprecate `OutputFormat::level()` (#870)
 
 ### Removed

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -96,16 +96,38 @@ class OutputFormat
     public $sSpaceAfterSelectorSeparator = ' ';
 
     /**
-     * This is what’s printed after the comma of value lists
+     * This is what’s inserted before the separator in value lists, by default.
      *
-     * @var string
+     * `array` is deprecated in version 8.8.0, and will be removed in version 9.0.0.
+     * To set the spacing for specific separators, use {@see $aSpaceBeforeListArgumentSeparators} instead.
+     *
+     * @var string|array<non-empty-string, string>
      */
     public $sSpaceBeforeListArgumentSeparator = '';
 
     /**
-     * @var string
+     * Keys are separators (e.g. `,`).  Values are the space sequence to insert, or an empty string.
+     *
+     * @var array<non-empty-string, string>
+     */
+    public $aSpaceBeforeListArgumentSeparators = [];
+
+    /**
+     * This is what’s inserted after the separator in value lists, by default.
+     *
+     * `array` is deprecated in version 8.8.0, and will be removed in version 9.0.0.
+     * To set the spacing for specific separators, use {@see $aSpaceAfterListArgumentSeparators} instead.
+     *
+     * @var string|array<non-empty-string, string>
      */
     public $sSpaceAfterListArgumentSeparator = '';
+
+    /**
+     * Keys are separators (e.g. `,`).  Values are the space sequence to insert, or an empty string.
+     *
+     * @var array<non-empty-string, string>
+     */
+    public $aSpaceAfterListArgumentSeparators = [];
 
     /**
      * @var string
@@ -343,7 +365,7 @@ class OutputFormat
         $format->set('Space*Rules', "\n")
             ->set('Space*Blocks', "\n")
             ->setSpaceBetweenBlocks("\n\n")
-            ->set('SpaceAfterListArgumentSeparator', ['default' => '', ',' => ' '])
+            ->set('SpaceAfterListArgumentSeparators', [',' => ' '])
             ->setRenderComments(true);
         return $format;
     }

--- a/src/OutputFormatter.php
+++ b/src/OutputFormatter.php
@@ -117,7 +117,9 @@ class OutputFormatter
      */
     public function spaceBeforeListArgumentSeparator($sSeparator)
     {
-        return $this->space('BeforeListArgumentSeparator', $sSeparator);
+        $spaceForSeparator = $this->oFormat->getSpaceBeforeListArgumentSeparators();
+
+        return $spaceForSeparator[$sSeparator] ?? $this->space('BeforeListArgumentSeparator', $sSeparator);
     }
 
     /**
@@ -127,7 +129,9 @@ class OutputFormatter
      */
     public function spaceAfterListArgumentSeparator($sSeparator)
     {
-        return $this->space('AfterListArgumentSeparator', $sSeparator);
+        $spaceForSeparator = $this->oFormat->getSpaceAfterListArgumentSeparators();
+
+        return $spaceForSeparator[$sSeparator] ?? $this->space('AfterListArgumentSeparator', $sSeparator);
     }
 
     /**

--- a/src/OutputFormatter.php
+++ b/src/OutputFormatter.php
@@ -118,8 +118,11 @@ class OutputFormatter
     public function spaceBeforeListArgumentSeparator($sSeparator)
     {
         $spaceForSeparator = $this->oFormat->getSpaceBeforeListArgumentSeparators();
+        if (isset($spaceForSeparator[$sSeparator])) {
+            return $spaceForSeparator[$sSeparator];
+        }
 
-        return $spaceForSeparator[$sSeparator] ?? $this->space('BeforeListArgumentSeparator', $sSeparator);
+        return $this->space('BeforeListArgumentSeparator', $sSeparator);
     }
 
     /**
@@ -130,8 +133,11 @@ class OutputFormatter
     public function spaceAfterListArgumentSeparator($sSeparator)
     {
         $spaceForSeparator = $this->oFormat->getSpaceAfterListArgumentSeparators();
+        if (isset($spaceForSeparator[$sSeparator])) {
+            return $spaceForSeparator[$sSeparator];
+        }
 
-        return $spaceForSeparator[$sSeparator] ?? $this->space('AfterListArgumentSeparator', $sSeparator);
+        return $this->space('AfterListArgumentSeparator', $sSeparator);
     }
 
     /**

--- a/tests/OutputFormatTest.php
+++ b/tests/OutputFormatTest.php
@@ -104,8 +104,11 @@ EOT;
 
     /**
      * @test
+     *
+     * @deprecated since version 8.8.0; will be removed in version 9.0.
+     * Use `setSpaceAfterListArgumentSeparators()` to set different spacing per separator.
      */
-    public function spaceAfterListArgumentSeparatorComplex()
+    public function spaceAfterListArgumentSeparatorComplexDeprecated()
     {
         $this->setUpTestcase();
 
@@ -118,6 +121,28 @@ EOT;
                 '/' => '',
                 ' ' => '',
             ]))
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function spaceAfterListArgumentSeparatorComplex()
+    {
+        $this->setUpTestcase();
+
+        self::assertSame(
+            '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",	Verdana,	sans-serif;background: white;}'
+            . "\n@media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff;}}",
+            $this->oDocument->render(
+                OutputFormat::create()
+                    ->setSpaceAfterListArgumentSeparator(' ')
+                    ->setSpaceAfterListArgumentSeparators([
+                        ',' => "\t",
+                        '/' => '',
+                        ' ' => '',
+                    ])
+            )
         );
     }
 


### PR DESCRIPTION
`SpaceBeforeListArgumentSeparators` and `SpaceAfterListArgumentSeparators` are added to allow for different spacing for different separators.

`SpaceBeforeListArgumentSeparator` and `SpaceAfterListArgumentSeparator` will specify the default spacing.  Setting these as an array is deprecated.

This is the backport of #880.