### PR TITLE
[TASK] Only allow `string` for some `OutputFormat` properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please also have a look at our
 
 ### Changed
 
+- Only allow `string` for some `OutputFormat` properties (#885)
 - Make all non-private properties `@internal` (#886)
 - Use more native type declarations and strict mode
   (#641, #772, #774, #778, #804, #841, #873, #875)

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -124,10 +124,7 @@ class OutputFormat
     /**
      * This is what’s inserted before the separator in value lists, by default.
      *
-     * `array` is deprecated in version 8.8.0, and will be removed in version 9.0.0.
-     * To set the spacing for specific separators, use {@see $aSpaceBeforeListArgumentSeparators} instead.
-     *
-     * @var string|array<non-empty-string, string>
+     * @var string
      *
      * @internal since 8.8.0, will be made private in 9.0.0
      */
@@ -145,10 +142,7 @@ class OutputFormat
     /**
      * This is what’s inserted after the separator in value lists, by default.
      *
-     * `array` is deprecated in version 8.8.0, and will be removed in version 9.0.0.
-     * To set the spacing for specific separators, use {@see $aSpaceAfterListArgumentSeparators} instead.
-     *
-     * @var string|array<non-empty-string, string>
+     * @var string
      *
      * @internal since 8.8.0, will be made private in 9.0.0
      */
@@ -597,21 +591,17 @@ class OutputFormat
     }
 
     /**
-     * @return string|array<non-empty-string, string>
-     *
      * @internal
      */
-    public function getSpaceAfterListArgumentSeparator()
+    public function getSpaceAfterListArgumentSeparator(): string
     {
         return $this->sSpaceAfterListArgumentSeparator;
     }
 
     /**
-     * @param string|array<non-empty-string, string> $whitespace
-     *
      * @return $this fluent interface
      */
-    public function setSpaceAfterListArgumentSeparator($whitespace): self
+    public function setSpaceAfterListArgumentSeparator(string $whitespace): self
     {
         $this->sSpaceAfterListArgumentSeparator = $whitespace;
 

--- a/tests/OutputFormatTest.php
+++ b/tests/OutputFormatTest.php
@@ -98,26 +98,6 @@ EOT;
 
     /**
      * @test
-     *
-     * @deprecated since version 8.8.0; will be removed in version 9.0.
-     * Use `setSpaceAfterListArgumentSeparators()` to set different spacing per separator.
-     */
-    public function spaceAfterListArgumentSeparatorComplexDeprecated(): void
-    {
-        self::assertSame(
-            '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",	Verdana,	sans-serif;background: white;}'
-            . "\n@media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff;}}",
-            $this->document->render(OutputFormat::create()->setSpaceAfterListArgumentSeparator([
-                'default' => ' ',
-                ',' => "\t",
-                '/' => '',
-                ' ' => '',
-            ]))
-        );
-    }
-
-    /**
-     * @test
      */
     public function spaceAfterListArgumentSeparatorComplex(): void
     {


### PR DESCRIPTION
`sBeforeAfterListArgumentSeparator` and
`sSpaceAfterListArgumentSeparator` now can only hold strings, and no longer arrays (which was deprecated in V8.8.0).