### PR TITLE
[TASK] Make all non-private properties `@internal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please also have a look at our
 
 ### Changed
 
+- Make all non-private properties `@internal` (#886)
 - Use more native type declarations and strict mode
   (#641, #772, #774, #778, #804, #841, #873, #875)
 - Add visibility to all class/interface constants (#469)

--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -35,16 +35,22 @@ abstract class CSSList implements Renderable, Commentable
 {
     /**
      * @var array<array-key, Comment>
+     *
+     * @internal since 8.8.0
      */
     protected $comments;
 
     /**
      * @var array<int, RuleSet|CSSList|Import|Charset>
+     *
+     * @internal since 8.8.0
      */
     protected $contents;
 
     /**
      * @var int
+     *
+     * @internal since 8.8.0
      */
     protected $lineNumber;
 

--- a/src/Comment/Comment.php
+++ b/src/Comment/Comment.php
@@ -11,11 +11,15 @@ class Comment implements Renderable
 {
     /**
      * @var int
+     *
+     * @internal since 8.8.0
      */
     protected $lineNumber;
 
     /**
      * @var string
+     *
+     * @internal since 8.8.0
      */
     protected $commentText;
 

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -10,6 +10,8 @@ class OutputFormat
      * Value format: `"` means double-quote, `'` means single-quote
      *
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sStringQuotingType = '"';
 
@@ -17,6 +19,8 @@ class OutputFormat
      * Output RGB colors in hash notation if possible
      *
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $bRGBHashNotation = true;
 
@@ -26,6 +30,8 @@ class OutputFormat
      * Semicolon after the last rule of a declaration block can be omitted. To do that, set this false.
      *
      * @var bool
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $bSemicolonAfterLastRule = true;
 
@@ -34,36 +40,52 @@ class OutputFormat
      * Note that these strings are not sanity-checked: the value should only consist of whitespace
      * Any newline character will be indented according to the current level.
      * The triples (After, Before, Between) can be set using a wildcard (e.g. `$oFormat->set('Space*Rules', "\n");`)
+     *
+     * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sSpaceAfterRuleName = ' ';
 
     /**
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sSpaceBeforeRules = '';
 
     /**
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sSpaceAfterRules = '';
 
     /**
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sSpaceBetweenRules = '';
 
     /**
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sSpaceBeforeBlocks = '';
 
     /**
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sSpaceAfterBlocks = '';
 
     /**
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sSpaceBetweenBlocks = "\n";
 
@@ -71,11 +93,15 @@ class OutputFormat
      * Content injected in and around at-rule blocks.
      *
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sBeforeAtRuleBlock = '';
 
     /**
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sAfterAtRuleBlock = '';
 
@@ -83,11 +109,15 @@ class OutputFormat
      * This is what’s printed before and after the comma if a declaration block contains multiple selectors.
      *
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sSpaceBeforeSelectorSeparator = '';
 
     /**
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sSpaceAfterSelectorSeparator = ' ';
 
@@ -98,6 +128,8 @@ class OutputFormat
      * To set the spacing for specific separators, use {@see $aSpaceBeforeListArgumentSeparators} instead.
      *
      * @var string|array<non-empty-string, string>
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sSpaceBeforeListArgumentSeparator = '';
 
@@ -105,6 +137,8 @@ class OutputFormat
      * Keys are separators (e.g. `,`).  Values are the space sequence to insert, or an empty string.
      *
      * @var array<non-empty-string, string>
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $aSpaceBeforeListArgumentSeparators = [];
 
@@ -115,6 +149,8 @@ class OutputFormat
      * To set the spacing for specific separators, use {@see $aSpaceAfterListArgumentSeparators} instead.
      *
      * @var string|array<non-empty-string, string>
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sSpaceAfterListArgumentSeparator = '';
 
@@ -122,11 +158,15 @@ class OutputFormat
      * Keys are separators (e.g. `,`).  Values are the space sequence to insert, or an empty string.
      *
      * @var array<non-empty-string, string>
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $aSpaceAfterListArgumentSeparators = [];
 
     /**
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sSpaceBeforeOpeningBrace = ' ';
 
@@ -134,16 +174,22 @@ class OutputFormat
      * Content injected in and around declaration blocks.
      *
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sBeforeDeclarationBlock = '';
 
     /**
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sAfterDeclarationBlockSelectors = '';
 
     /**
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sAfterDeclarationBlock = '';
 
@@ -151,6 +197,8 @@ class OutputFormat
      * Indentation character(s) per level. Only applicable if newlines are used in any of the spacing settings.
      *
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sIndentation = "\t";
 
@@ -158,6 +206,8 @@ class OutputFormat
      * Output exceptions.
      *
      * @var bool
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $bIgnoreExceptions = false;
 
@@ -165,6 +215,8 @@ class OutputFormat
      * Render comments for lists and RuleSets
      *
      * @var bool
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $bRenderComments = false;
 

--- a/src/Property/CSSNamespace.php
+++ b/src/Property/CSSNamespace.php
@@ -29,6 +29,8 @@ class CSSNamespace implements AtRule
 
     /**
      * @var array<array-key, Comment>
+     *
+     * @internal since 8.8.0
      */
     protected $comments;
 

--- a/src/Property/Charset.php
+++ b/src/Property/Charset.php
@@ -25,11 +25,15 @@ class Charset implements AtRule
 
     /**
      * @var int
+     *
+     * @internal since 8.8.0
      */
     protected $lineNumber;
 
     /**
      * @var array<array-key, Comment>
+     *
+     * @internal since 8.8.0
      */
     protected $comments;
 

--- a/src/Property/Import.php
+++ b/src/Property/Import.php
@@ -25,11 +25,15 @@ class Import implements AtRule
 
     /**
      * @var int
+     *
+     * @internal since 8.8.0
      */
     protected $lineNumber;
 
     /**
      * @var array<array-key, Comment>
+     *
+     * @internal since 8.8.0
      */
     protected $comments;
 

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -48,11 +48,15 @@ class Rule implements Renderable, Commentable
 
     /**
      * @var int
+     *
+     * @internal since 8.8.0
      */
     protected $iColNo;
 
     /**
      * @var array<array-key, Comment>
+     *
+     * @internal since 8.8.0
      */
     protected $comments;
 

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -31,11 +31,15 @@ abstract class RuleSet implements Renderable, Commentable
 
     /**
      * @var int
+     *
+     * @internal since 8.8.0
      */
     protected $lineNumber;
 
     /**
      * @var array<array-key, Comment>
+     *
+     * @internal since 8.8.0
      */
     protected $comments;
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -18,6 +18,8 @@ class Settings
      * and `mb_strpos` functions. Otherwise, the normal (ASCII-Only) functions will be used.
      *
      * @var bool
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $bMultibyteSupport;
 
@@ -25,6 +27,8 @@ class Settings
      * The default charset for the CSS if no `@charset` declaration is found. Defaults to utf-8.
      *
      * @var string
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $sDefaultCharset = 'utf-8';
 
@@ -32,6 +36,8 @@ class Settings
      * Whether the parser silently ignore invalid rules instead of choking on them.
      *
      * @var bool
+     *
+     * @internal since 8.8.0, will be made private in 9.0.0
      */
     public $bLenientParsing = true;
 

--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -15,6 +15,8 @@ class CSSFunction extends ValueList
 {
     /**
      * @var string
+     *
+     * @internal since 8.8.0
      */
     protected $sName;
 

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -18,6 +18,8 @@ abstract class Value implements Renderable
 {
     /**
      * @var int
+     *
+     * @internal since 8.8.0
      */
     protected $lineNumber;
 

--- a/src/Value/ValueList.php
+++ b/src/Value/ValueList.php
@@ -16,11 +16,15 @@ abstract class ValueList extends Value
 {
     /**
      * @var array<array-key, Value|string>
+     *
+     * @internal since 8.8.0
      */
     protected $aComponents;
 
     /**
      * @var string
+     *
+     * @internal since 8.8.0
      */
     protected $sSeparator;
 


### PR DESCRIPTION
This communicates clearly that the properties may be removed, renamed or made `private` at any point, and that they should not be accessed directly, but using the accessors instead.

Also add a type annotation that was missing.

Fixes #881