### PR TITLE
[TASK] Deprecate method forwarding `OutputFormat` to `OutputFormatter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Please also have a look at our
 
 ### Deprecated
 
+- Deprecate magic method forwarding from `OutputFormat` to `OutputFormatter`
+  (#894)
 - Deprecate greedy calculation of selector specificity (#1018)
 - Deprecate `__toString()` (#1006)
 - `OutputFormat` properties for space around list separators as an array (#880)

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -244,6 +244,7 @@ class OutputFormat
     public function __call(string $sMethodName, array $aArguments)
     {
         if (\method_exists(OutputFormatter::class, $sMethodName)) {
+            // @deprecated since 8.8.0, will be removed in 9.0.0. Call the method on the formatter directly instead.
             return \call_user_func_array([$this->getFormatter(), $sMethodName], $aArguments);
         } else {
             throw new \Exception('Unknown OutputFormat method called: ' . $sMethodName);


### PR DESCRIPTION
Instead, the corresponding method on the formatter should be called directly.

This increases type safety and helps static code analysis. Also, it makes the code easier to understand.