### PR TITLE
[TASK] Mark `OutputFormatter` as `@internal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please also have a look at our
 
 ### Changed
 
+- Mark `OutputFormatter` as `@internal` (#896)
 - Make `Selector` a `Renderable` (#1017)
 - Mark `Selector::isValid()` as `@internal` (#1037)
 - Mark parsing-related methods of most CSS elements as `@internal` (#908)

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -751,11 +751,15 @@ class OutputFormat
         $this->bIgnoreExceptions = true;
     }
 
+    /**
+     * @internal since 8.8.0
+     */
     public function getFormatter(): OutputFormatter
     {
         if ($this->outputFormatter === null) {
             $this->outputFormatter = new OutputFormatter($this);
         }
+
         return $this->outputFormatter;
     }
 

--- a/src/OutputFormatter.php
+++ b/src/OutputFormatter.php
@@ -7,6 +7,9 @@ namespace Sabberworm\CSS;
 use Sabberworm\CSS\Comment\Commentable;
 use Sabberworm\CSS\Parsing\OutputException;
 
+/**
+ * @internal since 8.8.0
+ */
 class OutputFormatter
 {
     /**


### PR DESCRIPTION
This class should only be used for formatting CSS from within this library. It is not intended to be called from outside.