### PR TITLE
[BUGFIX] Add missing imports for `@throws` annotations

### DIFF
--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -4,6 +4,9 @@ namespace Sabberworm\CSS\Value;
 
 use Sabberworm\CSS\OutputFormat;
 use Sabberworm\CSS\Parsing\ParserState;
+use Sabberworm\CSS\Parsing\SourceException;
+use Sabberworm\CSS\Parsing\UnexpectedEOFException;
+use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 
 /**
  * A `CSSFunction` represents a special kind of value that also contains a function name and where the values are the


### PR DESCRIPTION
This is the V8.x backport of #897.