### PR TITLE
[TASK] Mark `OutputFormat::nextLevel()` as `@internal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please also have a look at our
 
 ### Changed
 
+- Mark `OutputFormat::nextLevel()` as `@internal` (#901)
 - Only allow `string` for some `OutputFormat` properties (#885)
 - Make all non-private properties `@internal` (#886)
 - Use more native type declarations and strict mode

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -780,6 +780,9 @@ class OutputFormat
         return $this->setIndentation(\str_repeat(' ', $numberOfSpaces));
     }
 
+    /**
+     * @internal since V8.8.0
+     */
     public function nextLevel(): self
     {
         if ($this->oNextLevelFormat === null) {


### PR DESCRIPTION
This method is used internally for rendering the CSS, and it is not intended to be called from outside this library.