### PR TITLE
[TASK] Mark `OutputFormat::nextLevel()` as `@internal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Mark `OutputFormat::nextLevel()` as `@internal` (#901)
 - Make all non-private properties `@internal` (#886)
 
 ### Deprecated

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -339,6 +339,8 @@ class OutputFormat
 
     /**
      * @return OutputFormat
+     *
+     * @internal since V8.8.0
      */
     public function nextLevel()
     {


### PR DESCRIPTION
This method is used internally for rendering the CSS, and it is not intended to be called from outside this library.

This is the V8.x backport of #901.