### PR TITLE
[BUGFIX] Fix an incorrect type annotation in `OutputFormat`

### DIFF
--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -22,7 +22,7 @@ class OutputFormat
     /**
      * Output RGB colors in hash notation if possible
      *
-     * @var string
+     * @var bool
      *
      * @internal since 8.8.0, will be made private in 9.0.0
      */


### PR DESCRIPTION
This is the V8.x backport of #902.