### PR TITLE
[TASK] Mark many parsing-related methods as `@internal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please also have a look at our
 
 ### Changed
 
+- Mark parsing-related methods of most CSS elements as `@internal` (#907)
 - Mark `OutputFormat::nextLevel()` as `@internal` (#901)
 - Only allow `string` for some `OutputFormat` properties (#885)
 - Make all non-private properties `@internal` (#886)

--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -67,6 +67,8 @@ abstract class CSSList implements Renderable, Commentable
     /**
      * @throws UnexpectedTokenException
      * @throws SourceException
+     *
+     * @internal since V8.8.0
      */
     public static function parseList(ParserState $parserState, CSSList $list): void
     {

--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -28,6 +28,8 @@ class Document extends CSSBlockList
 
     /**
      * @throws SourceException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $parserState): Document
     {

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -136,6 +136,8 @@ class ParserState
      * @return string
      *
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public function parseIdentifier($bIgnoreCase = true)
     {
@@ -167,6 +169,8 @@ class ParserState
      *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public function parseCharacter($bIsForIdentifier)
     {

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -79,6 +79,8 @@ class Rule implements Renderable, Commentable
     /**
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $parserState): Rule
     {

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -45,6 +45,8 @@ class DeclarationBlock extends RuleSet
      *
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $parserState, $list = null)
     {

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -56,6 +56,8 @@ abstract class RuleSet implements Renderable, Commentable
     /**
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
+     *
+     * @internal since V8.8.0
      */
     public static function parseRuleSet(ParserState $parserState, RuleSet $ruleSet): void
     {

--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -44,6 +44,8 @@ class CSSFunction extends ValueList
      * @throws SourceException
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $parserState, bool $bIgnoreCase = false): CSSFunction
     {

--- a/src/Value/CSSString.php
+++ b/src/Value/CSSString.php
@@ -36,6 +36,8 @@ class CSSString extends PrimitiveValue
      * @throws SourceException
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $parserState): CSSString
     {

--- a/src/Value/CalcFunction.php
+++ b/src/Value/CalcFunction.php
@@ -23,6 +23,8 @@ class CalcFunction extends CSSFunction
     /**
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $parserState, bool $bIgnoreCase = false): CSSFunction
     {

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -27,6 +27,8 @@ class Color extends CSSFunction
     /**
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $parserState, bool $ignoreCase = false): CSSFunction
     {

--- a/src/Value/LineName.php
+++ b/src/Value/LineName.php
@@ -23,6 +23,8 @@ class LineName extends ValueList
     /**
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $parserState): LineName
     {

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -86,6 +86,8 @@ class Size extends PrimitiveValue
      *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $parserState, $bIsColorComponent = false): Size
     {

--- a/src/Value/URL.php
+++ b/src/Value/URL.php
@@ -33,6 +33,8 @@ class URL extends PrimitiveValue
      * @throws SourceException
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $parserState): URL
     {

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -38,6 +38,8 @@ abstract class Value implements Renderable
      *
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
+     *
+     * @internal since V8.8.0
      */
     public static function parseValue(ParserState $parserState, array $aListDelimiters = [])
     {
@@ -114,6 +116,8 @@ abstract class Value implements Renderable
      *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public static function parseIdentifierOrFunction(ParserState $parserState, $bIgnoreCase = false)
     {
@@ -144,6 +148,8 @@ abstract class Value implements Renderable
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      * @throws SourceException
+     *
+     * @internal since V8.8.0
      */
     public static function parsePrimitiveValue(ParserState $parserState)
     {


### PR DESCRIPTION
The only parsing method that is expected to be called from outside of this library is `Parser::parse()`.