### PR TITLE
[CLEANUP] Avoid Hungarian notation for `outputFormat`

### DIFF
--- a/src/CSSList/AtRuleBlockList.php
+++ b/src/CSSList/AtRuleBlockList.php
@@ -55,18 +55,18 @@ class AtRuleBlockList extends CSSBlockList implements AtRule
         return $this->render(new OutputFormat());
     }
 
-    public function render(OutputFormat $oOutputFormat): string
+    public function render(OutputFormat $outputFormat): string
     {
-        $sResult = $oOutputFormat->comments($this);
-        $sResult .= $oOutputFormat->sBeforeAtRuleBlock;
+        $sResult = $outputFormat->comments($this);
+        $sResult .= $outputFormat->sBeforeAtRuleBlock;
         $sArgs = $this->sArgs;
         if ($sArgs) {
             $sArgs = ' ' . $sArgs;
         }
-        $sResult .= "@{$this->type}$sArgs{$oOutputFormat->spaceBeforeOpeningBrace()}{";
-        $sResult .= $this->renderListContents($oOutputFormat);
+        $sResult .= "@{$this->type}$sArgs{$outputFormat->spaceBeforeOpeningBrace()}{";
+        $sResult .= $this->renderListContents($outputFormat);
         $sResult .= '}';
-        $sResult .= $oOutputFormat->sAfterAtRuleBlock;
+        $sResult .= $outputFormat->sAfterAtRuleBlock;
         return $sResult;
     }
 

--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -410,16 +410,16 @@ abstract class CSSList implements Renderable, Commentable
     /**
      * @return string
      */
-    protected function renderListContents(OutputFormat $oOutputFormat)
+    protected function renderListContents(OutputFormat $outputFormat)
     {
         $result = '';
         $isFirst = true;
-        $nextLevelFormat = $oOutputFormat;
+        $nextLevelFormat = $outputFormat;
         if (!$this->isRootList()) {
-            $nextLevelFormat = $oOutputFormat->nextLevel();
+            $nextLevelFormat = $outputFormat->nextLevel();
         }
         foreach ($this->contents as $listItem) {
-            $renderedCss = $oOutputFormat->safely(static function () use ($nextLevelFormat, $listItem): string {
+            $renderedCss = $outputFormat->safely(static function () use ($nextLevelFormat, $listItem): string {
                 return $listItem->render($nextLevelFormat);
             });
             if ($renderedCss === null) {
@@ -436,7 +436,7 @@ abstract class CSSList implements Renderable, Commentable
 
         if (!$isFirst) {
             // Had some output
-            $result .= $oOutputFormat->spaceAfterBlocks();
+            $result .= $outputFormat->spaceAfterBlocks();
         }
 
         return $result;

--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -114,12 +114,12 @@ class Document extends CSSBlockList
     /**
      * Overrides `render()` to make format argument optional.
      */
-    public function render(?OutputFormat $oOutputFormat = null): string
+    public function render(?OutputFormat $outputFormat = null): string
     {
-        if ($oOutputFormat === null) {
-            $oOutputFormat = new OutputFormat();
+        if ($outputFormat === null) {
+            $outputFormat = new OutputFormat();
         }
-        return $oOutputFormat->comments($this) . $this->renderListContents($oOutputFormat);
+        return $outputFormat->comments($this) . $this->renderListContents($outputFormat);
     }
 
     public function isRootList(): bool

--- a/src/CSSList/KeyFrame.php
+++ b/src/CSSList/KeyFrame.php
@@ -66,11 +66,11 @@ class KeyFrame extends CSSList implements AtRule
         return $this->render(new OutputFormat());
     }
 
-    public function render(OutputFormat $oOutputFormat): string
+    public function render(OutputFormat $outputFormat): string
     {
-        $sResult = $oOutputFormat->comments($this);
-        $sResult .= "@{$this->vendorKeyFrame} {$this->animationName}{$oOutputFormat->spaceBeforeOpeningBrace()}{";
-        $sResult .= $this->renderListContents($oOutputFormat);
+        $sResult = $outputFormat->comments($this);
+        $sResult .= "@{$this->vendorKeyFrame} {$this->animationName}{$outputFormat->spaceBeforeOpeningBrace()}{";
+        $sResult .= $this->renderListContents($outputFormat);
         $sResult .= '}';
         return $sResult;
     }

--- a/src/Property/CSSNamespace.php
+++ b/src/Property/CSSNamespace.php
@@ -60,10 +60,10 @@ class CSSNamespace implements AtRule
         return $this->render(new OutputFormat());
     }
 
-    public function render(OutputFormat $oOutputFormat): string
+    public function render(OutputFormat $outputFormat): string
     {
         return '@namespace ' . ($this->sPrefix === null ? '' : $this->sPrefix . ' ')
-            . $this->mUrl->render($oOutputFormat) . ';';
+            . $this->mUrl->render($outputFormat) . ';';
     }
 
     /**

--- a/src/Property/Charset.php
+++ b/src/Property/Charset.php
@@ -77,9 +77,9 @@ class Charset implements AtRule
         return $this->render(new OutputFormat());
     }
 
-    public function render(OutputFormat $oOutputFormat): string
+    public function render(OutputFormat $outputFormat): string
     {
-        return "{$oOutputFormat->comments($this)}@charset {$this->oCharset->render($oOutputFormat)};";
+        return "{$outputFormat->comments($this)}@charset {$this->oCharset->render($outputFormat)};";
     }
 
     public function atRuleName(): string

--- a/src/Property/Import.php
+++ b/src/Property/Import.php
@@ -78,9 +78,9 @@ class Import implements AtRule
         return $this->render(new OutputFormat());
     }
 
-    public function render(OutputFormat $oOutputFormat): string
+    public function render(OutputFormat $outputFormat): string
     {
-        return $oOutputFormat->comments($this) . '@import ' . $this->location->render($oOutputFormat)
+        return $outputFormat->comments($this) . '@import ' . $this->location->render($outputFormat)
             . ($this->mediaQuery === null ? '' : ' ' . $this->mediaQuery) . ';';
     }
 

--- a/src/Renderable.php
+++ b/src/Renderable.php
@@ -8,7 +8,7 @@ interface Renderable
 {
     public function __toString(): string;
 
-    public function render(OutputFormat $oOutputFormat): string;
+    public function render(OutputFormat $outputFormat): string;
 
     /**
      * @return int<0, max>

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -267,11 +267,11 @@ class Rule implements Renderable, Commentable
         return $this->render(new OutputFormat());
     }
 
-    public function render(OutputFormat $oOutputFormat): string
+    public function render(OutputFormat $outputFormat): string
     {
-        $sResult = "{$oOutputFormat->comments($this)}{$this->sRule}:{$oOutputFormat->spaceAfterRuleName()}";
+        $sResult = "{$outputFormat->comments($this)}{$this->sRule}:{$outputFormat->spaceAfterRuleName()}";
         if ($this->mValue instanceof Value) { // Can also be a ValueList
-            $sResult .= $this->mValue->render($oOutputFormat);
+            $sResult .= $this->mValue->render($outputFormat);
         } else {
             $sResult .= $this->mValue;
         }

--- a/src/RuleSet/AtRuleSet.php
+++ b/src/RuleSet/AtRuleSet.php
@@ -58,15 +58,15 @@ class AtRuleSet extends RuleSet implements AtRule
         return $this->render(new OutputFormat());
     }
 
-    public function render(OutputFormat $oOutputFormat): string
+    public function render(OutputFormat $outputFormat): string
     {
-        $sResult = $oOutputFormat->comments($this);
+        $sResult = $outputFormat->comments($this);
         $sArgs = $this->sArgs;
         if ($sArgs) {
             $sArgs = ' ' . $sArgs;
         }
-        $sResult .= "@{$this->sType}$sArgs{$oOutputFormat->spaceBeforeOpeningBrace()}{";
-        $sResult .= $this->renderRules($oOutputFormat);
+        $sResult .= "@{$this->sType}$sArgs{$outputFormat->spaceBeforeOpeningBrace()}{";
+        $sResult .= $this->renderRules($outputFormat);
         $sResult .= '}';
         return $sResult;
     }

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -159,23 +159,23 @@ class DeclarationBlock extends RuleSet
     /**
      * @throws OutputException
      */
-    public function render(OutputFormat $oOutputFormat): string
+    public function render(OutputFormat $outputFormat): string
     {
-        $sResult = $oOutputFormat->comments($this);
+        $sResult = $outputFormat->comments($this);
         if (\count($this->aSelectors) === 0) {
             // If all the selectors have been removed, this declaration block becomes invalid
             throw new OutputException('Attempt to print declaration block with missing selector', $this->lineNumber);
         }
-        $sResult .= $oOutputFormat->sBeforeDeclarationBlock;
-        $sResult .= $oOutputFormat->implode(
-            $oOutputFormat->spaceBeforeSelectorSeparator() . ',' . $oOutputFormat->spaceAfterSelectorSeparator(),
+        $sResult .= $outputFormat->sBeforeDeclarationBlock;
+        $sResult .= $outputFormat->implode(
+            $outputFormat->spaceBeforeSelectorSeparator() . ',' . $outputFormat->spaceAfterSelectorSeparator(),
             $this->aSelectors
         );
-        $sResult .= $oOutputFormat->sAfterDeclarationBlockSelectors;
-        $sResult .= $oOutputFormat->spaceBeforeOpeningBrace() . '{';
-        $sResult .= $this->renderRules($oOutputFormat);
+        $sResult .= $outputFormat->sAfterDeclarationBlockSelectors;
+        $sResult .= $outputFormat->spaceBeforeOpeningBrace() . '{';
+        $sResult .= $this->renderRules($outputFormat);
         $sResult .= '}';
-        $sResult .= $oOutputFormat->sAfterDeclarationBlock;
+        $sResult .= $outputFormat->sAfterDeclarationBlock;
         return $sResult;
     }
 }

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -263,11 +263,11 @@ abstract class RuleSet implements Renderable, Commentable
     /**
      * @return string
      */
-    protected function renderRules(OutputFormat $oOutputFormat)
+    protected function renderRules(OutputFormat $outputFormat)
     {
         $sResult = '';
         $bIsFirst = true;
-        $oNextLevel = $oOutputFormat->nextLevel();
+        $oNextLevel = $outputFormat->nextLevel();
         foreach ($this->aRules as $aRules) {
             foreach ($aRules as $rule) {
                 $sRendered = $oNextLevel->safely(static function () use ($rule, $oNextLevel): string {
@@ -288,10 +288,10 @@ abstract class RuleSet implements Renderable, Commentable
 
         if (!$bIsFirst) {
             // Had some output
-            $sResult .= $oOutputFormat->spaceAfterRules();
+            $sResult .= $outputFormat->spaceAfterRules();
         }
 
-        return $oOutputFormat->removeLastSemicolon($sResult);
+        return $outputFormat->removeLastSemicolon($sResult);
     }
 
     /**

--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -108,9 +108,9 @@ class CSSFunction extends ValueList
         return $this->render(new OutputFormat());
     }
 
-    public function render(OutputFormat $oOutputFormat): string
+    public function render(OutputFormat $outputFormat): string
     {
-        $aArguments = parent::render($oOutputFormat);
+        $aArguments = parent::render($outputFormat);
         return "{$this->sName}({$aArguments})";
     }
 }

--- a/src/Value/CSSString.php
+++ b/src/Value/CSSString.php
@@ -93,10 +93,10 @@ class CSSString extends PrimitiveValue
         return $this->render(new OutputFormat());
     }
 
-    public function render(OutputFormat $oOutputFormat): string
+    public function render(OutputFormat $outputFormat): string
     {
         $sString = \addslashes($this->sString);
         $sString = \str_replace("\n", '\\A', $sString);
-        return $oOutputFormat->getStringQuotingType() . $sString . $oOutputFormat->getStringQuotingType();
+        return $outputFormat->getStringQuotingType() . $sString . $outputFormat->getStringQuotingType();
     }
 }

--- a/src/Value/CalcRuleValueList.php
+++ b/src/Value/CalcRuleValueList.php
@@ -16,8 +16,8 @@ class CalcRuleValueList extends RuleValueList
         parent::__construct(',', $lineNumber);
     }
 
-    public function render(OutputFormat $oOutputFormat): string
+    public function render(OutputFormat $outputFormat): string
     {
-        return $oOutputFormat->implode(' ', $this->aComponents);
+        return $outputFormat->implode(' ', $this->aComponents);
     }
 }

--- a/src/Value/LineName.php
+++ b/src/Value/LineName.php
@@ -52,7 +52,7 @@ class LineName extends ValueList
         return $this->render(new OutputFormat());
     }
 
-    public function render(OutputFormat $oOutputFormat): string
+    public function render(OutputFormat $outputFormat): string
     {
         return '[' . parent::render(OutputFormat::createCompact()) . ']';
     }

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -213,7 +213,7 @@ class Size extends PrimitiveValue
         return $this->render(new OutputFormat());
     }
 
-    public function render(OutputFormat $oOutputFormat): string
+    public function render(OutputFormat $outputFormat): string
     {
         $l = \localeconv();
         $sPoint = \preg_quote($l['decimal_point'], '/');

--- a/src/Value/URL.php
+++ b/src/Value/URL.php
@@ -79,8 +79,8 @@ class URL extends PrimitiveValue
         return $this->render(new OutputFormat());
     }
 
-    public function render(OutputFormat $oOutputFormat): string
+    public function render(OutputFormat $outputFormat): string
     {
-        return "url({$this->oURL->render($oOutputFormat)})";
+        return "url({$this->oURL->render($outputFormat)})";
     }
 }

--- a/src/Value/ValueList.php
+++ b/src/Value/ValueList.php
@@ -88,11 +88,11 @@ abstract class ValueList extends Value
         return $this->render(new OutputFormat());
     }
 
-    public function render(OutputFormat $oOutputFormat): string
+    public function render(OutputFormat $outputFormat): string
     {
-        return $oOutputFormat->implode(
-            $oOutputFormat->spaceBeforeListArgumentSeparator($this->sSeparator) . $this->sSeparator
-            . $oOutputFormat->spaceAfterListArgumentSeparator($this->sSeparator),
+        return $outputFormat->implode(
+            $outputFormat->spaceBeforeListArgumentSeparator($this->sSeparator) . $this->sSeparator
+            . $outputFormat->spaceAfterListArgumentSeparator($this->sSeparator),
             $this->aComponents
         );
     }


### PR DESCRIPTION
Part of #756