### PR TITLE
[TASK] Move some tests for `Comment` to functional tests

### DIFF
--- a/tests/Functional/Comment/CommentTest.php
+++ b/tests/Functional/Comment/CommentTest.php
@@ -49,7 +49,7 @@ final class CommentTest extends TestCase
 
         $subject->setComment($comment);
 
-        self::assertSame('/*' . $comment . '*/', $subject->render(new OutputFormat()));
+        self::assertSame('/*' . $comment . '*/', $subject->render(OutputFormat::createCompact()));
     }
 
     /**

--- a/tests/Functional/Comment/CommentTest.php
+++ b/tests/Functional/Comment/CommentTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabberworm\CSS\Tests\Functional\Comment;
+
+use PHPUnit\Framework\TestCase;
+use Sabberworm\CSS\Comment\Comment;
+use Sabberworm\CSS\OutputFormat;
+
+/**
+ * @covers \Sabberworm\CSS\Comment\Comment
+ */
+final class CommentTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function toStringRendersCommentEnclosedInCommentDelimiters(): void
+    {
+        $comment = 'There is no spoon.';
+        $subject = new Comment();
+
+        $subject->setComment($comment);
+
+        self::assertSame('/*' . $comment . '*/', (string) $subject);
+    }
+
+    /**
+     * @test
+     */
+    public function renderWithDefaultOutputFormatRendersCommentEnclosedInCommentDelimiters(): void
+    {
+        $comment = 'There is no spoon.';
+        $subject = new Comment();
+
+        $subject->setComment($comment);
+
+        self::assertSame('/*' . $comment . '*/', $subject->render(new OutputFormat()));
+    }
+
+    /**
+     * @test
+     */
+    public function renderWithCompactOutputFormatRendersCommentEnclosedInCommentDelimiters(): void
+    {
+        $comment = 'There is no spoon.';
+        $subject = new Comment();
+
+        $subject->setComment($comment);
+
+        self::assertSame('/*' . $comment . '*/', $subject->render(new OutputFormat()));
+    }
+
+    /**
+     * @test
+     */
+    public function renderWithPrettyOutputFormatRendersCommentEnclosedInCommentDelimiters(): void
+    {
+        $comment = 'There is no spoon.';
+        $subject = new Comment();
+
+        $subject->setComment($comment);
+
+        self::assertSame('/*' . $comment . '*/', $subject->render(new OutputFormat()));
+    }
+}

--- a/tests/Functional/Comment/CommentTest.php
+++ b/tests/Functional/Comment/CommentTest.php
@@ -62,6 +62,6 @@ final class CommentTest extends TestCase
 
         $subject->setComment($comment);
 
-        self::assertSame('/*' . $comment . '*/', $subject->render(new OutputFormat()));
+        self::assertSame('/*' . $comment . '*/', $subject->render(OutputFormat::createPretty()));
     }
 }

--- a/tests/Functional/Comment/CommentTest.php
+++ b/tests/Functional/Comment/CommentTest.php
@@ -29,7 +29,7 @@ final class CommentTest extends TestCase
     /**
      * @test
      */
-    public function renderWithDefaultOutputFormatRendersCommentEnclosedInCommentDelimiters(): void
+    public function renderWithVirginOutputFormatRendersCommentEnclosedInCommentDelimiters(): void
     {
         $comment = 'There is no spoon.';
         $subject = new Comment();
@@ -37,6 +37,19 @@ final class CommentTest extends TestCase
         $subject->setComment($comment);
 
         self::assertSame('/*' . $comment . '*/', $subject->render(new OutputFormat()));
+    }
+
+    /**
+     * @test
+     */
+    public function renderWithDefaultOutputFormatRendersCommentEnclosedInCommentDelimiters(): void
+    {
+        $comment = 'There is no spoon.';
+        $subject = new Comment();
+
+        $subject->setComment($comment);
+
+        self::assertSame('/*' . $comment . '*/', $subject->render(OutputFormat::create()));
     }
 
     /**

--- a/tests/Unit/Comment/CommentTest.php
+++ b/tests/Unit/Comment/CommentTest.php
@@ -6,7 +6,6 @@ namespace Sabberworm\CSS\Tests\Unit\Comment;
 
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\Comment\Comment;
-use Sabberworm\CSS\OutputFormat;
 use Sabberworm\CSS\Renderable;
 
 /**
@@ -77,31 +76,5 @@ final class CommentTest extends TestCase
         $subject = new Comment('', $lineNumber);
 
         self::assertSame($lineNumber, $subject->getLineNo());
-    }
-
-    /**
-     * @test
-     */
-    public function toStringRendersCommentEnclosedInCommentDelimiters(): void
-    {
-        $comment = 'There is no spoon.';
-        $subject = new Comment();
-
-        $subject->setComment($comment);
-
-        self::assertSame('/*' . $comment . '*/', (string) $subject);
-    }
-
-    /**
-     * @test
-     */
-    public function renderRendersCommentEnclosedInCommentDelimiters(): void
-    {
-        $comment = 'There is no spoon.';
-        $subject = new Comment();
-
-        $subject->setComment($comment);
-
-        self::assertSame('/*' . $comment . '*/', $subject->render(new OutputFormat()));
     }
 }


### PR DESCRIPTION
Move the tests that rely on another class (`OutputFormat`) (or might in the future).

Part of #757.