### PR TITLE
[TASK] Mark many parsing-related methods as `@internal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Mark parsing-related methods of most CSS elements as `@internal` (#90)
 - Mark `OutputFormat::nextLevel()` as `@internal` (#901)
 - Make all non-private properties `@internal` (#886)
 

--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -67,6 +67,8 @@ abstract class CSSList implements Renderable, Commentable
      *
      * @throws UnexpectedTokenException
      * @throws SourceException
+     *
+     * @internal since V8.8.0
      */
     public static function parseList(ParserState $oParserState, CSSList $oList)
     {

--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -28,6 +28,8 @@ class Document extends CSSBlockList
      * @return Document
      *
      * @throws SourceException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $oParserState)
     {

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -141,6 +141,8 @@ class ParserState
      * @return string
      *
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public function parseIdentifier($bIgnoreCase = true)
     {
@@ -172,6 +174,8 @@ class ParserState
      *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public function parseCharacter($bIsForIdentifier)
     {

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -79,6 +79,8 @@ class Rule implements Renderable, Commentable
      *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $oParserState)
     {

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -49,6 +49,8 @@ class DeclarationBlock extends RuleSet
      *
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $oParserState, $oList = null)
     {

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -56,6 +56,8 @@ abstract class RuleSet implements Renderable, Commentable
      *
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
+     *
+     * @internal since V8.8.0
      */
     public static function parseRuleSet(ParserState $oParserState, RuleSet $oRuleSet)
     {

--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -47,6 +47,8 @@ class CSSFunction extends ValueList
      * @throws SourceException
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $oParserState, $bIgnoreCase = false)
     {

--- a/src/Value/CSSString.php
+++ b/src/Value/CSSString.php
@@ -36,6 +36,8 @@ class CSSString extends PrimitiveValue
      * @throws SourceException
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $oParserState)
     {

--- a/src/Value/CalcFunction.php
+++ b/src/Value/CalcFunction.php
@@ -30,6 +30,8 @@ class CalcFunction extends CSSFunction
      *
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $oParserState, $bIgnoreCase = false)
     {

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -30,6 +30,8 @@ class Color extends CSSFunction
      *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $oParserState, $bIgnoreCase = false)
     {

--- a/src/Value/LineName.php
+++ b/src/Value/LineName.php
@@ -23,6 +23,8 @@ class LineName extends ValueList
      *
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $oParserState)
     {

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -92,6 +92,8 @@ class Size extends PrimitiveValue
      *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $oParserState, $bIsColorComponent = false)
     {

--- a/src/Value/URL.php
+++ b/src/Value/URL.php
@@ -33,6 +33,8 @@ class URL extends PrimitiveValue
      * @throws SourceException
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public static function parse(ParserState $oParserState)
     {

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -36,6 +36,8 @@ abstract class Value implements Renderable
      *
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
+     *
+     * @internal since V8.8.0
      */
     public static function parseValue(ParserState $oParserState, array $aListDelimiters = [])
     {
@@ -112,6 +114,8 @@ abstract class Value implements Renderable
      *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @internal since V8.8.0
      */
     public static function parseIdentifierOrFunction(ParserState $oParserState, $bIgnoreCase = false)
     {
@@ -142,6 +146,8 @@ abstract class Value implements Renderable
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      * @throws SourceException
+     *
+     * @internal since V8.8.0
      */
     public static function parsePrimitiveValue(ParserState $oParserState)
     {


### PR DESCRIPTION
The only parsing method that is expected to be called from outside of this library is `Parser::parse()`.

This is the V8.x backport of #908.