### PR TITLE
[CLEANUP] Avoid Hungarian notation for `arguments`

### DIFF
--- a/src/CSSList/AtRuleBlockList.php
+++ b/src/CSSList/AtRuleBlockList.php
@@ -20,7 +20,7 @@ class AtRuleBlockList extends CSSBlockList implements AtRule
     /**
      * @var string
      */
-    private $sArgs;
+    private $arguments;
 
     /**
      * @param string $type
@@ -31,7 +31,7 @@ class AtRuleBlockList extends CSSBlockList implements AtRule
     {
         parent::__construct($lineNumber);
         $this->type = $type;
-        $this->sArgs = $arguments;
+        $this->arguments = $arguments;
     }
 
     /**
@@ -47,7 +47,7 @@ class AtRuleBlockList extends CSSBlockList implements AtRule
      */
     public function atRuleArgs()
     {
-        return $this->sArgs;
+        return $this->arguments;
     }
 
     public function __toString(): string
@@ -59,11 +59,11 @@ class AtRuleBlockList extends CSSBlockList implements AtRule
     {
         $sResult = $outputFormat->comments($this);
         $sResult .= $outputFormat->sBeforeAtRuleBlock;
-        $sArgs = $this->sArgs;
-        if ($sArgs) {
-            $sArgs = ' ' . $sArgs;
+        $arguments = $this->arguments;
+        if ($arguments) {
+            $arguments = ' ' . $arguments;
         }
-        $sResult .= "@{$this->type}$sArgs{$outputFormat->spaceBeforeOpeningBrace()}{";
+        $sResult .= "@{$this->type}$arguments{$outputFormat->spaceBeforeOpeningBrace()}{";
         $sResult .= $this->renderListContents($outputFormat);
         $sResult .= '}';
         $sResult .= $outputFormat->sAfterAtRuleBlock;

--- a/src/RuleSet/AtRuleSet.php
+++ b/src/RuleSet/AtRuleSet.php
@@ -23,18 +23,18 @@ class AtRuleSet extends RuleSet implements AtRule
     /**
      * @var string
      */
-    private $sArgs;
+    private $arguments;
 
     /**
      * @param string $sType
-     * @param string $sArgs
+     * @param string $arguments
      * @param int<0, max> $lineNumber
      */
-    public function __construct($sType, $sArgs = '', $lineNumber = 0)
+    public function __construct($sType, $arguments = '', $lineNumber = 0)
     {
         parent::__construct($lineNumber);
         $this->sType = $sType;
-        $this->sArgs = $sArgs;
+        $this->arguments = $arguments;
     }
 
     /**
@@ -50,7 +50,7 @@ class AtRuleSet extends RuleSet implements AtRule
      */
     public function atRuleArgs()
     {
-        return $this->sArgs;
+        return $this->arguments;
     }
 
     public function __toString(): string
@@ -61,11 +61,11 @@ class AtRuleSet extends RuleSet implements AtRule
     public function render(OutputFormat $outputFormat): string
     {
         $sResult = $outputFormat->comments($this);
-        $sArgs = $this->sArgs;
-        if ($sArgs) {
-            $sArgs = ' ' . $sArgs;
+        $arguments = $this->arguments;
+        if ($arguments) {
+            $arguments = ' ' . $arguments;
         }
-        $sResult .= "@{$this->sType}$sArgs{$outputFormat->spaceBeforeOpeningBrace()}{";
+        $sResult .= "@{$this->sType}$arguments{$outputFormat->spaceBeforeOpeningBrace()}{";
         $sResult .= $this->renderRules($outputFormat);
         $sResult .= '}';
         return $sResult;


### PR DESCRIPTION
Part of #756