### PR TITLE
[TASK] Use type-safe setters in `OutputFormat` factory methods

### DIFF
--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -820,12 +820,18 @@ class OutputFormat
     public static function createCompact(): self
     {
         $format = self::create();
-        $format->set('Space*Rules', '')
-            ->set('Space*Blocks', '')
+        $format
+            ->setSpaceBeforeRules('')
+            ->setSpaceBetweenRules('')
+            ->setSpaceAfterRules('')
+            ->setSpaceBeforeBlocks('')
+            ->setSpaceBetweenBlocks('')
+            ->setSpaceAfterBlocks('')
             ->setSpaceAfterRuleName('')
             ->setSpaceBeforeOpeningBrace('')
             ->setSpaceAfterSelectorSeparator('')
             ->setRenderComments(false);
+
         return $format;
     }
 
@@ -835,11 +841,16 @@ class OutputFormat
     public static function createPretty(): self
     {
         $format = self::create();
-        $format->set('Space*Rules', "\n")
-            ->set('Space*Blocks', "\n")
+        $format
+            ->setSpaceBeforeRules("\n")
+            ->setSpaceBetweenRules("\n")
+            ->setSpaceAfterRules("\n")
+            ->setSpaceBeforeBlocks("\n")
             ->setSpaceBetweenBlocks("\n\n")
-            ->set('SpaceAfterListArgumentSeparators', [',' => ' '])
+            ->setSpaceAfterBlocks("\n")
+            ->setSpaceAfterListArgumentSeparators([',' => ' '])
             ->setRenderComments(true);
+
         return $format;
     }
 }

--- a/tests/Unit/OutputFormatTest.php
+++ b/tests/Unit/OutputFormatTest.php
@@ -899,6 +899,14 @@ final class OutputFormatTest extends TestCase
     /**
      * @test
      */
+    public function createCreatesInstanceWithDefaultSettings(): void
+    {
+        self::assertEquals(new OutputFormat(), OutputFormat::create());
+    }
+
+    /**
+     * @test
+     */
     public function createCalledTwoTimesReturnsDifferentInstances(): void
     {
         $firstCallResult = OutputFormat::create();


### PR DESCRIPTION
Also add one more test for good measure.