### PR TITLE
[TASK] Drop redundant constructor code

### DIFF
--- a/src/CSSList/CSSBlockList.php
+++ b/src/CSSList/CSSBlockList.php
@@ -21,14 +21,6 @@ use Sabberworm\CSS\Value\ValueList;
 abstract class CSSBlockList extends CSSList
 {
     /**
-     * @param int<0, max> $lineNumber
-     */
-    public function __construct($lineNumber = 0)
-    {
-        parent::__construct($lineNumber);
-    }
-
-    /**
      * @param array<int, DeclarationBlock> $result
      */
     protected function allDeclarationBlocks(array &$result): void

--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -38,14 +38,14 @@ abstract class CSSList implements Renderable, Commentable
      *
      * @internal since 8.8.0
      */
-    protected $comments;
+    protected $comments = [];
 
     /**
      * @var array<int, RuleSet|CSSList|Import|Charset>
      *
      * @internal since 8.8.0
      */
-    protected $contents;
+    protected $contents = [];
 
     /**
      * @var int<0, max>
@@ -59,8 +59,6 @@ abstract class CSSList implements Renderable, Commentable
      */
     public function __construct($lineNumber = 0)
     {
-        $this->comments = [];
-        $this->contents = [];
         $this->lineNumber = $lineNumber;
     }
 

--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -19,14 +19,6 @@ use Sabberworm\CSS\Value\Value;
 class Document extends CSSBlockList
 {
     /**
-     * @param int<0, max> $lineNumber
-     */
-    public function __construct($lineNumber = 0)
-    {
-        parent::__construct($lineNumber);
-    }
-
-    /**
      * @throws SourceException
      *
      * @internal since V8.8.0

--- a/src/CSSList/KeyFrame.php
+++ b/src/CSSList/KeyFrame.php
@@ -12,12 +12,12 @@ class KeyFrame extends CSSList implements AtRule
     /**
      * @var string|null
      */
-    private $vendorKeyFrame = null;
+    private $vendorKeyFrame;
 
     /**
      * @var string|null
      */
-    private $animationName = null;
+    private $animationName;
 
     /**
      * @param string $vendorKeyFrame

--- a/src/CSSList/KeyFrame.php
+++ b/src/CSSList/KeyFrame.php
@@ -12,22 +12,12 @@ class KeyFrame extends CSSList implements AtRule
     /**
      * @var string|null
      */
-    private $vendorKeyFrame;
+    private $vendorKeyFrame = null;
 
     /**
      * @var string|null
      */
-    private $animationName;
-
-    /**
-     * @param int<0, max> $lineNumber
-     */
-    public function __construct($lineNumber = 0)
-    {
-        parent::__construct($lineNumber);
-        $this->vendorKeyFrame = null;
-        $this->animationName = null;
-    }
+    private $animationName = null;
 
     /**
      * @param string $vendorKeyFrame

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -217,12 +217,12 @@ class OutputFormat
     /**
      * @var OutputFormatter|null
      */
-    private $oFormatter = null;
+    private $oFormatter;
 
     /**
      * @var OutputFormat|null
      */
-    private $oNextLevelFormat = null;
+    private $oNextLevelFormat;
 
     /**
      * @var int

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -37,7 +37,7 @@ class ParserState
     /**
      * @var int
      */
-    private $iCurrentPosition;
+    private $iCurrentPosition = 0;
 
     /**
      * will only be used if the CSS does not contain an `@charset` declaration
@@ -64,7 +64,6 @@ class ParserState
     {
         $this->oParserSettings = $oParserSettings;
         $this->sText = $sText;
-        $this->iCurrentPosition = 0;
         $this->lineNumber = $lineNumber;
         $this->setCharset($this->oParserSettings->sDefaultCharset);
     }

--- a/src/Property/CSSNamespace.php
+++ b/src/Property/CSSNamespace.php
@@ -32,7 +32,7 @@ class CSSNamespace implements AtRule
      *
      * @internal since 8.8.0
      */
-    protected $comments;
+    protected $comments = [];
 
     /**
      * @param string $mUrl
@@ -44,7 +44,6 @@ class CSSNamespace implements AtRule
         $this->mUrl = $mUrl;
         $this->prefix = $prefix;
         $this->lineNumber = $lineNumber;
-        $this->comments = [];
     }
 
     /**

--- a/src/Property/Charset.php
+++ b/src/Property/Charset.php
@@ -35,7 +35,7 @@ class Charset implements AtRule
      *
      * @internal since 8.8.0
      */
-    protected $comments;
+    protected $comments = [];
 
     /**
      * @param int<0, max> $lineNumber
@@ -44,7 +44,6 @@ class Charset implements AtRule
     {
         $this->oCharset = $oCharset;
         $this->lineNumber = $lineNumber;
-        $this->comments = [];
     }
 
     /**

--- a/src/Property/Import.php
+++ b/src/Property/Import.php
@@ -35,7 +35,7 @@ class Import implements AtRule
      *
      * @internal since 8.8.0
      */
-    protected $comments;
+    protected $comments = [];
 
     /**
      * @param string $mediaQuery
@@ -46,7 +46,6 @@ class Import implements AtRule
         $this->location = $location;
         $this->mediaQuery = $mediaQuery;
         $this->lineNumber = $lineNumber;
-        $this->comments = [];
     }
 
     /**

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -29,7 +29,7 @@ class Rule implements Renderable, Commentable
     /**
      * @var RuleValueList|string|null
      */
-    private $mValue = null;
+    private $mValue;
 
     /**
      * @var bool

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -29,17 +29,17 @@ class Rule implements Renderable, Commentable
     /**
      * @var RuleValueList|string|null
      */
-    private $mValue;
+    private $mValue = null;
 
     /**
      * @var bool
      */
-    private $bIsImportant;
+    private $bIsImportant = false;
 
     /**
      * @var array<int, int>
      */
-    private $aIeHack;
+    private $aIeHack = [];
 
     /**
      * @var int
@@ -58,7 +58,7 @@ class Rule implements Renderable, Commentable
      *
      * @internal since 8.8.0
      */
-    protected $comments;
+    protected $comments = [];
 
     /**
      * @param string $sRule
@@ -68,12 +68,8 @@ class Rule implements Renderable, Commentable
     public function __construct($sRule, $lineNumber = 0, $iColNo = 0)
     {
         $this->sRule = $sRule;
-        $this->mValue = null;
-        $this->bIsImportant = false;
-        $this->aIeHack = [];
         $this->lineNumber = $lineNumber;
         $this->iColNo = $iColNo;
-        $this->comments = [];
     }
 
     /**

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -27,16 +27,7 @@ class DeclarationBlock extends RuleSet
     /**
      * @var array<int, Selector|string>
      */
-    private $aSelectors;
-
-    /**
-     * @param int<0, max> $lineNumber
-     */
-    public function __construct($lineNumber = 0)
-    {
-        parent::__construct($lineNumber);
-        $this->aSelectors = [];
-    }
+    private $aSelectors = [];
 
     /**
      * @param CSSList|null $list

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -27,7 +27,7 @@ abstract class RuleSet implements Renderable, Commentable
     /**
      * @var array<string, Rule>
      */
-    private $aRules;
+    private $aRules = [];
 
     /**
      * @var int<0, max>
@@ -41,16 +41,14 @@ abstract class RuleSet implements Renderable, Commentable
      *
      * @internal since 8.8.0
      */
-    protected $comments;
+    protected $comments = [];
 
     /**
      * @param int<0, max> $lineNumber
      */
     public function __construct($lineNumber = 0)
     {
-        $this->aRules = [];
         $this->lineNumber = $lineNumber;
-        $this->comments = [];
     }
 
     /**

--- a/src/Value/PrimitiveValue.php
+++ b/src/Value/PrimitiveValue.php
@@ -4,13 +4,4 @@ declare(strict_types=1);
 
 namespace Sabberworm\CSS\Value;
 
-abstract class PrimitiveValue extends Value
-{
-    /**
-     * @param int<0, max> $lineNumber
-     */
-    public function __construct($lineNumber = 0)
-    {
-        parent::__construct($lineNumber);
-    }
-}
+abstract class PrimitiveValue extends Value {}


### PR DESCRIPTION
- use default values for properties instead of setting them in the constructor
- drop constructors that are redundant to the constructor of the parent class