### PR TITLE
[CLEANUP] Avoid Hungarian notation for `text`/`characters`

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -19,15 +19,15 @@ class Parser
     private $parserState;
 
     /**
-     * @param string $sText the complete CSS as text (i.e., usually the contents of a CSS file)
+     * @param string $text the complete CSS as text (i.e., usually the contents of a CSS file)
      * @param int<0, max> $lineNumber the line number (starting from 1, not from 0)
      */
-    public function __construct($sText, ?Settings $parserSettings = null, $lineNumber = 1)
+    public function __construct($text, ?Settings $parserSettings = null, $lineNumber = 1)
     {
         if ($parserSettings === null) {
             $parserSettings = Settings::create();
         }
-        $this->parserState = new ParserState($sText, $parserSettings, $lineNumber);
+        $this->parserState = new ParserState($text, $parserSettings, $lineNumber);
     }
 
     /**

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -32,7 +32,7 @@ class ParserState
     /**
      * @var array<int, string>
      */
-    private $texts;
+    private $characters;
 
     /**
      * @var int
@@ -76,9 +76,9 @@ class ParserState
     public function setCharset($sCharset): void
     {
         $this->sCharset = $sCharset;
-        $this->texts = $this->strsplit($this->text);
-        if (\is_array($this->texts)) {
-            $this->iLength = \count($this->texts);
+        $this->characters = $this->strsplit($this->text);
+        if (\is_array($this->characters)) {
+            $this->iLength = \count($this->characters);
         }
     }
 
@@ -451,7 +451,7 @@ class ParserState
         }
         $result = '';
         while ($iLength > 0) {
-            $result .= $this->texts[$iStart];
+            $result .= $this->characters[$iStart];
             $iStart++;
             $iLength--;
         }

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -27,12 +27,12 @@ class ParserState
     /**
      * @var string
      */
-    private $sText;
+    private $text;
 
     /**
      * @var array<int, string>
      */
-    private $aText;
+    private $texts;
 
     /**
      * @var int
@@ -57,13 +57,13 @@ class ParserState
     private $lineNumber;
 
     /**
-     * @param string $sText the complete CSS as text (i.e., usually the contents of a CSS file)
+     * @param string $text the complete CSS as text (i.e., usually the contents of a CSS file)
      * @param int<0, max> $lineNumber
      */
-    public function __construct($sText, Settings $parserSettings, $lineNumber = 1)
+    public function __construct($text, Settings $parserSettings, $lineNumber = 1)
     {
         $this->parserSettings = $parserSettings;
-        $this->sText = $sText;
+        $this->text = $text;
         $this->lineNumber = $lineNumber;
         $this->setCharset($this->parserSettings->sDefaultCharset);
     }
@@ -76,9 +76,9 @@ class ParserState
     public function setCharset($sCharset): void
     {
         $this->sCharset = $sCharset;
-        $this->aText = $this->strsplit($this->sText);
-        if (\is_array($this->aText)) {
-            $this->iLength = \count($this->aText);
+        $this->texts = $this->strsplit($this->text);
+        if (\is_array($this->texts)) {
+            $this->iLength = \count($this->texts);
         }
     }
 
@@ -451,7 +451,7 @@ class ParserState
         }
         $result = '';
         while ($iLength > 0) {
-            $result .= $this->aText[$iStart];
+            $result .= $this->texts[$iStart];
             $iStart++;
             $iLength--;
         }


### PR DESCRIPTION
Part of #756