### PR TITLE
[TASK] Drop the unused `ParserState::getCharset()`

### DIFF
--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -83,16 +83,6 @@ class ParserState
     }
 
     /**
-     * Returns the charset that is used if the CSS does not contain an `@charset` declaration.
-     *
-     * @return string
-     */
-    public function getCharset()
-    {
-        return $this->sCharset;
-    }
-
-    /**
      * @return int
      */
     public function currentLine()


### PR DESCRIPTION
As this class is `@internal`, we do not need a deprecation process for this.