### PR TITLE
[TASK] Add some tests for `OutputFormatter` (part 1)

### DIFF
--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -121,6 +121,12 @@ parameters:
 			path: ../src/OutputFormat.php
 
 		-
+			message: '#^Parameters should have "string" types as the only types passed to this method$#'
+			identifier: typePerfect.narrowPublicClassMethodParamType
+			count: 2
+			path: ../src/OutputFormatter.php
+
+		-
 			message: '#^Default value of the parameter \#2 \$bIncludeEnd \(false\) of method Sabberworm\\CSS\\Parsing\\ParserState\:\:consumeUntil\(\) is incompatible with type string\.$#'
 			identifier: parameter.defaultValue
 			count: 1

--- a/tests/Unit/OutputFormatterTest.php
+++ b/tests/Unit/OutputFormatterTest.php
@@ -229,7 +229,7 @@ final class OutputFormatterTest extends TestCase
         $values = [$value1, $value2];
         $separator = ', ';
 
-        $result = $this->subject->implode(', ', $values);
+        $result = $this->subject->implode($separator, $values);
 
         self::assertSame($value1 . $separator . $value2, $result);
     }

--- a/tests/Unit/OutputFormatterTest.php
+++ b/tests/Unit/OutputFormatterTest.php
@@ -159,7 +159,7 @@ final class OutputFormatterTest extends TestCase
     /**
      * @test
      */
-    public function spaceAfterListArgumentSeparatorForExistingSpaceAfterProvidedSeparatorReturnsThat(): void
+    public function spaceAfterListArgumentSeparatorReturnsSpaceSetForSpecificSeparator(): void
     {
         $separator = ',';
         $space = '        ';

--- a/tests/Unit/OutputFormatterTest.php
+++ b/tests/Unit/OutputFormatterTest.php
@@ -258,7 +258,7 @@ final class OutputFormatterTest extends TestCase
         $renderedRenderable1 = 'tea';
         $renderable1->method('render')->with($this->outputFormat)->willReturn($renderedRenderable1);
         $renderable2 = $this->createMock(Renderable::class);
-        $renderedRenderable2 = 'tea';
+        $renderedRenderable2 = 'coffee';
         $renderable2->method('render')->with($this->outputFormat)->willReturn($renderedRenderable2);
         $values = [$renderable1, $renderable2];
         $separator = ', ';

--- a/tests/Unit/OutputFormatterTest.php
+++ b/tests/Unit/OutputFormatterTest.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabberworm\CSS\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Sabberworm\CSS\OutputFormat;
+use Sabberworm\CSS\OutputFormatter;
+use Sabberworm\CSS\Renderable;
+
+/**
+ * @covers \Sabberworm\CSS\OutputFormatter
+ */
+final class OutputFormatterTest extends TestCase
+{
+    /**
+     * @var OutputFormatter
+     */
+    private $subject;
+
+    /**
+     * @var OutputFormat
+     */
+    private $outputFormat;
+
+    protected function setUp(): void
+    {
+        $this->outputFormat = new OutputFormat();
+        $this->subject = new OutputFormatter($this->outputFormat);
+    }
+
+    /**
+     * @test
+     */
+    public function spaceAfterRuleNameReturnsSpaceAfterRuleNameFromOutputFormat(): void
+    {
+        $space = '        ';
+        $this->outputFormat->setSpaceAfterRuleName($space);
+
+        self::assertSame($space, $this->subject->spaceAfterRuleName());
+    }
+
+    /**
+     * @test
+     */
+    public function spaceBeforeRulesReturnsSpaceBeforeRulesFromOutputFormat(): void
+    {
+        $space = '        ';
+        $this->outputFormat->setSpaceBeforeRules($space);
+
+        self::assertSame($space, $this->subject->spaceBeforeRules());
+    }
+
+    /**
+     * @test
+     */
+    public function spaceAfterRulesReturnsSpaceAfterRulesFromOutputFormat(): void
+    {
+        $space = '        ';
+        $this->outputFormat->setSpaceAfterRules($space);
+
+        self::assertSame($space, $this->subject->spaceAfterRules());
+    }
+
+    /**
+     * @test
+     */
+    public function spaceBetweenRulesReturnsSpaceBetweenRulesFromOutputFormat(): void
+    {
+        $space = '        ';
+        $this->outputFormat->setSpaceBetweenRules($space);
+
+        self::assertSame($space, $this->subject->spaceBetweenRules());
+    }
+
+    /**
+     * @test
+     */
+    public function spaceBeforeBlocksReturnsSpaceBeforeBlocksFromOutputFormat(): void
+    {
+        $space = '        ';
+        $this->outputFormat->setSpaceBeforeBlocks($space);
+
+        self::assertSame($space, $this->subject->spaceBeforeBlocks());
+    }
+
+    /**
+     * @test
+     */
+    public function spaceAfterBlocksReturnsSpaceAfterBlocksFromOutputFormat(): void
+    {
+        $space = '        ';
+        $this->outputFormat->setSpaceAfterBlocks($space);
+
+        self::assertSame($space, $this->subject->spaceAfterBlocks());
+    }
+
+    /**
+     * @test
+     */
+    public function spaceBetweenBlocksReturnsSpaceBetweenBlocksFromOutputFormat(): void
+    {
+        $space = '        ';
+        $this->outputFormat->setSpaceBetweenBlocks($space);
+
+        self::assertSame($space, $this->subject->spaceBetweenBlocks());
+    }
+
+    /**
+     * @test
+     */
+    public function spaceBeforeSelectorSeparatorReturnsSpaceBeforeSelectorSeparatorFromOutputFormat(): void
+    {
+        $space = '        ';
+        $this->outputFormat->setSpaceBeforeSelectorSeparator($space);
+
+        self::assertSame($space, $this->subject->spaceBeforeSelectorSeparator());
+    }
+
+    /**
+     * @test
+     */
+    public function spaceAfterSelectorSeparatorReturnsSpaceAfterSelectorSeparatorFromOutputFormat(): void
+    {
+        $space = '        ';
+        $this->outputFormat->setSpaceAfterSelectorSeparator($space);
+
+        self::assertSame($space, $this->subject->spaceAfterSelectorSeparator());
+    }
+
+    /**
+     * @test
+     */
+    public function spaceBeforeListArgumentSeparatorForExistingSpaceBeforeProvidedSeparatorReturnsThat(): void
+    {
+        $separator = ',';
+        $space = '        ';
+        $this->outputFormat->setSpaceBeforeListArgumentSeparators([$separator => $space]);
+        $defaultSpace = "\t\t\t\t";
+        $this->outputFormat->setSpaceBeforeListArgumentSeparator($defaultSpace);
+
+        self::assertSame($space, $this->subject->spaceBeforeListArgumentSeparator($separator));
+    }
+
+    /**
+     * @test
+     */
+    public function spaceBeforeListArgumentSeparatorForNoExistingSpaceBeforeProvidedSeparatorReturnsDefaultSeparator(
+    ): void {
+        $space = '        ';
+        $this->outputFormat->setSpaceBeforeListArgumentSeparators([',' => $space]);
+        $defaultSpace = "\t\t\t\t";
+        $this->outputFormat->setSpaceBeforeListArgumentSeparator($defaultSpace);
+
+        self::assertSame($defaultSpace, $this->subject->spaceBeforeListArgumentSeparator(';'));
+    }
+
+    /**
+     * @test
+     */
+    public function spaceAfterListArgumentSeparatorForExistingSpaceAfterProvidedSeparatorReturnsThat(): void
+    {
+        $separator = ',';
+        $space = '        ';
+        $this->outputFormat->setSpaceAfterListArgumentSeparators([$separator => $space]);
+        $defaultSpace = "\t\t\t\t";
+        $this->outputFormat->setSpaceAfterListArgumentSeparator($defaultSpace);
+
+        self::assertSame($space, $this->subject->spaceAfterListArgumentSeparator($separator));
+    }
+
+    /**
+     * @test
+     */
+    public function spaceAfterListArgumentSeparatorForNoExistingSpaceAfterProvidedSeparatorReturnsDefaultSeparator(
+    ): void {
+        $space = '        ';
+        $this->outputFormat->setSpaceAfterListArgumentSeparators([',' => $space]);
+        $defaultSpace = "\t\t\t\t";
+        $this->outputFormat->setSpaceAfterListArgumentSeparator($defaultSpace);
+
+        self::assertSame($defaultSpace, $this->subject->spaceAfterListArgumentSeparator(';'));
+    }
+
+    /**
+     * @test
+     */
+    public function spaceBeforeOpeningBraceReturnsSpaceBeforeOpeningBraceFromOutputFormat(): void
+    {
+        $space = '        ';
+        $this->outputFormat->setSpaceBeforeOpeningBrace($space);
+
+        self::assertSame($space, $this->subject->spaceBeforeOpeningBrace());
+    }
+
+    /**
+     * @test
+     */
+    public function implodeForEmptyValuesReturnsEmptyString(): void
+    {
+        $values = [];
+
+        $result = $this->subject->implode(', ', $values);
+
+        self::assertSame('', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function implodeWithOneStringValueReturnsStringValue(): void
+    {
+        $value = 'tea';
+        $values = [$value];
+
+        $result = $this->subject->implode(', ', $values);
+
+        self::assertSame($value, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function implodeWithMultipleStringValuesReturnsValuesSeparatedBySeparator(): void
+    {
+        $value1 = 'tea';
+        $value2 = 'coffee';
+        $values = [$value1, $value2];
+        $separator = ', ';
+
+        $result = $this->subject->implode(', ', $values);
+
+        self::assertSame($value1 . $separator . $value2, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function implodeWithOneRenderableReturnsRenderedRenderable(): void
+    {
+        $renderable = $this->createMock(Renderable::class);
+        $renderedRenderable = 'tea';
+        $renderable->method('render')->with($this->outputFormat)->willReturn($renderedRenderable);
+        $values = [$renderable];
+
+        $result = $this->subject->implode(', ', $values);
+
+        self::assertSame($renderedRenderable, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function implodeWithMultipleRenderablesReturnsRenderedRenderablesSeparatedBySeparator(): void
+    {
+        $renderable1 = $this->createMock(Renderable::class);
+        $renderedRenderable1 = 'tea';
+        $renderable1->method('render')->with($this->outputFormat)->willReturn($renderedRenderable1);
+        $renderable2 = $this->createMock(Renderable::class);
+        $renderedRenderable2 = 'tea';
+        $renderable2->method('render')->with($this->outputFormat)->willReturn($renderedRenderable2);
+        $values = [$renderable1, $renderable2];
+        $separator = ', ';
+
+        $result = $this->subject->implode($separator, $values);
+
+        self::assertSame($renderedRenderable1 . $separator . $renderedRenderable2, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function implodeWithIncreaseLevelFalseUsesDefaultIndentationLevelForRendering(): void
+    {
+        $renderable = $this->createMock(Renderable::class);
+        $renderedRenderable = 'tea';
+        $renderable->method('render')->with($this->outputFormat)->willReturn($renderedRenderable);
+        $values = [$renderable];
+
+        $result = $this->subject->implode(', ', $values, false);
+
+        self::assertSame($renderedRenderable, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function implodeWithIncreaseLevelTrueIncreasesIndentationLevelForRendering(): void
+    {
+        $renderable = $this->createMock(Renderable::class);
+        $renderedRenderable = 'tea';
+        $renderable->method('render')->with($this->outputFormat->nextLevel())->willReturn($renderedRenderable);
+        $values = [$renderable];
+
+        $result = $this->subject->implode(', ', $values, true);
+
+        self::assertSame($renderedRenderable, $result);
+    }
+}

--- a/tests/Unit/OutputFormatterTest.php
+++ b/tests/Unit/OutputFormatterTest.php
@@ -173,7 +173,7 @@ final class OutputFormatterTest extends TestCase
     /**
      * @test
      */
-    public function spaceAfterListArgumentSeparatorForNoExistingSpaceAfterProvidedSeparatorReturnsDefaultSeparator(
+    public function spaceAfterListArgumentSeparatorWithoutSpecificSettingReturnsDefaultSpace(
     ): void {
         $space = '        ';
         $this->outputFormat->setSpaceAfterListArgumentSeparators([',' => $space]);

--- a/tests/Unit/OutputFormatterTest.php
+++ b/tests/Unit/OutputFormatterTest.php
@@ -132,7 +132,7 @@ final class OutputFormatterTest extends TestCase
     /**
      * @test
      */
-    public function spaceBeforeListArgumentSeparatorForExistingSpaceBeforeProvidedSeparatorReturnsThat(): void
+    public function spaceBeforeListArgumentSeparatorReturnsSpaceSetForSpecificSeparator(): void
     {
         $separator = ',';
         $space = '        ';

--- a/tests/Unit/OutputFormatterTest.php
+++ b/tests/Unit/OutputFormatterTest.php
@@ -146,7 +146,7 @@ final class OutputFormatterTest extends TestCase
     /**
      * @test
      */
-    public function spaceBeforeListArgumentSeparatorForNoExistingSpaceBeforeProvidedSeparatorReturnsDefaultSeparator(
+    public function spaceBeforeListArgumentSeparatorWithoutSpecificSettingReturnsDefaultSpace(
     ): void {
         $space = '        ';
         $this->outputFormat->setSpaceBeforeListArgumentSeparators([',' => $space]);


### PR DESCRIPTION
Note: The new PHPStan warnings will go away once we add
native type declarations for `OutputFormatter`.

Part of #757