### PR TITLE
[TASK] Add some tests for `OutputFormatter` (part 2)

### DIFF
--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -123,7 +123,7 @@ parameters:
 		-
 			message: '#^Parameters should have "string" types as the only types passed to this method$#'
 			identifier: typePerfect.narrowPublicClassMethodParamType
-			count: 2
+			count: 3
 			path: ../src/OutputFormatter.php
 
 		-

--- a/tests/Unit/OutputFormatterTest.php
+++ b/tests/Unit/OutputFormatterTest.php
@@ -520,7 +520,7 @@ final class OutputFormatterTest extends TestCase
 
         $commentText1 = 'I am a teapot.';
         $comment1 = new Comment($commentText1);
-        $commentText2 = 'But I am what.';
+        $commentText2 = 'But I am not.';
         $comment2 = new Comment($commentText2);
         $commentText3 = 'So what am I then?';
         $comment3 = new Comment($commentText3);

--- a/tests/Unit/OutputFormatterTest.php
+++ b/tests/Unit/OutputFormatterTest.php
@@ -307,10 +307,10 @@ final class OutputFormatterTest extends TestCase
     {
         return [
             'empty string' => [''],
-            'string without semicolon' => ['Tea or coffee?'],
-            'string with trailing semicolon' => ['Tea or coffee;'],
-            'string with semicolon in the middle' => ['Tea; coffee'],
-            'string with semicolons in the middle and trailing' => ['Tea; coffee;'],
+            'string without semicolon' => ['Earl Grey: hot'],
+            'string with trailing semicolon' => ['Earl Grey: hot;'],
+            'string with semicolon in the middle' => ['Earl Grey: hot; Coffee: Americano'],
+            'string with semicolons in the middle and trailing' => ['Earl Grey: hot; Coffee: Americano;'],
         ];
     }
 
@@ -334,19 +334,31 @@ final class OutputFormatterTest extends TestCase
     {
         return [
             'empty string' => ['', ''],
-            'non-empty string without semicolon' => ['Tea or coffee?', 'Tea or coffee?'],
+            'non-empty string without semicolon' => ['Earl Grey: hot', 'Earl Grey: hot'],
             'just 1 semicolon' => [';', ''],
             'just 2 semicolons' => [';;', ';'],
-            'string with trailing semicolon' => ['tea or coffee;', 'tea or coffee'],
-            'string with semicolon in the middle' => ['tea; coffee', 'tea coffee'],
-            'string with semicolon in the middle and trailing' => ['tea; coffee;', 'tea; coffee'],
+            'string with trailing semicolon' => ['Earl Grey: hot;', 'Earl Grey: hot'],
+            'string with semicolon in the middle' => [
+                'Earl Grey: hot; Coffee: Americano',
+                'Earl Grey: hot Coffee: Americano',
+            ],
+            'string with semicolon in the middle and trailing' => [
+                'Earl Grey: hot; Coffee: Americano;',
+                'Earl Grey: hot; Coffee: Americano',
+            ],
             'string with 2 semicolons in the middle' => ['tea; coffee; Club-Mate', 'tea; coffee Club-Mate'],
             'string with 2 semicolons in the middle surrounded by spaces' => [
-                'tea ; coffee ; Club-Mate',
-                'tea ; coffee  Club-Mate',
+                'Earl Grey: hot ; Coffee: Americano ; Club-Mate: cold',
+                'Earl Grey: hot ; Coffee: Americano  Club-Mate: cold',
             ],
-            'string with 2 adjacent semicolons in the middle' => ['tea ;; coffee', 'tea ; coffee'],
-            'string with 3 adjacent semicolons in the middle' => ['tea ;;; coffee', 'tea ;; coffee'],
+            'string with 2 adjacent semicolons in the middle' => [
+                'Earl Grey: hot;; Coffee: Americano',
+                'Earl Grey: hot; Coffee: Americano',
+            ],
+            'string with 3 adjacent semicolons in the middle' => [
+                'Earl Grey: hot;;; Coffee: Americano',
+                'Earl Grey: hot;; Coffee: Americano',
+            ],
         ];
     }
 

--- a/tests/Unit/OutputFormatterTest.php
+++ b/tests/Unit/OutputFormatterTest.php
@@ -380,11 +380,43 @@ final class OutputFormatterTest extends TestCase
     /**
      * @test
      */
+    public function commentsWithEmptyCommentableAndRenderCommentsDisabledDoesNotReturnSpaceBetweenBlocks(): void
+    {
+        $this->outputFormat->setRenderComments(false);
+        $spaceBetweenBlocks = ' between-space ';
+        $this->outputFormat->setSpaceBetweenBlocks($spaceBetweenBlocks);
+
+        $commentable = $this->createMock(Commentable::class);
+        $commentable->method('getComments')->willReturn([]);
+
+        $result = $this->subject->comments($commentable);
+
+        self::assertStringNotContainsString($spaceBetweenBlocks, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function commentsWithEmptyCommentableAndRenderCommentsDisabledDoesNotReturnSpaceAfterBlocks(): void
+    {
+        $this->outputFormat->setRenderComments(false);
+        $spaceAfterBlocks = ' after-space ';
+        $this->outputFormat->setSpaceAfterBlocks($spaceAfterBlocks);
+
+        $commentable = $this->createMock(Commentable::class);
+        $commentable->method('getComments')->willReturn([]);
+
+        $result = $this->subject->comments($commentable);
+
+        self::assertStringNotContainsString($spaceAfterBlocks, $result);
+    }
+
+    /**
+     * @test
+     */
     public function commentsWithEmptyCommentableAndRenderCommentsDisabledReturnsEmptyString(): void
     {
         $this->outputFormat->setRenderComments(false);
-        $this->outputFormat->setSpaceBetweenBlocks(' between-space ');
-        $this->outputFormat->setSpaceAfterBlocks(' after-space ');
 
         $commentable = $this->createMock(Commentable::class);
         $commentable->method('getComments')->willReturn([]);
@@ -397,11 +429,43 @@ final class OutputFormatterTest extends TestCase
     /**
      * @test
      */
+    public function commentsWithEmptyCommentableAndRenderCommentsEnabledDoesNotReturnSpaceBetweenBlocks(): void
+    {
+        $this->outputFormat->setRenderComments(true);
+        $spaceBetweenBlocks = ' between-space ';
+        $this->outputFormat->setSpaceBetweenBlocks($spaceBetweenBlocks);
+
+        $commentable = $this->createMock(Commentable::class);
+        $commentable->method('getComments')->willReturn([]);
+
+        $result = $this->subject->comments($commentable);
+
+        self::assertStringNotContainsString($spaceBetweenBlocks, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function commentsWithEmptyCommentableAndRenderCommentsEnabledDoesNotReturnSpaceAfterBlocks(): void
+    {
+        $this->outputFormat->setRenderComments(true);
+        $spaceAfterBlocks = ' after-space ';
+        $this->outputFormat->setSpaceAfterBlocks($spaceAfterBlocks);
+
+        $commentable = $this->createMock(Commentable::class);
+        $commentable->method('getComments')->willReturn([]);
+
+        $result = $this->subject->comments($commentable);
+
+        self::assertStringNotContainsString($spaceAfterBlocks, $result);
+    }
+
+    /**
+     * @test
+     */
     public function commentsWithEmptyCommentableAndRenderCommentsEnabledReturnsEmptyString(): void
     {
         $this->outputFormat->setRenderComments(true);
-        $this->outputFormat->setSpaceBetweenBlocks(' between-space ');
-        $this->outputFormat->setSpaceAfterBlocks(' after-space ');
 
         $commentable = $this->createMock(Commentable::class);
         $commentable->method('getComments')->willReturn([]);
@@ -417,8 +481,6 @@ final class OutputFormatterTest extends TestCase
     public function commentsWithCommentableWithOneCommentAndRenderCommentsDisabledReturnsEmptyString(): void
     {
         $this->outputFormat->setRenderComments(false);
-        $this->outputFormat->setSpaceBetweenBlocks(' between-space ');
-        $this->outputFormat->setSpaceAfterBlocks(' after-space ');
 
         $commentText = 'I am a teapot.';
         $comment = new Comment($commentText);

--- a/tests/Unit/OutputFormatterTest.php
+++ b/tests/Unit/OutputFormatterTest.php
@@ -420,7 +420,7 @@ final class OutputFormatterTest extends TestCase
         $this->outputFormat->setSpaceBetweenBlocks(' between-space ');
         $this->outputFormat->setSpaceAfterBlocks(' after-space ');
 
-        $commentText = 'This is a comment.';
+        $commentText = 'I am a teapot.';
         $comment = new Comment($commentText);
         $commentable = $this->createMock(Commentable::class);
         $commentable->method('getComments')->willReturn([$comment]);
@@ -439,7 +439,7 @@ final class OutputFormatterTest extends TestCase
         $this->outputFormat->setSpaceBetweenBlocks(' between-space ');
         $this->outputFormat->setSpaceAfterBlocks(' after-space ');
 
-        $commentText = 'This is a comment.';
+        $commentText = 'I am a teapot.';
         $comment = new Comment($commentText);
         $commentable = $this->createMock(Commentable::class);
         $commentable->method('getComments')->willReturn([$comment]);
@@ -459,7 +459,7 @@ final class OutputFormatterTest extends TestCase
         $afterSpace = ' after-space ';
         $this->outputFormat->setSpaceAfterBlocks($afterSpace);
 
-        $commentText = 'This is a comment.';
+        $commentText = 'I am a teapot.';
         $comment = new Comment($commentText);
         $commentable = $this->createMock(Commentable::class);
         $commentable->method('getComments')->willReturn([$comment]);
@@ -479,9 +479,9 @@ final class OutputFormatterTest extends TestCase
         $afterSpace = ' after-space ';
         $this->outputFormat->setSpaceAfterBlocks($afterSpace);
 
-        $commentText1 = 'This is a comment 1.';
+        $commentText1 = 'I am a teapot.';
         $comment1 = new Comment($commentText1);
-        $commentText2 = 'This is a comment 2.';
+        $commentText2 = 'But I am not.';
         $comment2 = new Comment($commentText2);
         $commentable = $this->createMock(Commentable::class);
         $commentable->method('getComments')->willReturn([$comment1, $comment2]);
@@ -501,9 +501,9 @@ final class OutputFormatterTest extends TestCase
         $this->outputFormat->setSpaceBetweenBlocks($betweenSpace);
         $this->outputFormat->setSpaceAfterBlocks(' after-space ');
 
-        $commentText1 = 'This is a comment 1.';
+        $commentText1 = 'I am a teapot.';
         $comment1 = new Comment($commentText1);
-        $commentText2 = 'You like pears.';
+        $commentText2 = 'But I am not.';
         $comment2 = new Comment($commentText2);
         $commentable = $this->createMock(Commentable::class);
         $commentable->method('getComments')->willReturn([$comment1, $comment2]);
@@ -524,11 +524,11 @@ final class OutputFormatterTest extends TestCase
         $afterSpace = ' after-space ';
         $this->outputFormat->setSpaceAfterBlocks($afterSpace);
 
-        $commentText1 = 'This is a comment 1.';
+        $commentText1 = 'I am a teapot.';
         $comment1 = new Comment($commentText1);
-        $commentText2 = 'This is a comment 2.';
+        $commentText2 = 'But I am what.';
         $comment2 = new Comment($commentText2);
-        $commentText3 = 'This is a comment 3.';
+        $commentText3 = 'So what am I then?';
         $comment3 = new Comment($commentText3);
         $commentable = $this->createMock(Commentable::class);
         $commentable->method('getComments')->willReturn([$comment1, $comment2, $comment3]);
@@ -548,11 +548,11 @@ final class OutputFormatterTest extends TestCase
         $this->outputFormat->setSpaceBetweenBlocks($betweenSpace);
         $this->outputFormat->setSpaceAfterBlocks(' after-space ');
 
-        $commentText1 = 'This is a comment 1.';
+        $commentText1 = 'I am a teapot.';
         $comment1 = new Comment($commentText1);
-        $commentText2 = 'This is a comment 2.';
+        $commentText2 = 'But I am what.';
         $comment2 = new Comment($commentText2);
-        $commentText3 = 'This is a comment 3.';
+        $commentText3 = 'So what am I then?';
         $comment3 = new Comment($commentText3);
         $commentable = $this->createMock(Commentable::class);
         $commentable->method('getComments')->willReturn([$comment1, $comment2, $comment3]);

--- a/tests/Unit/OutputFormatterTest.php
+++ b/tests/Unit/OutputFormatterTest.php
@@ -354,7 +354,7 @@ final class OutputFormatterTest extends TestCase
      * @test
      * @dataProvider provideChangedStringForRemoveLastSemicolon
      */
-    public function removeLastSemicolonWithSemicolonAfterLastRuleDisabledRemovesTheLastSemicolon(
+    public function removeLastSemicolonWithSemicolonAfterLastRuleDisabledRemovesLastSemicolon(
         string $input,
         string $expected
     ): void {

--- a/tests/Unit/OutputFormatterTest.php
+++ b/tests/Unit/OutputFormatterTest.php
@@ -436,8 +436,6 @@ final class OutputFormatterTest extends TestCase
     public function commentsWithCommentableWithOneCommentRendersComment(): void
     {
         $this->outputFormat->setRenderComments(true);
-        $this->outputFormat->setSpaceBetweenBlocks(' between-space ');
-        $this->outputFormat->setSpaceAfterBlocks(' after-space ');
 
         $commentText = 'I am a teapot.';
         $comment = new Comment($commentText);
@@ -455,7 +453,6 @@ final class OutputFormatterTest extends TestCase
     public function commentsWithCommentableWithOneCommentPutsSpaceAfterBlocksAfterRenderedComment(): void
     {
         $this->outputFormat->setRenderComments(true);
-        $this->outputFormat->setSpaceBetweenBlocks(' between-space ');
         $afterSpace = ' after-space ';
         $this->outputFormat->setSpaceAfterBlocks($afterSpace);
 
@@ -475,7 +472,6 @@ final class OutputFormatterTest extends TestCase
     public function commentsWithCommentableWithTwoCommentsPutsSpaceAfterBlocksAfterLastRenderedComment(): void
     {
         $this->outputFormat->setRenderComments(true);
-        $this->outputFormat->setSpaceBetweenBlocks(' between-space ');
         $afterSpace = ' after-space ';
         $this->outputFormat->setSpaceAfterBlocks($afterSpace);
 
@@ -499,7 +495,6 @@ final class OutputFormatterTest extends TestCase
         $this->outputFormat->setRenderComments(true);
         $betweenSpace = ' between-space ';
         $this->outputFormat->setSpaceBetweenBlocks($betweenSpace);
-        $this->outputFormat->setSpaceAfterBlocks(' after-space ');
 
         $commentText1 = 'I am a teapot.';
         $comment1 = new Comment($commentText1);
@@ -520,7 +515,6 @@ final class OutputFormatterTest extends TestCase
     public function commentsWithCommentableWithMoreThanTwoCommentsPutsSpaceAfterBlocksAfterLastRenderedComment(): void
     {
         $this->outputFormat->setRenderComments(true);
-        $this->outputFormat->setSpaceBetweenBlocks(' between-space ');
         $afterSpace = ' after-space ';
         $this->outputFormat->setSpaceAfterBlocks($afterSpace);
 
@@ -546,7 +540,6 @@ final class OutputFormatterTest extends TestCase
         $this->outputFormat->setRenderComments(true);
         $betweenSpace = ' between-space ';
         $this->outputFormat->setSpaceBetweenBlocks($betweenSpace);
-        $this->outputFormat->setSpaceAfterBlocks(' after-space ');
 
         $commentText1 = 'I am a teapot.';
         $comment1 = new Comment($commentText1);

--- a/tests/Unit/OutputFormatterTest.php
+++ b/tests/Unit/OutputFormatterTest.php
@@ -307,7 +307,7 @@ final class OutputFormatterTest extends TestCase
     {
         return [
             'empty string' => [''],
-            'string without semicolon' => ['Earl Grey: hot'],
+            'string without semicolon' => ['earl-grey: hot'],
             'string with trailing semicolon' => ['Earl Grey: hot;'],
             'string with semicolon in the middle' => ['Earl Grey: hot; Coffee: Americano'],
             'string with semicolons in the middle and trailing' => ['Earl Grey: hot; Coffee: Americano;'],

--- a/tests/Unit/OutputFormatterTest.php
+++ b/tests/Unit/OutputFormatterTest.php
@@ -318,7 +318,7 @@ final class OutputFormatterTest extends TestCase
      * @test
      * @dataProvider provideUnchangedStringForRemoveLastSemicolon
      */
-    public function removeLastSemicolonWithSemicolonAfterLastRuleEnabledUnchangedArgument(string $string): void
+    public function removeLastSemicolonWithSemicolonAfterLastRuleEnabledReturnsUnchangedArgument(string $string): void
     {
         $this->outputFormat->setSemicolonAfterLastRule(true);
 

--- a/tests/Unit/OutputFormatterTest.php
+++ b/tests/Unit/OutputFormatterTest.php
@@ -491,7 +491,7 @@ final class OutputFormatterTest extends TestCase
 
         $commentText1 = 'This is a comment 1.';
         $comment1 = new Comment($commentText1);
-        $commentText2 = 'This is a comment 2.';
+        $commentText2 = 'You like pears.';
         $comment2 = new Comment($commentText2);
         $commentable = $this->createMock(Commentable::class);
         $commentable->method('getComments')->willReturn([$comment1, $comment2]);

--- a/tests/Unit/OutputFormatterTest.php
+++ b/tests/Unit/OutputFormatterTest.php
@@ -543,7 +543,7 @@ final class OutputFormatterTest extends TestCase
 
         $commentText1 = 'I am a teapot.';
         $comment1 = new Comment($commentText1);
-        $commentText2 = 'But I am what.';
+        $commentText2 = 'But I am not.';
         $comment2 = new Comment($commentText2);
         $commentText3 = 'So what am I then?';
         $comment3 = new Comment($commentText3);


### PR DESCRIPTION
Also autoformat the test class.

The new PHPStan warning will go away once we switch the tested class to native type declarations.

Part of #757