### PR TITLE
[CLEANUP] Drop redundant `@internal` annotations

### DIFF
--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -14,8 +14,6 @@ class ParserState
 {
     /**
      * @var null
-     *
-     * @internal since 8.5.2
      */
     public const EOF = null;
 
@@ -125,8 +123,6 @@ class ParserState
      * @return string
      *
      * @throws UnexpectedTokenException
-     *
-     * @internal since V8.8.0
      */
     public function parseIdentifier($bIgnoreCase = true)
     {
@@ -158,8 +154,6 @@ class ParserState
      *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
-     *
-     * @internal since V8.8.0
      */
     public function parseCharacter($bIsForIdentifier)
     {


### PR DESCRIPTION
If a whole class is `@internal`, there is no need to mark the individual methods, properties or constants as `@internal`.