### PR TITLE
[CLEANUP] Don't store array length as a property

### DIFF
--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -30,7 +30,7 @@ class ParserState
     /**
      * @var array<int, string>
      */
-    private $characters;
+    private $characters = [];
 
     /**
      * @var int
@@ -43,11 +43,6 @@ class ParserState
      * @var string
      */
     private $charset;
-
-    /**
-     * @var int
-     */
-    private $length;
 
     /**
      * @var int
@@ -75,7 +70,6 @@ class ParserState
     {
         $this->charset = $charset;
         $this->characters = $this->strsplit($this->text);
-        $this->length = \count($this->characters);
     }
 
     /**
@@ -225,7 +219,7 @@ class ParserState
                 try {
                     $oComment = $this->consumeComment();
                 } catch (UnexpectedEOFException $e) {
-                    $this->currentPosition = $this->length;
+                    $this->currentPosition = \count($this->characters);
                     return $comments;
                 }
             } else {
@@ -257,7 +251,7 @@ class ParserState
     public function peek($length = 1, $offset = 0): string
     {
         $offset += $this->currentPosition;
-        if ($offset >= $this->length) {
+        if ($offset >= \count($this->characters)) {
             return '';
         }
         return $this->substr($offset, $length);
@@ -286,7 +280,7 @@ class ParserState
             $this->currentPosition += $this->strlen($mValue);
             return $mValue;
         } else {
-            if ($this->currentPosition + $mValue > $this->length) {
+            if ($this->currentPosition + $mValue > \count($this->characters)) {
                 throw new UnexpectedEOFException((string) $mValue, $this->peek(5), 'count', $this->lineNumber);
             }
             $result = $this->substr($this->currentPosition, $mValue);
@@ -343,7 +337,7 @@ class ParserState
 
     public function isEnd(): bool
     {
-        return $this->currentPosition >= $this->length;
+        return $this->currentPosition >= \count($this->characters);
     }
 
     /**
@@ -436,10 +430,10 @@ class ParserState
     private function substr($iStart, $length): string
     {
         if ($length < 0) {
-            $length = $this->length - $iStart + $length;
+            $length = \count($this->characters) - $iStart + $length;
         }
-        if ($iStart + $length > $this->length) {
-            $length = $this->length - $iStart;
+        if ($iStart + $length > \count($this->characters)) {
+            $length = \count($this->characters) - $iStart;
         }
         $result = '';
         while ($length > 0) {

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -30,7 +30,7 @@ class ParserState
     /**
      * @var array<int, string>
      */
-    private $characters = [];
+    private $characters;
 
     /**
      * @var int


### PR DESCRIPTION
Since PHP 5, if not earlier, the length of an array is internally stored by PHP and can be accessed in O(1) time.
Maintaining both the array and its length in class properties is error-prone (particularly regarding possible future code changes). When used in a loop, `\count($array)` is more repetitively expensive than `$arrayLength`,
but the latter can be set up as a local variable as and when needed.

Reference:
https://stackoverflow.com/questions/5835241/is-phps-count-function-o1-or-on-for-arrays

This change also ensures that the characters are always a (dazzling) array.

Resolves #953.