### PR TITLE
[CLEANUP] Avoid Hungarian notation for `ignoreCase`

### DIFF
--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -118,13 +118,13 @@ class ParserState
     }
 
     /**
-     * @param bool $bIgnoreCase
+     * @param bool $ignoreCase
      *
      * @return string
      *
      * @throws UnexpectedTokenException
      */
-    public function parseIdentifier($bIgnoreCase = true)
+    public function parseIdentifier($ignoreCase = true)
     {
         if ($this->isEnd()) {
             throw new UnexpectedEOFException('', '', 'identifier', $this->lineNumber);
@@ -141,7 +141,7 @@ class ParserState
                 $result .= '\\' . $sCharacter;
             }
         }
-        if ($bIgnoreCase) {
+        if ($ignoreCase) {
             $result = $this->strtolower($result);
         }
         return $result;

--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -47,9 +47,9 @@ class CSSFunction extends ValueList
      *
      * @internal since V8.8.0
      */
-    public static function parse(ParserState $parserState, bool $bIgnoreCase = false): CSSFunction
+    public static function parse(ParserState $parserState, bool $ignoreCase = false): CSSFunction
     {
-        $sName = self::parseName($parserState, $bIgnoreCase);
+        $sName = self::parseName($parserState, $ignoreCase);
         $parserState->consume('(');
         $mArguments = self::parseArguments($parserState);
 
@@ -64,9 +64,9 @@ class CSSFunction extends ValueList
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */
-    private static function parseName(ParserState $parserState, bool $bIgnoreCase = false): string
+    private static function parseName(ParserState $parserState, bool $ignoreCase = false): string
     {
-        return $parserState->parseIdentifier($bIgnoreCase);
+        return $parserState->parseIdentifier($ignoreCase);
     }
 
     /**

--- a/src/Value/CalcFunction.php
+++ b/src/Value/CalcFunction.php
@@ -26,7 +26,7 @@ class CalcFunction extends CSSFunction
      *
      * @internal since V8.8.0
      */
-    public static function parse(ParserState $parserState, bool $bIgnoreCase = false): CSSFunction
+    public static function parse(ParserState $parserState, bool $ignoreCase = false): CSSFunction
     {
         $aOperators = ['+', '-', '*', '/'];
         $sFunction = $parserState->parseIdentifier();

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -110,7 +110,7 @@ abstract class Value implements Renderable
     }
 
     /**
-     * @param bool $bIgnoreCase
+     * @param bool $ignoreCase
      *
      * @return CSSFunction|string
      *
@@ -119,10 +119,10 @@ abstract class Value implements Renderable
      *
      * @internal since V8.8.0
      */
-    public static function parseIdentifierOrFunction(ParserState $parserState, $bIgnoreCase = false)
+    public static function parseIdentifierOrFunction(ParserState $parserState, $ignoreCase = false)
     {
         $oAnchor = $parserState->anchor();
-        $result = $parserState->parseIdentifier($bIgnoreCase);
+        $result = $parserState->parseIdentifier($ignoreCase);
 
         if ($parserState->comes('(')) {
             $oAnchor->backtrack();
@@ -135,7 +135,7 @@ abstract class Value implements Renderable
             ) {
                 $result = CalcFunction::parse($parserState);
             } else {
-                $result = CSSFunction::parse($parserState, $bIgnoreCase);
+                $result = CSSFunction::parse($parserState, $ignoreCase);
             }
         }
 


### PR DESCRIPTION
Part of #756