### PR TITLE
[CLEANUP] Avoid Hungarian notation for `comment(able)`

### DIFF
--- a/src/OutputFormatter.php
+++ b/src/OutputFormatter.php
@@ -165,18 +165,18 @@ class OutputFormatter
         return \implode(';', $sString);
     }
 
-    public function comments(Commentable $oCommentable): string
+    public function comments(Commentable $commentable): string
     {
         if (!$this->outputFormat->bRenderComments) {
             return '';
         }
 
         $result = '';
-        $comments = $oCommentable->getComments();
+        $comments = $commentable->getComments();
         $iLastCommentIndex = \count($comments) - 1;
 
-        foreach ($comments as $i => $oComment) {
-            $result .= $oComment->render($this->outputFormat);
+        foreach ($comments as $i => $comment) {
+            $result .= $comment->render($this->outputFormat);
             $result .= $i === $iLastCommentIndex ? $this->spaceAfterBlocks() : $this->spaceBetweenBlocks();
         }
         return $result;

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -223,18 +223,18 @@ class ParserState
             }
             if ($this->parserSettings->bLenientParsing) {
                 try {
-                    $oComment = $this->consumeComment();
+                    $comment = $this->consumeComment();
                 } catch (UnexpectedEOFException $e) {
                     $this->currentPosition = $this->length;
                     return $comments;
                 }
             } else {
-                $oComment = $this->consumeComment();
+                $comment = $this->consumeComment();
             }
-            if ($oComment !== false) {
-                $comments[] = $oComment;
+            if ($comment !== false) {
+                $comments[] = $comment;
             }
-        } while ($oComment !== false);
+        } while ($comment !== false);
         return $comments;
     }
 


### PR DESCRIPTION
Part of #756