### PR TITLE
[CLEANUP] Drop some comments from testcases

### DIFF
--- a/tests/Unit/CSSList/AtRuleBlockListTest.php
+++ b/tests/Unit/CSSList/AtRuleBlockListTest.php
@@ -18,10 +18,6 @@ use Sabberworm\CSS\Renderable;
  */
 final class AtRuleBlockListTest extends TestCase
 {
-    /*
-     * Tests for the implemented interfaces and superclasses
-     */
-
     /**
      * @test
      */
@@ -71,10 +67,6 @@ final class AtRuleBlockListTest extends TestCase
 
         self::assertInstanceOf(CSSList::class, $subject);
     }
-
-    /*
-     * not grouped yet
-     */
 
     /**
      * @test

--- a/tests/Unit/CSSList/DocumentTest.php
+++ b/tests/Unit/CSSList/DocumentTest.php
@@ -24,10 +24,6 @@ use Sabberworm\CSS\Value\URL;
  */
 final class DocumentTest extends TestCase
 {
-    /*
-     * Tests for the implemented interfaces and superclasses
-     */
-
     /**
      * @test
      */
@@ -63,10 +59,6 @@ final class DocumentTest extends TestCase
 
         self::assertInstanceOf(CSSList::class, $subject);
     }
-
-    /*
-     * not grouped yet
-     */
 
     /**
      * @test

--- a/tests/Unit/CSSList/KeyFrameTest.php
+++ b/tests/Unit/CSSList/KeyFrameTest.php
@@ -17,10 +17,6 @@ use Sabberworm\CSS\Renderable;
  */
 final class KeyFrameTest extends TestCase
 {
-    /*
-     * Tests for the implemented interfaces and superclasses
-     */
-
     /**
      * @test
      */
@@ -60,10 +56,6 @@ final class KeyFrameTest extends TestCase
 
         self::assertInstanceOf(CSSList::class, $subject);
     }
-
-    /*
-     * not grouped yet
-     */
 
     /**
      * @test


### PR DESCRIPTION
These comments are no longer needed now that the abstract base classes have their own testcases.