### PR TITLE
[CLEANUP] Avoid Hungarian notation for `start(Position)`

### DIFF
--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -424,21 +424,21 @@ class ParserState
     }
 
     /**
-     * @param int $start
+     * @param int $offset
      * @param int $length
      */
-    private function substr($start, $length): string
+    private function substr($offset, $length): string
     {
         if ($length < 0) {
-            $length = \count($this->characters) - $start + $length;
+            $length = \count($this->characters) - $offset + $length;
         }
-        if ($start + $length > \count($this->characters)) {
-            $length = \count($this->characters) - $start;
+        if ($offset + $length > \count($this->characters)) {
+            $length = \count($this->characters) - $offset;
         }
         $result = '';
         while ($length > 0) {
-            $result .= $this->characters[$start];
-            $start++;
+            $result .= $this->characters[$offset];
+            $offset++;
             $length--;
         }
         return $result;

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -424,21 +424,21 @@ class ParserState
     }
 
     /**
-     * @param int $iStart
+     * @param int $start
      * @param int $length
      */
-    private function substr($iStart, $length): string
+    private function substr($start, $length): string
     {
         if ($length < 0) {
-            $length = \count($this->characters) - $iStart + $length;
+            $length = \count($this->characters) - $start + $length;
         }
-        if ($iStart + $length > \count($this->characters)) {
-            $length = \count($this->characters) - $iStart;
+        if ($start + $length > \count($this->characters)) {
+            $length = \count($this->characters) - $start;
         }
         $result = '';
         while ($length > 0) {
-            $result .= $this->characters[$iStart];
-            $iStart++;
+            $result .= $this->characters[$start];
+            $start++;
             $length--;
         }
         return $result;

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -78,23 +78,23 @@ abstract class Value implements Renderable
                 return $aStack[0];
             }
             $aNewStack = [];
-            for ($iStartPosition = 0; $iStartPosition < $iStackLength; ++$iStartPosition) {
-                if ($iStartPosition === ($iStackLength - 1) || $sDelimiter !== $aStack[$iStartPosition + 1]) {
-                    $aNewStack[] = $aStack[$iStartPosition];
+            for ($startPosition = 0; $startPosition < $iStackLength; ++$startPosition) {
+                if ($startPosition === ($iStackLength - 1) || $sDelimiter !== $aStack[$startPosition + 1]) {
+                    $aNewStack[] = $aStack[$startPosition];
                     continue;
                 }
                 $length = 2; //Number of elements to be joined
-                for ($i = $iStartPosition + 3; $i < $iStackLength; $i += 2, ++$length) {
+                for ($i = $startPosition + 3; $i < $iStackLength; $i += 2, ++$length) {
                     if ($sDelimiter !== $aStack[$i]) {
                         break;
                     }
                 }
                 $list = new RuleValueList($sDelimiter, $parserState->currentLine());
-                for ($i = $iStartPosition; $i - $iStartPosition < $length * 2; $i += 2) {
+                for ($i = $startPosition; $i - $startPosition < $length * 2; $i += 2) {
                     $list->addListComponent($aStack[$i]);
                 }
                 $aNewStack[] = $list;
-                $iStartPosition += $length * 2 - 2;
+                $startPosition += $length * 2 - 2;
             }
             $aStack = $aNewStack;
         }

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -78,23 +78,23 @@ abstract class Value implements Renderable
                 return $aStack[0];
             }
             $aNewStack = [];
-            for ($startPosition = 0; $startPosition < $iStackLength; ++$startPosition) {
-                if ($startPosition === ($iStackLength - 1) || $sDelimiter !== $aStack[$startPosition + 1]) {
-                    $aNewStack[] = $aStack[$startPosition];
+            for ($offset = 0; $offset < $iStackLength; ++$offset) {
+                if ($offset === ($iStackLength - 1) || $sDelimiter !== $aStack[$offset + 1]) {
+                    $aNewStack[] = $aStack[$offset];
                     continue;
                 }
                 $length = 2; //Number of elements to be joined
-                for ($i = $startPosition + 3; $i < $iStackLength; $i += 2, ++$length) {
+                for ($i = $offset + 3; $i < $iStackLength; $i += 2, ++$length) {
                     if ($sDelimiter !== $aStack[$i]) {
                         break;
                     }
                 }
                 $list = new RuleValueList($sDelimiter, $parserState->currentLine());
-                for ($i = $startPosition; $i - $startPosition < $length * 2; $i += 2) {
+                for ($i = $offset; $i - $offset < $length * 2; $i += 2) {
                     $list->addListComponent($aStack[$i]);
                 }
                 $aNewStack[] = $list;
-                $startPosition += $length * 2 - 2;
+                $offset += $length * 2 - 2;
             }
             $aStack = $aNewStack;
         }


### PR DESCRIPTION
Part of #756