### PR TITLE
[CLEANUP] Use `null` for unset value in `DeclarationBlock::parse()`

### DIFF
--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -331,12 +331,6 @@ parameters:
 			path: ../src/RuleSet/DeclarationBlock.php
 
 		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 1
-			path: ../src/RuleSet/DeclarationBlock.php
-
-		-
 			message: '#^Parameters should have "string" types as the only types passed to this method$#'
 			identifier: typePerfect.narrowPublicClassMethodParamType
 			count: 1

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -45,18 +45,17 @@ class DeclarationBlock extends RuleSet
         $result = new DeclarationBlock($parserState->currentLine());
         try {
             $aSelectorParts = [];
-            $stringWrapperCharacter = false;
             do {
                 $aSelectorParts[] = $parserState->consume(1)
                     . $parserState->consumeUntil(['{', '}', '\'', '"'], false, false, $comments);
                 if (\in_array($parserState->peek(), ['\'', '"'], true) && \substr(\end($aSelectorParts), -1) != '\\') {
-                    if ($stringWrapperCharacter === false) {
+                    if (!isset($stringWrapperCharacter)) {
                         $stringWrapperCharacter = $parserState->peek();
-                    } elseif ($stringWrapperCharacter == $parserState->peek()) {
-                        $stringWrapperCharacter = false;
+                    } elseif ($stringWrapperCharacter === $parserState->peek()) {
+                        unset($stringWrapperCharacter);
                     }
                 }
-            } while (!\in_array($parserState->peek(), ['{', '}'], true) || $stringWrapperCharacter !== false);
+            } while (!\in_array($parserState->peek(), ['{', '}'], true) || isset($stringWrapperCharacter));
             $result->setSelectors(\implode('', $aSelectorParts), $list);
             if ($parserState->comes('{')) {
                 $parserState->consume(1);


### PR DESCRIPTION
The variable is either a string or it isn't.
The best practice for when it isn't is for it to be `null` or `unset()`.

Using `false` for when it isn't can lead to type-safety issues. Reference:
https://vulke.medium.com/when-should-variables-be-null-false-undefined-or-an-empty-string-in-php-4ebd73c7a954

Also use `===` in a comparison in the affected code.

Resolves #975.
Part of #976.