### PR TITLE
[TASK] Deprecate the IE hack in `Rule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
+- Deprecate the IE hack in `Rule` (#993)
 - `OutputFormat` properties for space around list separators as an array (#880)
 - Deprecate `OutputFormat::level()` (#870)
 

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -36,6 +36,8 @@ class Rule implements Renderable, Commentable
 
     /**
      * @var array<int, int>
+     *
+     * @deprecated since V8.8.0, will be removed in V9.0
      */
     private $aIeHack;
 
@@ -319,6 +321,8 @@ class Rule implements Renderable, Commentable
      * @param array<int, int> $aModifiers
      *
      * @return void
+     *
+     * @deprecated since V8.8.0, will be removed in V9.0
      */
     public function setIeHack(array $aModifiers)
     {
@@ -327,6 +331,8 @@ class Rule implements Renderable, Commentable
 
     /**
      * @return array<int, int>
+     *
+     * @deprecated since V8.8.0, will be removed in V9.0
      */
     public function getIeHack()
     {


### PR DESCRIPTION
With modern browsers, we don't need IE hacks anymore.

(Also, this code is not used.)