### PR TITLE
[CLEANUP] Avoid Hungarian notation in `Settings`

### DIFF
--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -74,7 +74,7 @@ abstract class CSSList implements Renderable, Commentable
         if (\is_string($parserState)) {
             $parserState = new ParserState($parserState, Settings::create());
         }
-        $usesLenientParsing = $parserState->getSettings()->bLenientParsing;
+        $usesLenientParsing = $parserState->getSettings()->lenientParsing;
         $comments = [];
         while (!$parserState->isEnd()) {
             $comments = \array_merge($comments, $parserState->consumeWhiteSpace());
@@ -138,7 +138,7 @@ abstract class CSSList implements Renderable, Commentable
             return $atRule;
         } elseif ($parserState->comes('}')) {
             if ($isRoot) {
-                if ($parserState->getSettings()->bLenientParsing) {
+                if ($parserState->getSettings()->lenientParsing) {
                     return DeclarationBlock::parse($parserState);
                 } else {
                     throw new SourceException('Unopened {', $parserState->currentLine());
@@ -215,7 +215,7 @@ abstract class CSSList implements Renderable, Commentable
             // Unknown other at rule (font-face or such)
             $arguments = \trim($parserState->consumeUntil('{', false, true));
             if (\substr_count($arguments, '(') != \substr_count($arguments, ')')) {
-                if ($parserState->getSettings()->bLenientParsing) {
+                if ($parserState->getSettings()->lenientParsing) {
                     return null;
                 } else {
                     throw new SourceException('Unmatched brace count in media query', $parserState->currentLine());

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -58,7 +58,7 @@ class ParserState
         $this->parserSettings = $parserSettings;
         $this->text = $text;
         $this->lineNumber = $lineNumber;
-        $this->setCharset($this->parserSettings->sDefaultCharset);
+        $this->setCharset($this->parserSettings->defaultCharset);
     }
 
     /**
@@ -151,7 +151,7 @@ class ParserState
     {
         if ($this->peek() === '\\') {
             if (
-                $isForIdentifier && $this->parserSettings->bLenientParsing
+                $isForIdentifier && $this->parserSettings->lenientParsing
                 && ($this->comes('\\0') || $this->comes('\\9'))
             ) {
                 // Non-strings can contain \0 or \9 which is an IE hack supported in lenient parsing.
@@ -215,7 +215,7 @@ class ParserState
             while (\preg_match('/\\s/isSu', $this->peek()) === 1) {
                 $this->consume(1);
             }
-            if ($this->parserSettings->bLenientParsing) {
+            if ($this->parserSettings->lenientParsing) {
                 try {
                     $comment = $this->consumeComment();
                 } catch (UnexpectedEOFException $e) {
@@ -416,7 +416,7 @@ class ParserState
      */
     public function strlen($string): int
     {
-        if ($this->parserSettings->bMultibyteSupport) {
+        if ($this->parserSettings->multibyteSupport) {
             return \mb_strlen($string, $this->charset);
         } else {
             return \strlen($string);
@@ -449,7 +449,7 @@ class ParserState
      */
     private function strtolower($string): string
     {
-        if ($this->parserSettings->bMultibyteSupport) {
+        if ($this->parserSettings->multibyteSupport) {
             return \mb_strtolower($string, $this->charset);
         } else {
             return \strtolower($string);
@@ -465,7 +465,7 @@ class ParserState
      */
     private function strsplit($string)
     {
-        if ($this->parserSettings->bMultibyteSupport) {
+        if ($this->parserSettings->multibyteSupport) {
             if ($this->streql($this->charset, 'utf-8')) {
                 $result = \preg_split('//u', $string, -1, PREG_SPLIT_NO_EMPTY);
                 if (!\is_array($result)) {
@@ -498,7 +498,7 @@ class ParserState
      */
     private function strpos($haystack, $needle, $offset)
     {
-        if ($this->parserSettings->bMultibyteSupport) {
+        if ($this->parserSettings->multibyteSupport) {
             return \mb_strpos($haystack, $needle, $offset, $this->charset);
         } else {
             return \strpos($haystack, $needle, $offset);

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -91,7 +91,7 @@ class Rule implements Renderable, Commentable
         $parserState->consume(':');
         $value = Value::parseValue($parserState, self::listDelimiterForRule($rule->getRule()));
         $rule->setValue($value);
-        if ($parserState->getSettings()->bLenientParsing) {
+        if ($parserState->getSettings()->lenientParsing) {
             while ($parserState->comes('\\')) {
                 $parserState->consume('\\');
                 $rule->addIeHack($parserState->consume());

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -61,7 +61,7 @@ class DeclarationBlock extends RuleSet
                 $parserState->consume(1);
             }
         } catch (UnexpectedTokenException $e) {
-            if ($parserState->getSettings()->bLenientParsing) {
+            if ($parserState->getSettings()->lenientParsing) {
                 if (!$parserState->comes('}')) {
                     $parserState->consumeUntil('}', false, true);
                 }

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -64,7 +64,7 @@ abstract class RuleSet implements Renderable, Commentable
         }
         while (!$parserState->comes('}')) {
             $rule = null;
-            if ($parserState->getSettings()->bLenientParsing) {
+            if ($parserState->getSettings()->lenientParsing) {
                 try {
                     $rule = Rule::parse($parserState);
                 } catch (UnexpectedTokenException $e) {

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -21,7 +21,7 @@ class Settings
      *
      * @internal since 8.8.0, will be made private in 9.0.0
      */
-    public $bMultibyteSupport;
+    public $multibyteSupport;
 
     /**
      * The default charset for the CSS if no `@charset` declaration is found. Defaults to utf-8.
@@ -30,7 +30,7 @@ class Settings
      *
      * @internal since 8.8.0, will be made private in 9.0.0
      */
-    public $sDefaultCharset = 'utf-8';
+    public $defaultCharset = 'utf-8';
 
     /**
      * Whether the parser silently ignore invalid rules instead of choking on them.
@@ -39,11 +39,11 @@ class Settings
      *
      * @internal since 8.8.0, will be made private in 9.0.0
      */
-    public $bLenientParsing = true;
+    public $lenientParsing = true;
 
     private function __construct()
     {
-        $this->bMultibyteSupport = \extension_loaded('mbstring');
+        $this->multibyteSupport = \extension_loaded('mbstring');
     }
 
     public static function create(): self
@@ -59,9 +59,9 @@ class Settings
      *
      * @return $this fluent interface
      */
-    public function withMultibyteSupport(bool $bMultibyteSupport = true): self
+    public function withMultibyteSupport(bool $multibyteSupport = true): self
     {
-        $this->bMultibyteSupport = $bMultibyteSupport;
+        $this->multibyteSupport = $multibyteSupport;
         return $this;
     }
 
@@ -70,9 +70,9 @@ class Settings
      *
      * @return $this fluent interface
      */
-    public function withDefaultCharset(string $sDefaultCharset): self
+    public function withDefaultCharset(string $defaultCharset): self
     {
-        $this->sDefaultCharset = $sDefaultCharset;
+        $this->defaultCharset = $defaultCharset;
         return $this;
     }
 
@@ -83,7 +83,7 @@ class Settings
      */
     public function withLenientParsing(bool $usesLenientParsing = true): self
     {
-        $this->bLenientParsing = $usesLenientParsing;
+        $this->lenientParsing = $usesLenientParsing;
         return $this;
     }
 

--- a/src/Value/LineName.php
+++ b/src/Value/LineName.php
@@ -32,7 +32,7 @@ class LineName extends ValueList
         $parserState->consumeWhiteSpace();
         $aNames = [];
         do {
-            if ($parserState->getSettings()->bLenientParsing) {
+            if ($parserState->getSettings()->lenientParsing) {
                 try {
                     $aNames[] = $parserState->parseIdentifier();
                 } catch (UnexpectedTokenException $e) {

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -166,7 +166,7 @@ abstract class Value implements Renderable
             $oValue = Color::parse($parserState);
         } elseif ($parserState->comes("'") || $parserState->comes('"')) {
             $oValue = CSSString::parse($parserState);
-        } elseif ($parserState->comes('progid:') && $parserState->getSettings()->bLenientParsing) {
+        } elseif ($parserState->comes('progid:') && $parserState->getSettings()->lenientParsing) {
             $oValue = self::parseMicrosoftFilter($parserState);
         } elseif ($parserState->comes('[')) {
             $oValue = LineName::parse($parserState);

--- a/tests/Unit/SettingsTest.php
+++ b/tests/Unit/SettingsTest.php
@@ -48,7 +48,7 @@ final class SettingsTest extends TestCase
      */
     public function multibyteSupportByDefaultStateOfMbStringExtension(): void
     {
-        self::assertSame(\extension_loaded('mbstring'), $this->subject->bMultibyteSupport);
+        self::assertSame(\extension_loaded('mbstring'), $this->subject->multibyteSupport);
     }
 
     /**
@@ -78,7 +78,7 @@ final class SettingsTest extends TestCase
     {
         $this->subject->withMultibyteSupport($value);
 
-        self::assertSame($value, $this->subject->bMultibyteSupport);
+        self::assertSame($value, $this->subject->multibyteSupport);
     }
 
     /**
@@ -86,7 +86,7 @@ final class SettingsTest extends TestCase
      */
     public function defaultCharsetByDefaultIsUtf8(): void
     {
-        self::assertSame('utf-8', $this->subject->sDefaultCharset);
+        self::assertSame('utf-8', $this->subject->defaultCharset);
     }
 
     /**
@@ -105,7 +105,7 @@ final class SettingsTest extends TestCase
         $charset = 'ISO-8859-1';
         $this->subject->withDefaultCharset($charset);
 
-        self::assertSame($charset, $this->subject->sDefaultCharset);
+        self::assertSame($charset, $this->subject->defaultCharset);
     }
 
     /**
@@ -113,7 +113,7 @@ final class SettingsTest extends TestCase
      */
     public function lenientParsingByDefaultIsTrue(): void
     {
-        self::assertTrue($this->subject->bLenientParsing);
+        self::assertTrue($this->subject->lenientParsing);
     }
 
     /**
@@ -132,7 +132,7 @@ final class SettingsTest extends TestCase
     {
         $this->subject->withLenientParsing($value);
 
-        self::assertSame($value, $this->subject->bLenientParsing);
+        self::assertSame($value, $this->subject->lenientParsing);
     }
 
     /**
@@ -150,6 +150,6 @@ final class SettingsTest extends TestCase
     {
         $this->subject->beStrict();
 
-        self::assertFalse($this->subject->bLenientParsing);
+        self::assertFalse($this->subject->lenientParsing);
     }
 }


### PR DESCRIPTION
We'll change the direct accesses to use the accessors in a later chance.

Part of #756