### PR TITLE
[TASK] Deprecate `__toString()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
+- Deprecate `__toString()` (#1006)
 - Deprecate greedy calculation of selector specificity (#1018)
 - Deprecate the IE hack in `Rule` (#993, #1003)
 - `OutputFormat` properties for space around list separators as an array (#880)

--- a/src/CSSList/AtRuleBlockList.php
+++ b/src/CSSList/AtRuleBlockList.php
@@ -50,6 +50,8 @@ class AtRuleBlockList extends CSSBlockList implements AtRule
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -416,6 +416,8 @@ abstract class CSSList implements Renderable, Commentable
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/CSSList/KeyFrame.php
+++ b/src/CSSList/KeyFrame.php
@@ -61,6 +61,8 @@ class KeyFrame extends CSSList implements AtRule
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/Comment/Comment.php
+++ b/src/Comment/Comment.php
@@ -59,6 +59,8 @@ class Comment implements Renderable
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/Property/CSSNamespace.php
+++ b/src/Property/CSSNamespace.php
@@ -55,6 +55,8 @@ class CSSNamespace implements AtRule
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/Property/Charset.php
+++ b/src/Property/Charset.php
@@ -75,6 +75,8 @@ class Charset implements AtRule
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/Property/Import.php
+++ b/src/Property/Import.php
@@ -76,6 +76,8 @@ class Import implements AtRule
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -121,6 +121,8 @@ class Selector
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/Renderable.php
+++ b/src/Renderable.php
@@ -6,6 +6,8 @@ interface Renderable
 {
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString();
 

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -359,6 +359,8 @@ class Rule implements Renderable, Commentable
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/RuleSet/AtRuleSet.php
+++ b/src/RuleSet/AtRuleSet.php
@@ -53,6 +53,8 @@ class AtRuleSet extends RuleSet implements AtRule
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -831,6 +831,8 @@ class DeclarationBlock extends RuleSet
      * @return string
      *
      * @throws OutputException
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -268,6 +268,8 @@ abstract class RuleSet implements Renderable, Commentable
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -88,6 +88,8 @@ class CSSFunction extends ValueList
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/Value/CSSString.php
+++ b/src/Value/CSSString.php
@@ -94,6 +94,8 @@ class CSSString extends PrimitiveValue
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -155,6 +155,8 @@ class Color extends CSSFunction
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/Value/LineName.php
+++ b/src/Value/LineName.php
@@ -51,6 +51,8 @@ class LineName extends ValueList
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -222,6 +222,8 @@ class Size extends PrimitiveValue
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/Value/URL.php
+++ b/src/Value/URL.php
@@ -81,6 +81,8 @@ class URL extends PrimitiveValue
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {

--- a/src/Value/ValueList.php
+++ b/src/Value/ValueList.php
@@ -90,6 +90,8 @@ abstract class ValueList extends Value
 
     /**
      * @return string
+     *
+     * @deprecated in V8.8.0, will be removed in V9.0.0. Use `render` instead.
      */
     public function __toString()
     {


### PR DESCRIPTION
Part of #998

This is the V8.x backport of #1006.