### PR TITLE
[TASK] Make `Selector` a `Renderable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please also have a look at our
 
 ### Changed
 
+- Make `Selector` a `Renderable` (#1017)
 - Mark `Selector::isValid()` as `@internal` (#1037)
 - Mark parsing-related methods of most CSS elements as `@internal` (#908)
 - Mark `OutputFormat::nextLevel()` as `@internal` (#901)

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Sabberworm\CSS\Property;
 
+use Sabberworm\CSS\OutputFormat;
+use Sabberworm\CSS\Renderable;
+
 /**
  * Class representing a single CSS selector. Selectors have to be split by the comma prior to being passed into this
  * class.
  */
-class Selector
+class Selector implements Renderable
 {
     /**
      * regexp for specificity calculations
@@ -138,5 +141,10 @@ class Selector
             $this->specificity = ($a * 1000) + ($b * 100) + ($c * 10) + $d;
         }
         return $this->specificity;
+    }
+
+    public function render(OutputFormat $outputFormat): string
+    {
+        return $this->getSelector();
     }
 }

--- a/tests/Functional/Property/SelectorTest.php
+++ b/tests/Functional/Property/SelectorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabberworm\CSS\Tests\Functional\Selector;
+
+use PHPUnit\Framework\TestCase;
+use Sabberworm\CSS\OutputFormat;
+use Sabberworm\CSS\Property\Selector;
+
+/**
+ * @covers \Sabberworm\CSS\Property\Selector
+ */
+final class SelectorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function renderWithVirginOutputFormatRendersSelectorPassedToConstructor(): void
+    {
+        $pattern = 'a';
+        $subject = new Selector($pattern);
+
+        self::assertSame($pattern, $subject->render(new OutputFormat()));
+    }
+
+    /**
+     * @test
+     */
+    public function renderWithDefaultOutputFormatRendersSelectorPassedToConstructor(): void
+    {
+        $pattern = 'a';
+        $subject = new Selector($pattern);
+
+        self::assertSame($pattern, $subject->render(OutputFormat::create()));
+    }
+
+    /**
+     * @test
+     */
+    public function renderWithCompactOutputFormatRendersSelectorPassedToConstructor(): void
+    {
+        $pattern = 'a';
+        $subject = new Selector($pattern);
+
+        self::assertSame($pattern, $subject->render(OutputFormat::createCompact()));
+    }
+
+    /**
+     * @test
+     */
+    public function renderWithPrettyOutputFormatRendersSelectorPassedToConstructor(): void
+    {
+        $pattern = 'a';
+        $subject = new Selector($pattern);
+
+        self::assertSame($pattern, $subject->render(OutputFormat::createPretty()));
+    }
+}

--- a/tests/Unit/Property/SelectorTest.php
+++ b/tests/Unit/Property/SelectorTest.php
@@ -6,12 +6,23 @@ namespace Sabberworm\CSS\Tests\Unit\Property;
 
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\Property\Selector;
+use Sabberworm\CSS\Renderable;
 
 /**
  * @covers \Sabberworm\CSS\Property\Selector
  */
 final class SelectorTest extends TestCase
 {
+    /**
+     * @test
+     */
+    public function implementsRenderable(): void
+    {
+        $subject = new Selector('a');
+
+        self::assertInstanceOf(Renderable::class, $subject);
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
This is required to be able to drop `__toString` for this class.