### PR TITLE
[TASK] Deprecate greedy calculation of selector specificity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Please also have a look at our
 
 ### Deprecated
 
+- Deprecate greedy calculation of selector specificity (#1018)
 - Deprecate `__toString()` (#1006)
 - `OutputFormat` properties for space around list separators as an array (#880)
 

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -86,7 +86,7 @@ class Selector
 
     /**
      * @param string $selector
-     * @param bool $calculateSpecificity
+     * @param bool $calculateSpecificity @deprecated since V8.8.0, will be removed in V9.0.0
      */
     public function __construct($selector, $calculateSpecificity = false)
     {


### PR DESCRIPTION
This constructor parameter is not used, and having the specificity calculation always done lazily is not a problem.