### PR TITLE
[TASK] Drop greedy calculation of selector specificity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Please also have a look at our
 
 ### Removed
 
+- Drop greedy calculation of selector specificity (#1021)
 - Drop `getLineNo()` from the `Renderable` interface (#1038)
 - Remove `OutputFormat::level()` (#874)
 - Remove expansion of shorthand properties (#838)

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -87,15 +87,9 @@ class Selector implements Renderable
         return \preg_match(static::SELECTOR_VALIDATION_RX, $selector);
     }
 
-    /**
-     * @param bool $calculateSpecificity @deprecated since V8.8.0, will be removed in V9.0.0
-     */
-    public function __construct(string $selector, bool $calculateSpecificity = false)
+    public function __construct(string $selector)
     {
         $this->setSelector($selector);
-        if ($calculateSpecificity) {
-            $this->getSpecificity();
-        }
     }
 
     public function getSelector(): string


### PR DESCRIPTION
This constructor parameter is not used, and having the specificity calculation always done lazily is not a problem.