### PR TITLE
[TASK] Deprecate greedy calculation of selector specificity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
+- Deprecate greedy calculation of selector specificity (#1018)
 - Deprecate the IE hack in `Rule` (#993, #1003)
 - `OutputFormat` properties for space around list separators as an array (#880)
 - Deprecate `OutputFormat::level()` (#870)

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -88,7 +88,7 @@ class Selector
 
     /**
      * @param string $sSelector
-     * @param bool $bCalculateSpecificity
+     * @param bool $bCalculateSpecificity @deprecated since V8.8.0, will be removed in V9.0.0
      */
     public function __construct($sSelector, $bCalculateSpecificity = false)
     {


### PR DESCRIPTION
This constructor parameter is not used, and having the specificity calculation always done lazily is not a problem.

This is the V8.x backport of #1018.