### PR TITLE
[TASK] Add tests for the selector specificity

### DIFF
--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -223,12 +223,6 @@ parameters:
 			path: ../src/Property/Import.php
 
 		-
-			message: '#^Parameters should have "string" types as the only types passed to this method$#'
-			identifier: typePerfect.narrowPublicClassMethodParamType
-			count: 1
-			path: ../src/Property/Selector.php
-
-		-
 			message: '#^Call to an undefined method Sabberworm\\CSS\\OutputFormat\:\:comments\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -246,30 +246,6 @@ final class ParserTest extends TestCase
     public function specificity(): void
     {
         $document = self::parsedStructureForFile('specificity');
-        $declarationBlocks = $document->getAllDeclarationBlocks();
-        $declarationBlock = $declarationBlocks[0];
-        $selectors = $declarationBlock->getSelectors();
-        foreach ($selectors as $selector) {
-            switch ($selector->getSelector()) {
-                case '#test .help':
-                    self::assertSame(110, $selector->getSpecificity());
-                    break;
-                case '#file':
-                    self::assertSame(100, $selector->getSpecificity());
-                    break;
-                case '.help:hover':
-                    self::assertSame(20, $selector->getSpecificity());
-                    break;
-                case 'ol li::before':
-                    self::assertSame(3, $selector->getSpecificity());
-                    break;
-                case 'li.green':
-                    self::assertSame(11, $selector->getSpecificity());
-                    break;
-                default:
-                    self::fail('specificity: untested selector ' . $selector->getSelector());
-            }
-        }
         self::assertEquals([new Selector('#test .help', true)], $document->getSelectorsBySpecificity('> 100'));
         self::assertEquals(
             [new Selector('#test .help', true), new Selector('#file', true)],

--- a/tests/Unit/Property/SelectorTest.php
+++ b/tests/Unit/Property/SelectorTest.php
@@ -35,4 +35,56 @@ final class SelectorTest extends TestCase
 
         self::assertSame($selector, $subject->getSelector());
     }
+
+    /**
+     * @return array<string, array{0: non-empty-string, 1: int<0, max>}>
+     */
+    public static function provideSelectorsAndSpecificities(): array
+    {
+        return [
+            'element' => ['a', 1],
+            'element and descendant with pseudo-selector' => ['ol li::before', 3],
+            'class' => ['.highlighted', 10],
+            'element with class' => ['li.green', 11],
+            'class with pseudo-selector' => ['.help:hover', 20],
+            'ID' => ['#file', 100],
+            'ID and descendant class' => ['#test .help', 110],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param non-empty-string $selector
+     * @param int<0, max> $expectedSpecificity
+     *
+     * @dataProvider provideSelectorsAndSpecificities
+     */
+    public function getSpecificityByDefaultReturnsSpecificityOfSelectorProvidedToConstructor(
+        string $selector,
+        int $expectedSpecificity
+    ): void {
+        $subject = new Selector($selector);
+
+        self::assertSame($expectedSpecificity, $subject->getSpecificity());
+    }
+
+    /**
+     * @test
+     *
+     * @param non-empty-string $selector
+     * @param int<0, max> $expectedSpecificity
+     *
+     * @dataProvider provideSelectorsAndSpecificities
+     */
+    public function getSpecificityByReturnsSpecificityOfSelectorLastProvidedViaSetSelector(
+        string $selector,
+        int $expectedSpecificity
+    ): void {
+        $subject = new Selector('p');
+
+        $subject->setSelector($selector);
+
+        self::assertSame($expectedSpecificity, $subject->getSpecificity());
+    }
 }

--- a/tests/Unit/Property/SelectorTest.php
+++ b/tests/Unit/Property/SelectorTest.php
@@ -77,7 +77,7 @@ final class SelectorTest extends TestCase
      *
      * @dataProvider provideSelectorsAndSpecificities
      */
-    public function getSpecificityByReturnsSpecificityOfSelectorLastProvidedViaSetSelector(
+    public function getSpecificityReturnsSpecificityOfSelectorLastProvidedViaSetSelector(
         string $selector,
         int $expectedSpecificity
     ): void {


### PR DESCRIPTION
Mostly move tests from `ParserTest` that belong into
the unit tests.

Part of #757
Part of #758