### PR TITLE
[CLEANUP] Avoid Hungarian notation for `nextLevelFormat`

### DIFF
--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -173,7 +173,7 @@ class OutputFormat
     /**
      * @var OutputFormat|null
      */
-    private $oNextLevelFormat;
+    private $nextLevelFormat;
 
     /**
      * @var int
@@ -737,12 +737,12 @@ class OutputFormat
      */
     public function nextLevel(): self
     {
-        if ($this->oNextLevelFormat === null) {
-            $this->oNextLevelFormat = clone $this;
-            $this->oNextLevelFormat->iIndentationLevel++;
-            $this->oNextLevelFormat->outputFormatter = null;
+        if ($this->nextLevelFormat === null) {
+            $this->nextLevelFormat = clone $this;
+            $this->nextLevelFormat->iIndentationLevel++;
+            $this->nextLevelFormat->outputFormatter = null;
         }
-        return $this->oNextLevelFormat;
+        return $this->nextLevelFormat;
     }
 
     public function beLenient(): void

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -270,20 +270,20 @@ abstract class RuleSet implements Renderable, Commentable
     {
         $result = '';
         $isFirst = true;
-        $oNextLevel = $outputFormat->nextLevel();
+        $nextLevelFormat = $outputFormat->nextLevel();
         foreach ($this->rules as $rules) {
             foreach ($rules as $rule) {
-                $sRendered = $oNextLevel->safely(static function () use ($rule, $oNextLevel): string {
-                    return $rule->render($oNextLevel);
+                $sRendered = $nextLevelFormat->safely(static function () use ($rule, $nextLevelFormat): string {
+                    return $rule->render($nextLevelFormat);
                 });
                 if ($sRendered === null) {
                     continue;
                 }
                 if ($isFirst) {
                     $isFirst = false;
-                    $result .= $oNextLevel->spaceBeforeRules();
+                    $result .= $nextLevelFormat->spaceBeforeRules();
                 } else {
-                    $result .= $oNextLevel->spaceBetweenRules();
+                    $result .= $nextLevelFormat->spaceBetweenRules();
                 }
                 $result .= $sRendered;
             }


### PR DESCRIPTION
Part of #756