### PR TITLE
[TASK] Drop `getLineNo()` from the `Renderable` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Please also have a look at our
 
 ### Removed
 
+- Drop `getLineNo()` from the `Renderable` interface (#1038)
 - Remove `OutputFormat::level()` (#874)
 - Remove expansion of shorthand properties (#838)
 - Remove `Parser::setCharset/getCharset` (#808)

--- a/src/Renderable.php
+++ b/src/Renderable.php
@@ -12,9 +12,4 @@ interface Renderable
     public function __toString(): string;
 
     public function render(OutputFormat $outputFormat): string;
-
-    /**
-     * @return int<0, max>
-     */
-    public function getLineNo(): int;
 }


### PR DESCRIPTION
The concept of being able to get rendered is logically independent from having a position in the input stream.

Hence, both concepts should not be intermingled in the `Renderable` interface.

(We might want to add a dedicated interface for classes that are linked to specific points in the input stream later, though.)