### PR TITLE
[TASK] Mark `Selector::isValid()` as `@internal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Mark `Selector::isValid()` as `@internal` (#1037)
 - Mark parsing-related methods of most CSS elements as `@internal` (#908)
 - Mark `OutputFormat::nextLevel()` as `@internal` (#901)
 - Make all non-private properties `@internal` (#886)

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -80,6 +80,8 @@ class Selector
      * @param string $sSelector
      *
      * @return bool
+     *
+     * @internal since V8.8.0
      */
     public static function isValid($sSelector)
     {


### PR DESCRIPTION
This is the V8.x backport of #1037.