### PR TITLE
[TASK] Add more native type declarations for `Selector`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Please also have a look at our
 - Make all non-private properties `@internal` (#886)
 - Use more native type declarations and strict mode
   (#641, #772, #774, #778, #804, #841, #873, #875, #891, #922, #923, #933, #958,
-  #964, #967, #1000)
+  #964, #967, #1000, #1044)
 - Add visibility to all class/interface constants (#469)
 
 ### Deprecated

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -75,22 +75,19 @@ class Selector
     private $specificity;
 
     /**
-     * @param string $selector
-     *
      * @return bool
      *
      * @internal since V8.8.0
      */
-    public static function isValid($selector)
+    public static function isValid(string $selector)
     {
         return \preg_match(static::SELECTOR_VALIDATION_RX, $selector);
     }
 
     /**
-     * @param string $selector
      * @param bool $calculateSpecificity @deprecated since V8.8.0, will be removed in V9.0.0
      */
-    public function __construct($selector, $calculateSpecificity = false)
+    public function __construct(string $selector, bool $calculateSpecificity = false)
     {
         $this->setSelector($selector);
         if ($calculateSpecificity) {
@@ -98,18 +95,12 @@ class Selector
         }
     }
 
-    /**
-     * @return string
-     */
-    public function getSelector()
+    public function getSelector(): string
     {
         return $this->selector;
     }
 
-    /**
-     * @param string $selector
-     */
-    public function setSelector($selector): void
+    public function setSelector(string $selector): void
     {
         $this->selector = \trim($selector);
         $this->specificity = null;
@@ -124,9 +115,9 @@ class Selector
     }
 
     /**
-     * @return int
+     * @return int<0, max>
      */
-    public function getSpecificity()
+    public function getSpecificity(): int
     {
         if ($this->specificity === null) {
             $a = 0;


### PR DESCRIPTION
The return type of `::isValid()` cannot use a native return type declaration yet as the method's return values currently are of a different type (#1043).

Part of #811