### PR TITLE
[CLEANUP] Avoid Hungarian notation for `document`

### DIFF
--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -24,9 +24,10 @@ class Document extends CSSBlockList
      */
     public static function parse(ParserState $parserState): Document
     {
-        $oDocument = new Document($parserState->currentLine());
-        CSSList::parseList($parserState, $oDocument);
-        return $oDocument;
+        $document = new Document($parserState->currentLine());
+        CSSList::parseList($parserState, $document);
+
+        return $document;
     }
 
     /**


### PR DESCRIPTION
Part of #756