### PR TITLE
[CLEANUP] Refactor `CSSBlockList::getAllRuleSets()`

### DIFF
--- a/src/CSSList/CSSBlockList.php
+++ b/src/CSSList/CSSBlockList.php
@@ -57,28 +57,21 @@ abstract class CSSBlockList extends CSSList
     /**
      * Returns all `RuleSet` objects recursively found in the tree, no matter how deeply nested the rule sets are.
      *
-     * @return array<int, RuleSet>
+     * @return list<RuleSet>
      */
     public function getAllRuleSets(): array
     {
-        /** @var array<int, RuleSet> $result */
         $result = [];
-        $this->allRuleSets($result);
-        return $result;
-    }
 
-    /**
-     * @param array<int, RuleSet> $result
-     */
-    protected function allRuleSets(array &$result): void
-    {
         foreach ($this->contents as $item) {
             if ($item instanceof RuleSet) {
                 $result[] = $item;
             } elseif ($item instanceof CSSBlockList) {
-                $item->allRuleSets($result);
+                $result = \array_merge($result, $item->getAllRuleSets());
             }
         }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Also remove the now-unused method `allRuleSets()`.

Part of #994.