### PR TITLE
[TASK] Deprecate method forwarding `OutputFormat` to `OutputFormatter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
+- Deprecate magic method forwarding from `OutputFormat` to `OutputFormatter`
+  (#894)
 - Deprecate the expansion of shorthand properties (#719)
 - Deprecate `Parser::setCharset()` and `Parser::getCharset()` (#703)
 

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -311,6 +311,7 @@ class OutputFormat
         } elseif (strpos($sMethodName, 'get') === 0) {
             return $this->get(substr($sMethodName, 3));
         } elseif (method_exists(OutputFormatter::class, $sMethodName)) {
+            // @deprecated since 8.8.0, will be removed in 9.0.0. Call the method on the formatter directly instead.
             return call_user_func_array([$this->getFormatter(), $sMethodName], $aArguments);
         } else {
             throw new \Exception('Unknown OutputFormat method called: ' . $sMethodName);


### PR DESCRIPTION
This is the V8.x backport of #894.