### PR TITLE
Allow rules to be in any order in shorthand tests

### DIFF
--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -19,6 +19,7 @@ use Sabberworm\CSS\RuleSet\AtRuleSet;
 use Sabberworm\CSS\RuleSet\DeclarationBlock;
 use Sabberworm\CSS\RuleSet\RuleSet;
 use Sabberworm\CSS\Settings;
+use Sabberworm\CSS\Tests\RuleSet\DeclarationBlockTest;
 use Sabberworm\CSS\Value\Color;
 use Sabberworm\CSS\Value\Size;
 use Sabberworm\CSS\Value\URL;
@@ -511,7 +512,7 @@ body {color: green;}',
             . 'font-family: "Trebuchet MS",Georgia,serif;background-color: #ccc;'
             . 'background-image: url("/images/foo.png");background-repeat: no-repeat;background-attachment: scroll;'
             . 'background-position: left top;}';
-        self::assertSame($sExpected, $oDoc->render());
+        DeclarationBlockTest::assertDeclarationBlockEquals($sExpected, $oDoc->render());
     }
 
     /**
@@ -528,7 +529,7 @@ body {color: green;}',
         $oDoc->createShorthands();
         $sExpected = 'body {background: #fff url("foobar.png") repeat-y;margin: 2px 5px 4px 3px;'
             . 'border: 2px dotted #999;font: bold 2em Helvetica,Arial,sans-serif;}';
-        self::assertSame($sExpected, $oDoc->render());
+        DeclarationBlockTest::assertDeclarationBlockEquals($sExpected, $oDoc->render());
     }
 
     /**

--- a/tests/RuleSet/DeclarationBlockTest.php
+++ b/tests/RuleSet/DeclarationBlockTest.php
@@ -29,7 +29,7 @@ final class DeclarationBlockTest extends TestCase
         foreach ($oDoc->getAllDeclarationBlocks() as $oDeclaration) {
             $oDeclaration->expandBorderShorthand();
         }
-        self::assertSame(trim((string)$oDoc), $sExpected);
+        self::assertDeclarationBlockEquals(trim((string)$oDoc), $sExpected);
     }
 
     /**
@@ -62,7 +62,7 @@ final class DeclarationBlockTest extends TestCase
         foreach ($oDoc->getAllDeclarationBlocks() as $oDeclaration) {
             $oDeclaration->expandFontShorthand();
         }
-        self::assertSame(trim((string)$oDoc), $sExpected);
+        self::assertDeclarationBlockEquals(trim((string)$oDoc), $sExpected);
     }
 
     /**
@@ -118,7 +118,7 @@ final class DeclarationBlockTest extends TestCase
         foreach ($oDoc->getAllDeclarationBlocks() as $oDeclaration) {
             $oDeclaration->expandBackgroundShorthand();
         }
-        self::assertSame(trim((string)$oDoc), $sExpected);
+        self::assertDeclarationBlockEquals(trim((string)$oDoc), $sExpected);
     }
 
     /**
@@ -171,7 +171,7 @@ final class DeclarationBlockTest extends TestCase
         foreach ($oDoc->getAllDeclarationBlocks() as $oDeclaration) {
             $oDeclaration->expandDimensionsShorthand();
         }
-        self::assertSame(trim((string)$oDoc), $sExpected);
+        self::assertDeclarationBlockEquals(trim((string)$oDoc), $sExpected);
     }
 
     /**
@@ -504,5 +504,51 @@ final class DeclarationBlockTest extends TestCase
         $renderedDocument = $document->render($outputFormat);
 
         self::assertSame($cssWithoutComments, $renderedDocument);
+    }
+
+    /**
+     * Asserts two declaration blocks are equivalent, allowing the rules to be in any order.
+     *
+     * @param string $expected
+     * @param string $actual
+     */
+    public static function assertDeclarationBlockEquals($expected, $actual)
+    {
+        $normalizedExpected = self::sortRulesInDeclarationBlock($expected);
+        $normalizedActual = self::sortRulesInDeclarationBlock($actual);
+
+        self::assertSame($normalizedExpected, $normalizedActual);
+    }
+
+    /**
+     * Sorts the rules within a declaration block by property name.
+     *
+     * @param string $declarationBlock
+     *
+     * @return string
+     */
+    private static function sortRulesInDeclarationBlock($declarationBlock)
+    {
+        // Match everything between `{` and `}`.
+        return \preg_replace_callback(
+            '/(?<=\{)[^\}]*+(?=\})/',
+            [self::class, 'sortDeclarationBlockRules'],
+            $declarationBlock
+        );
+    }
+
+    /**
+     * Sorts rules from within a declaration block by property name.
+     *
+     * @param array{0: string} $rulesMatches
+     *        This method is intended as a callback for `preg_replace_callback`.
+     *
+     * @return string
+     */
+    private static function sortDeclarationBlockRules($rulesMatches)
+    {
+        $rules = \explode(';', $rulesMatches[0]);
+        \sort($rules);
+        return \implode(';', $rules);
     }
 }

--- a/tests/RuleSet/DeclarationBlockTest.php
+++ b/tests/RuleSet/DeclarationBlockTest.php
@@ -531,7 +531,7 @@ final class DeclarationBlockTest extends TestCase
     {
         // Match everything between `{` and `}`.
         return \preg_replace_callback(
-            '/(?<=\{)[^\}]*+(?=\})/',
+            '/(?<=\\{)[^\\}]*+(?=\\})/',
             [self::class, 'sortDeclarationBlockRules'],
             $declarationBlock
         );


### PR DESCRIPTION
This is a pre-patch for #1062.