### PR TITLE
[CLEANUP] Avoid Hungarian notation for `arguments`

### DIFF
--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -235,17 +235,17 @@ class OutputFormat
 
     /**
      * @param non-empty-string $sMethodName
-     * @param array<array-key, mixed> $aArguments
+     * @param array<array-key, mixed> $arguments
      *
      * @return mixed
      *
      * @throws \Exception
      */
-    public function __call(string $sMethodName, array $aArguments)
+    public function __call(string $sMethodName, array $arguments)
     {
         if (\method_exists(OutputFormatter::class, $sMethodName)) {
             // @deprecated since 8.8.0, will be removed in 9.0.0. Call the method on the formatter directly instead.
-            return \call_user_func_array([$this->getFormatter(), $sMethodName], $aArguments);
+            return \call_user_func_array([$this->getFormatter(), $sMethodName], $arguments);
         } else {
             throw new \Exception('Unknown OutputFormat method called: ' . $sMethodName);
         }

--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -25,19 +25,19 @@ class CSSFunction extends ValueList
 
     /**
      * @param string $sName
-     * @param RuleValueList|array<array-key, Value|string> $aArguments
+     * @param RuleValueList|array<array-key, Value|string> $arguments
      * @param string $sSeparator
      * @param int<0, max> $lineNumber
      */
-    public function __construct($sName, $aArguments, $sSeparator = ',', $lineNumber = 0)
+    public function __construct($sName, $arguments, $sSeparator = ',', $lineNumber = 0)
     {
-        if ($aArguments instanceof RuleValueList) {
-            $sSeparator = $aArguments->getListSeparator();
-            $aArguments = $aArguments->getListComponents();
+        if ($arguments instanceof RuleValueList) {
+            $sSeparator = $arguments->getListSeparator();
+            $arguments = $arguments->getListComponents();
         }
         $this->sName = $sName;
         $this->lineNumber = $lineNumber;
-        parent::__construct($aArguments, $sSeparator, $lineNumber);
+        parent::__construct($arguments, $sSeparator, $lineNumber);
     }
 
     /**
@@ -51,9 +51,9 @@ class CSSFunction extends ValueList
     {
         $sName = self::parseName($parserState, $ignoreCase);
         $parserState->consume('(');
-        $mArguments = self::parseArguments($parserState);
+        $arguments = self::parseArguments($parserState);
 
-        $result = new CSSFunction($sName, $mArguments, ',', $parserState->currentLine());
+        $result = new CSSFunction($sName, $arguments, ',', $parserState->currentLine());
         $parserState->consume(')');
 
         return $result;
@@ -115,7 +115,7 @@ class CSSFunction extends ValueList
 
     public function render(OutputFormat $outputFormat): string
     {
-        $aArguments = parent::render($outputFormat);
-        return "{$this->sName}({$aArguments})";
+        $arguments = parent::render($outputFormat);
+        return "{$this->sName}({$arguments})";
     }
 }

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -194,8 +194,8 @@ abstract class Value implements Renderable
     private static function parseMicrosoftFilter(ParserState $parserState): CSSFunction
     {
         $sFunction = $parserState->consumeUntil('(', false, true);
-        $aArguments = Value::parseValue($parserState, [',', '=']);
-        return new CSSFunction($sFunction, $aArguments, ',', $parserState->currentLine());
+        $arguments = Value::parseValue($parserState, [',', '=']);
+        return new CSSFunction($sFunction, $arguments, ',', $parserState->currentLine());
     }
 
     /**


### PR DESCRIPTION
Part of #756