### PR TITLE
[CLEANUP] Avoid Hungarian notation for `function`

### DIFF
--- a/src/Value/CalcFunction.php
+++ b/src/Value/CalcFunction.php
@@ -29,13 +29,13 @@ class CalcFunction extends CSSFunction
     public static function parse(ParserState $parserState, bool $ignoreCase = false): CSSFunction
     {
         $aOperators = ['+', '-', '*', '/'];
-        $sFunction = $parserState->parseIdentifier();
+        $function = $parserState->parseIdentifier();
         if ($parserState->peek() != '(') {
             // Found ; or end of line before an opening bracket
             throw new UnexpectedTokenException('(', $parserState->peek(), 'literal', $parserState->currentLine());
-        } elseif (!\in_array($sFunction, ['calc', '-moz-calc', '-webkit-calc'], true)) {
+        } elseif (!\in_array($function, ['calc', '-moz-calc', '-webkit-calc'], true)) {
             // Found invalid calc definition. Example calc (...
-            throw new UnexpectedTokenException('calc', $sFunction, 'literal', $parserState->currentLine());
+            throw new UnexpectedTokenException('calc', $function, 'literal', $parserState->currentLine());
         }
         $parserState->consume('(');
         $oCalcList = new CalcRuleValueList($parserState->currentLine());
@@ -100,6 +100,6 @@ class CalcFunction extends CSSFunction
         if (!$parserState->isEnd()) {
             $parserState->consume(')');
         }
-        return new CalcFunction($sFunction, $list, ',', $parserState->currentLine());
+        return new CalcFunction($function, $list, ',', $parserState->currentLine());
     }
 }

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -193,9 +193,9 @@ abstract class Value implements Renderable
      */
     private static function parseMicrosoftFilter(ParserState $parserState): CSSFunction
     {
-        $sFunction = $parserState->consumeUntil('(', false, true);
+        $function = $parserState->consumeUntil('(', false, true);
         $arguments = Value::parseValue($parserState, [',', '=']);
-        return new CSSFunction($sFunction, $arguments, ',', $parserState->currentLine());
+        return new CSSFunction($function, $arguments, ',', $parserState->currentLine());
     }
 
     /**


### PR DESCRIPTION
Part of #756