### PR TITLE
[CLEANUP] Avoid Hungarian notation for `components`

### DIFF
--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -102,7 +102,7 @@ class CSSFunction extends ValueList
      */
     public function getArguments()
     {
-        return $this->aComponents;
+        return $this->components;
     }
 
     /**

--- a/src/Value/CalcRuleValueList.php
+++ b/src/Value/CalcRuleValueList.php
@@ -18,6 +18,6 @@ class CalcRuleValueList extends RuleValueList
 
     public function render(OutputFormat $outputFormat): string
     {
-        return $outputFormat->implode(' ', $this->aComponents);
+        return $outputFormat->implode(' ', $this->components);
     }
 }

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -204,7 +204,7 @@ class Color extends CSSFunction
      */
     public function getColor()
     {
-        return $this->aComponents;
+        return $this->components;
     }
 
     /**
@@ -213,7 +213,7 @@ class Color extends CSSFunction
     public function setColor(array $colorValues): void
     {
         $this->setName(\implode('', \array_keys($colorValues)));
-        $this->aComponents = $colorValues;
+        $this->components = $colorValues;
     }
 
     /**
@@ -260,7 +260,7 @@ class Color extends CSSFunction
      */
     private function getRealName(): string
     {
-        return \implode('', \array_keys($this->aComponents));
+        return \implode('', \array_keys($this->components));
     }
 
     /**
@@ -269,7 +269,7 @@ class Color extends CSSFunction
      */
     private function allComponentsAreNumbers(): bool
     {
-        foreach ($this->aComponents as $component) {
+        foreach ($this->components as $component) {
             if (!($component instanceof Size) || $component->getUnit() !== null) {
                 return false;
             }
@@ -280,7 +280,7 @@ class Color extends CSSFunction
 
     /**
      * Note that this method assumes the following:
-     * - The `aComponents` array has keys for `r`, `g` and `b`;
+     * - The `components` array has keys for `r`, `g` and `b`;
      * - The values in the array are all instances of `Size`.
      *
      * Errors will be triggered or thrown if this is not the case.
@@ -291,9 +291,9 @@ class Color extends CSSFunction
     {
         $result = \sprintf(
             '%02x%02x%02x',
-            $this->aComponents['r']->getSize(),
-            $this->aComponents['g']->getSize(),
-            $this->aComponents['b']->getSize()
+            $this->components['r']->getSize(),
+            $this->components['g']->getSize(),
+            $this->components['b']->getSize()
         );
         $canUseShortVariant = ($result[0] == $result[1]) && ($result[2] == $result[3]) && ($result[4] == $result[5]);
 
@@ -327,7 +327,7 @@ class Color extends CSSFunction
 
         $hasPercentage = false;
         $hasNumber = false;
-        foreach ($this->aComponents as $key => $value) {
+        foreach ($this->components as $key => $value) {
             if ($key === 'a') {
                 // Alpha can have units that don't match those of the RGB components in the "legacy" syntax.
                 // So it is not necessary to check it.  It's also always last, hence `break` rather than `continue`.
@@ -354,7 +354,7 @@ class Color extends CSSFunction
 
     private function hasNoneAsComponentValue(): bool
     {
-        return \in_array('none', $this->aComponents, true);
+        return \in_array('none', $this->components, true);
     }
 
     /**
@@ -376,10 +376,10 @@ class Color extends CSSFunction
     private function renderInModernSyntax(OutputFormat $outputFormat): string
     {
         // Maybe not yet without alpha, but will be...
-        $componentsWithoutAlpha = $this->aComponents;
+        $componentsWithoutAlpha = $this->components;
         \end($componentsWithoutAlpha);
         if (\key($componentsWithoutAlpha) === 'a') {
-            $alpha = $this->aComponents['a'];
+            $alpha = $this->components['a'];
             unset($componentsWithoutAlpha['a']);
         }
 

--- a/src/Value/LineName.php
+++ b/src/Value/LineName.php
@@ -12,12 +12,12 @@ use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 class LineName extends ValueList
 {
     /**
-     * @param array<int, Value|string> $aComponents
+     * @param array<int, Value|string> $components
      * @param int<0, max> $lineNumber
      */
-    public function __construct(array $aComponents = [], $lineNumber = 0)
+    public function __construct(array $components = [], $lineNumber = 0)
     {
-        parent::__construct($aComponents, ' ', $lineNumber);
+        parent::__construct($components, ' ', $lineNumber);
     }
 
     /**

--- a/src/Value/ValueList.php
+++ b/src/Value/ValueList.php
@@ -19,7 +19,7 @@ abstract class ValueList extends Value
      *
      * @internal since 8.8.0
      */
-    protected $aComponents;
+    protected $components;
 
     /**
      * @var string
@@ -29,17 +29,17 @@ abstract class ValueList extends Value
     protected $sSeparator;
 
     /**
-     * @param array<array-key, Value|string>|Value|string $aComponents
+     * @param array<array-key, Value|string>|Value|string $components
      * @param string $sSeparator
      * @param int<0, max> $lineNumber
      */
-    public function __construct($aComponents = [], $sSeparator = ',', $lineNumber = 0)
+    public function __construct($components = [], $sSeparator = ',', $lineNumber = 0)
     {
         parent::__construct($lineNumber);
-        if (!\is_array($aComponents)) {
-            $aComponents = [$aComponents];
+        if (!\is_array($components)) {
+            $components = [$components];
         }
-        $this->aComponents = $aComponents;
+        $this->components = $components;
         $this->sSeparator = $sSeparator;
     }
 
@@ -48,7 +48,7 @@ abstract class ValueList extends Value
      */
     public function addListComponent($component): void
     {
-        $this->aComponents[] = $component;
+        $this->components[] = $component;
     }
 
     /**
@@ -56,15 +56,15 @@ abstract class ValueList extends Value
      */
     public function getListComponents()
     {
-        return $this->aComponents;
+        return $this->components;
     }
 
     /**
-     * @param array<array-key, Value|string> $aComponents
+     * @param array<array-key, Value|string> $components
      */
-    public function setListComponents(array $aComponents): void
+    public function setListComponents(array $components): void
     {
-        $this->aComponents = $aComponents;
+        $this->components = $components;
     }
 
     /**
@@ -96,7 +96,7 @@ abstract class ValueList extends Value
         return $outputFormat->implode(
             $outputFormat->spaceBeforeListArgumentSeparator($this->sSeparator) . $this->sSeparator
             . $outputFormat->spaceAfterListArgumentSeparator($this->sSeparator),
-            $this->aComponents
+            $this->components
         );
     }
 }


### PR DESCRIPTION
Part of #756