### PR TITLE
[CLEANUP] Avoid Hungarian notation for `separator`

### DIFF
--- a/src/OutputFormatter.php
+++ b/src/OutputFormatter.php
@@ -119,23 +119,23 @@ class OutputFormatter
     }
 
     /**
-     * @param non-empty-string $sSeparator
+     * @param non-empty-string $separator
      */
-    public function spaceBeforeListArgumentSeparator(string $sSeparator): string
+    public function spaceBeforeListArgumentSeparator(string $separator): string
     {
         $spaceForSeparator = $this->outputFormat->getSpaceBeforeListArgumentSeparators();
 
-        return $spaceForSeparator[$sSeparator] ?? $this->space('BeforeListArgumentSeparator');
+        return $spaceForSeparator[$separator] ?? $this->space('BeforeListArgumentSeparator');
     }
 
     /**
-     * @param non-empty-string $sSeparator
+     * @param non-empty-string $separator
      */
-    public function spaceAfterListArgumentSeparator(string $sSeparator): string
+    public function spaceAfterListArgumentSeparator(string $separator): string
     {
         $spaceForSeparator = $this->outputFormat->getSpaceAfterListArgumentSeparators();
 
-        return $spaceForSeparator[$sSeparator] ?? $this->space('AfterListArgumentSeparator');
+        return $spaceForSeparator[$separator] ?? $this->space('AfterListArgumentSeparator');
     }
 
     public function spaceBeforeOpeningBrace(): string

--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -26,18 +26,18 @@ class CSSFunction extends ValueList
     /**
      * @param string $sName
      * @param RuleValueList|array<array-key, Value|string> $arguments
-     * @param string $sSeparator
+     * @param string $separator
      * @param int<0, max> $lineNumber
      */
-    public function __construct($sName, $arguments, $sSeparator = ',', $lineNumber = 0)
+    public function __construct($sName, $arguments, $separator = ',', $lineNumber = 0)
     {
         if ($arguments instanceof RuleValueList) {
-            $sSeparator = $arguments->getListSeparator();
+            $separator = $arguments->getListSeparator();
             $arguments = $arguments->getListComponents();
         }
         $this->sName = $sName;
         $this->lineNumber = $lineNumber;
-        parent::__construct($arguments, $sSeparator, $lineNumber);
+        parent::__construct($arguments, $separator, $lineNumber);
     }
 
     /**

--- a/src/Value/RuleValueList.php
+++ b/src/Value/RuleValueList.php
@@ -12,11 +12,11 @@ namespace Sabberworm\CSS\Value;
 class RuleValueList extends ValueList
 {
     /**
-     * @param string $sSeparator
+     * @param string $separator
      * @param int<0, max> $lineNumber
      */
-    public function __construct($sSeparator = ',', $lineNumber = 0)
+    public function __construct($separator = ',', $lineNumber = 0)
     {
-        parent::__construct([], $sSeparator, $lineNumber);
+        parent::__construct([], $separator, $lineNumber);
     }
 }

--- a/src/Value/ValueList.php
+++ b/src/Value/ValueList.php
@@ -26,21 +26,21 @@ abstract class ValueList extends Value
      *
      * @internal since 8.8.0
      */
-    protected $sSeparator;
+    protected $separator;
 
     /**
      * @param array<array-key, Value|string>|Value|string $components
-     * @param string $sSeparator
+     * @param string $separator
      * @param int<0, max> $lineNumber
      */
-    public function __construct($components = [], $sSeparator = ',', $lineNumber = 0)
+    public function __construct($components = [], $separator = ',', $lineNumber = 0)
     {
         parent::__construct($lineNumber);
         if (!\is_array($components)) {
             $components = [$components];
         }
         $this->components = $components;
-        $this->sSeparator = $sSeparator;
+        $this->separator = $separator;
     }
 
     /**
@@ -72,15 +72,15 @@ abstract class ValueList extends Value
      */
     public function getListSeparator()
     {
-        return $this->sSeparator;
+        return $this->separator;
     }
 
     /**
-     * @param string $sSeparator
+     * @param string $separator
      */
-    public function setListSeparator($sSeparator): void
+    public function setListSeparator($separator): void
     {
-        $this->sSeparator = $sSeparator;
+        $this->separator = $separator;
     }
 
     /**
@@ -94,8 +94,8 @@ abstract class ValueList extends Value
     public function render(OutputFormat $outputFormat): string
     {
         return $outputFormat->implode(
-            $outputFormat->spaceBeforeListArgumentSeparator($this->sSeparator) . $this->sSeparator
-            . $outputFormat->spaceAfterListArgumentSeparator($this->sSeparator),
+            $outputFormat->spaceBeforeListArgumentSeparator($this->separator) . $this->separator
+            . $outputFormat->spaceAfterListArgumentSeparator($this->separator),
             $this->components
         );
     }


### PR DESCRIPTION
Part of #756