### PR TITLE
[TASK] Drop special support for vendor prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Please also have a look at our
 
 ### Removed
 
+- Drop special support for vendor prefixes (#1083)
 - Remove the IE hack in `Rule` (#995)
 - Drop `getLineNo()` from the `Renderable` interface (#1038)
 - Remove `OutputFormat::level()` (#874)

--- a/src/Value/CalcFunction.php
+++ b/src/Value/CalcFunction.php
@@ -33,7 +33,7 @@ class CalcFunction extends CSSFunction
         if ($parserState->peek() != '(') {
             // Found ; or end of line before an opening bracket
             throw new UnexpectedTokenException('(', $parserState->peek(), 'literal', $parserState->currentLine());
-        } elseif (!\in_array($function, ['calc', '-moz-calc', '-webkit-calc'], true)) {
+        } elseif ($function !== 'calc') {
             // Found invalid calc definition. Example calc (...
             throw new UnexpectedTokenException('calc', $function, 'literal', $parserState->currentLine());
         }

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -127,11 +127,7 @@ abstract class Value implements Renderable
             $anchor->backtrack();
             if ($parserState->streql('url', $result)) {
                 $result = URL::parse($parserState);
-            } elseif (
-                $parserState->streql('calc', $result)
-                || $parserState->streql('-webkit-calc', $result)
-                || $parserState->streql('-moz-calc', $result)
-            ) {
+            } elseif ($parserState->streql('calc', $result)) {
                 $result = CalcFunction::parse($parserState);
             } else {
                 $result = CSSFunction::parse($parserState, $ignoreCase);

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -618,7 +618,7 @@ div {background: rgba(17,34,51,.27);}';
         $document = self::parsedStructureForFile('calc', Settings::create()->withMultibyteSupport(true));
         $expected = 'div {width: calc(100% / 4);}
 div {margin-top: calc(-120% - 4px);}
-div {height: -webkit-calc(9 / 16 * 100%) !important;width: -moz-calc(( 50px - 50% ) * 2);}
+div {height: calc(9 / 16 * 100%) !important;width: calc(( 50px - 50% ) * 2);}
 div {width: calc(50% - ( ( 4% ) * .5 ));}';
         self::assertSame($expected, $document->render());
     }

--- a/tests/fixtures/calc.css
+++ b/tests/fixtures/calc.css
@@ -1,7 +1,7 @@
 div { width: calc(100% / 4); }
 div { margin-top: calc(-120% - 4px); }
 div {
-    height: -webkit-calc(9/16 * 100%)!important;
-    width: -moz-calc((50px - 50%)*2);
+    height: calc(9/16 * 100%)!important;
+    width: calc((50px - 50%)*2);
 }
 div { width: calc(50% - ( ( 4% ) * 0.5 ) ); }


### PR DESCRIPTION
In the past, vendor prefixes like `-moz-` or `-webkit-` were used for experimental CSS features in browsers. Nowadays, the browsers use features for this instead. Hence, special support for vendor prefixes is no longer needed.

https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix