### PR TITLE
[CLEANUP] Avoid Hungarian notation for `tokenLength`

### DIFF
--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -132,11 +132,11 @@ class Size extends PrimitiveValue
         if (!\is_array(self::$SIZE_UNITS)) {
             self::$SIZE_UNITS = [];
             foreach (\array_merge(self::ABSOLUTE_SIZE_UNITS, self::RELATIVE_SIZE_UNITS, self::NON_SIZE_UNITS) as $val) {
-                $iSize = \strlen($val);
-                if (!isset(self::$SIZE_UNITS[$iSize])) {
-                    self::$SIZE_UNITS[$iSize] = [];
+                $tokenLength = \strlen($val);
+                if (!isset(self::$SIZE_UNITS[$tokenLength])) {
+                    self::$SIZE_UNITS[$tokenLength] = [];
                 }
-                self::$SIZE_UNITS[$iSize][\strtolower($val)] = $val;
+                self::$SIZE_UNITS[$tokenLength][\strtolower($val)] = $val;
             }
 
             \krsort(self::$SIZE_UNITS, SORT_NUMERIC);


### PR DESCRIPTION
Part of #756