### PR TITLE
[CLEANUP] Improve some `OutputFormat` property and getter names

### DIFF
--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -18,7 +18,7 @@ class OutputFormat
      *
      * @var bool
      */
-    private $rgbHashNotation = true;
+    private $usesRgbHashNotation = true;
 
     /**
      * Declaration format
@@ -27,7 +27,7 @@ class OutputFormat
      *
      * @var bool
      */
-    private $semicolonAfterLastRule = true;
+    private $renderSemicolonAfterLastRule = true;
 
     /**
      * Spacing
@@ -272,17 +272,17 @@ class OutputFormat
     /**
      * @internal
      */
-    public function getRGBHashNotation(): bool
+    public function usesRgbHashNotation(): bool
     {
-        return $this->rgbHashNotation;
+        return $this->usesRgbHashNotation;
     }
 
     /**
      * @return $this fluent interface
      */
-    public function setRGBHashNotation(bool $rgbHashNotation): self
+    public function setRGBHashNotation(bool $usesRgbHashNotation): self
     {
-        $this->rgbHashNotation = $rgbHashNotation;
+        $this->usesRgbHashNotation = $usesRgbHashNotation;
 
         return $this;
     }
@@ -290,17 +290,17 @@ class OutputFormat
     /**
      * @internal
      */
-    public function getSemicolonAfterLastRule(): bool
+    public function shouldRenderSemicolonAfterLastRule(): bool
     {
-        return $this->semicolonAfterLastRule;
+        return $this->renderSemicolonAfterLastRule;
     }
 
     /**
      * @return $this fluent interface
      */
-    public function setSemicolonAfterLastRule(bool $semicolonAfterLastRule): self
+    public function setSemicolonAfterLastRule(bool $renderSemicolonAfterLastRule): self
     {
-        $this->semicolonAfterLastRule = $semicolonAfterLastRule;
+        $this->renderSemicolonAfterLastRule = $renderSemicolonAfterLastRule;
 
         return $this;
     }

--- a/src/OutputFormatter.php
+++ b/src/OutputFormatter.php
@@ -191,7 +191,7 @@ class OutputFormatter
 
     public function removeLastSemicolon(string $string): string
     {
-        if ($this->outputFormat->getSemicolonAfterLastRule()) {
+        if ($this->outputFormat->shouldRenderSemicolonAfterLastRule()) {
             return $string;
         }
 

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -248,7 +248,7 @@ class Color extends CSSFunction
     private function shouldRenderAsHex(OutputFormat $outputFormat): bool
     {
         return
-            $outputFormat->getRGBHashNotation()
+            $outputFormat->usesRgbHashNotation()
             && $this->getRealName() === 'rgb'
             && $this->allComponentsAreNumbers();
     }

--- a/tests/Unit/OutputFormatTest.php
+++ b/tests/Unit/OutputFormatTest.php
@@ -53,9 +53,9 @@ final class OutputFormatTest extends TestCase
     /**
      * @test
      */
-    public function getRGBHashNotationInitiallyReturnsTrue(): void
+    public function usesRgbHashNotationInitiallyReturnsTrue(): void
     {
-        self::assertTrue($this->subject->getRGBHashNotation());
+        self::assertTrue($this->subject->usesRgbHashNotation());
     }
 
     /**
@@ -78,7 +78,7 @@ final class OutputFormatTest extends TestCase
     {
         $this->subject->setRGBHashNotation($value);
 
-        self::assertSame($value, $this->subject->getRGBHashNotation());
+        self::assertSame($value, $this->subject->usesRgbHashNotation());
     }
 
     /**
@@ -92,9 +92,9 @@ final class OutputFormatTest extends TestCase
     /**
      * @test
      */
-    public function getSemicolonAfterLastRuleInitiallyReturnsTrue(): void
+    public function shouldRenderSemicolonAfterLastRuleInitiallyReturnsTrue(): void
     {
-        self::assertTrue($this->subject->getSemicolonAfterLastRule());
+        self::assertTrue($this->subject->shouldRenderSemicolonAfterLastRule());
     }
 
     /**
@@ -106,7 +106,7 @@ final class OutputFormatTest extends TestCase
     {
         $this->subject->setSemicolonAfterLastRule($value);
 
-        self::assertSame($value, $this->subject->getSemicolonAfterLastRule());
+        self::assertSame($value, $this->subject->shouldRenderSemicolonAfterLastRule());
     }
 
     /**


### PR DESCRIPTION
As suggested in #1098.

The setters are not changed a those are part of the public API.