### PR TITLE
[CLEANUP] Use the explicit `OutputFormat` setters in the tests

### DIFF
--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -103,12 +103,6 @@ parameters:
 			path: ../src/CSSList/KeyFrame.php
 
 		-
-			message: '#^Parameters should have "string\|string" types as the only types passed to this method$#'
-			identifier: typePerfect.narrowPublicClassMethodParamType
-			count: 1
-			path: ../src/OutputFormat.php
-
-		-
 			message: '#^Returning false in non return bool class method\. Use null with type\|null instead or add bool return type$#'
 			identifier: typePerfect.nullOverFalse
 			count: 1

--- a/tests/OutputFormatTest.php
+++ b/tests/OutputFormatTest.php
@@ -182,6 +182,11 @@ EOT;
      */
     public function spaceRules(): void
     {
+        $outputFormat = OutputFormat::create()
+            ->setSpaceBeforeRules("\n")
+            ->setSpaceBetweenRules("\n")
+            ->setSpaceAfterRules("\n");
+
         self::assertSame('.main, .test {
 	font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;
 	background: white;
@@ -190,7 +195,7 @@ EOT;
 		background-size: 100% 100%;
 		font-size: 1.3em;
 		background-color: #fff;
-	}}', $this->document->render(OutputFormat::create()->set('Space*Rules', "\n")));
+	}}', $this->document->render($outputFormat));
     }
 
     /**
@@ -198,12 +203,17 @@ EOT;
      */
     public function spaceBlocks(): void
     {
+        $outputFormat = OutputFormat::create()
+            ->setSpaceBeforeBlocks("\n")
+            ->setSpaceBetweenBlocks("\n")
+            ->setSpaceAfterBlocks("\n");
+
         self::assertSame('
 .main, .test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white;}
 @media screen {
 	.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff;}
 }
-', $this->document->render(OutputFormat::create()->set('Space*Blocks', "\n")));
+', $this->document->render($outputFormat));
     }
 
     /**
@@ -211,6 +221,14 @@ EOT;
      */
     public function spaceBoth(): void
     {
+        $outputFormat = OutputFormat::create()
+            ->setSpaceBeforeRules("\n")
+            ->setSpaceBetweenRules("\n")
+            ->setSpaceAfterRules("\n")
+            ->setSpaceBeforeBlocks("\n")
+            ->setSpaceBetweenBlocks("\n")
+            ->setSpaceAfterBlocks("\n");
+
         self::assertSame('
 .main, .test {
 	font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;
@@ -223,7 +241,7 @@ EOT;
 		background-color: #fff;
 	}
 }
-', $this->document->render(OutputFormat::create()->set('Space*Rules', "\n")->set('Space*Blocks', "\n")));
+', $this->document->render($outputFormat));
     }
 
     /**
@@ -231,10 +249,13 @@ EOT;
      */
     public function spaceBetweenBlocks(): void
     {
+        $outputFormat = OutputFormat::create()
+            ->setSpaceBetweenBlocks('');
+
         self::assertSame(
             '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white;}'
             . '@media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff;}}',
-            $this->document->render(OutputFormat::create()->setSpaceBetweenBlocks(''))
+            $this->document->render($outputFormat)
         );
     }
 
@@ -243,6 +264,15 @@ EOT;
      */
     public function indentation(): void
     {
+        $outputFormat = OutputFormat::create()
+            ->setSpaceBeforeRules("\n")
+            ->setSpaceBetweenRules("\n")
+            ->setSpaceAfterRules("\n")
+            ->setSpaceBeforeBlocks("\n")
+            ->setSpaceBetweenBlocks("\n")
+            ->setSpaceAfterBlocks("\n")
+            ->setIndentation('');
+
         self::assertSame('
 .main, .test {
 font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;
@@ -255,10 +285,7 @@ font-size: 1.3em;
 background-color: #fff;
 }
 }
-', $this->document->render(OutputFormat::create()
-            ->set('Space*Rules', "\n")
-            ->set('Space*Blocks', "\n")
-            ->setIndentation('')));
+', $this->document->render($outputFormat));
     }
 
     /**
@@ -266,10 +293,13 @@ background-color: #fff;
      */
     public function spaceBeforeBraces(): void
     {
+        $outputFormat = OutputFormat::create()
+            ->setSpaceBeforeOpeningBrace('');
+
         self::assertSame(
             '.main, .test{font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white;}
 @media screen{.main{background-size: 100% 100%;font-size: 1.3em;background-color: #fff;}}',
-            $this->document->render(OutputFormat::create()->setSpaceBeforeOpeningBrace(''))
+            $this->document->render($outputFormat)
         );
     }
 
@@ -280,6 +310,8 @@ background-color: #fff;
     {
         $this->expectException(OutputException::class);
 
+        $outputFormat = OutputFormat::create()->setIgnoreExceptions(false);
+
         $declarationBlocks = $this->document->getAllDeclarationBlocks();
         $firstDeclarationBlock = $declarationBlocks[0];
         $firstDeclarationBlock->removeSelector('.main');
@@ -289,7 +321,7 @@ background-color: #fff;
             $this->document->render(OutputFormat::create()->setIgnoreExceptions(false))
         );
         $firstDeclarationBlock->removeSelector('.test');
-        $this->document->render(OutputFormat::create()->setIgnoreExceptions(false));
+        $this->document->render($outputFormat);
     }
 
     /**
@@ -297,13 +329,15 @@ background-color: #fff;
      */
     public function ignoreExceptionsOn(): void
     {
+        $outputFormat = OutputFormat::create()->setIgnoreExceptions(true);
+
         $declarationBlocks = $this->document->getAllDeclarationBlocks();
         $firstDeclarationBlock = $declarationBlocks[0];
         $firstDeclarationBlock->removeSelector('.main');
         $firstDeclarationBlock->removeSelector('.test');
         self::assertSame(
             '@media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff;}}',
-            $this->document->render(OutputFormat::create()->setIgnoreExceptions(true))
+            $this->document->render($outputFormat)
         );
     }
 }

--- a/tests/OutputFormatTest.php
+++ b/tests/OutputFormatTest.php
@@ -318,7 +318,7 @@ background-color: #fff;
         self::assertSame(
             '.test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white;}
 @media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff;}}',
-            $this->document->render(OutputFormat::create()->setIgnoreExceptions(false))
+            $this->document->render($outputFormat)
         );
         $firstDeclarationBlock->removeSelector('.test');
         $this->document->render($outputFormat);


### PR DESCRIPTION
The `set()` method will be removed soon.

Also unify the tests a bit.

Part of #1103