### PR TITLE
[TASK] Deprecate `OutputFormat::get()` and `::set()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
+- Deprecate `OutputFormat::get()` and `::set()` (#1107)
 - Deprecate support for `-webkit-calc` and `-moz-calc` (#1086)
 - Deprecate `__toString()` (#1006)
 - Deprecate greedy calculation of selector specificity (#1018)

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -268,7 +268,7 @@ class OutputFormat
      *
      * @return self|false
      *
-     * @deprecated since 8.8.0, will be removed in 9.0.0. Use specific magic setters instead.
+     * @deprecated since 8.8.0, will be removed in 9.0.0. Use specific setters instead.
      */
     public function set($aNames, $mValue)
     {

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -247,6 +247,8 @@ class OutputFormat
      * @param string $sName
      *
      * @return string|null
+     *
+     * @deprecated since 8.8.0, will be removed in 9.0.0. Use specific magic getters instead.
      */
     public function get($sName)
     {
@@ -265,6 +267,8 @@ class OutputFormat
      * @param mixed $mValue
      *
      * @return self|false
+     *
+     * @deprecated since 8.8.0, will be removed in 9.0.0. Use specific magic setters instead.
      */
     public function set($aNames, $mValue)
     {

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -248,7 +248,7 @@ class OutputFormat
      *
      * @return string|null
      *
-     * @deprecated since 8.8.0, will be removed in 9.0.0. Use specific magic getters instead.
+     * @deprecated since 8.8.0, will be removed in 9.0.0. Use specific getters instead.
      */
     public function get($sName)
     {


### PR DESCRIPTION
Part of #1103