### PR TITLE
[TASK] Remove `OutputFormat::get()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Please also have a look at our
 
 ### Removed
 
+- Remove `OutputFormat::get()` (#1108)
 - Drop special support for vendor prefixes (#1083)
 - Remove the IE hack in `Rule` (#995)
 - Drop `getLineNo()` from the `Renderable` interface (#1038)

--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -117,7 +117,7 @@ parameters:
 		-
 			message: '#^Variable property access on \$this\(Sabberworm\\CSS\\OutputFormat\)\.$#'
 			identifier: property.dynamicName
-			count: 4
+			count: 2
 			path: ../src/OutputFormat.php
 
 		-

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -183,21 +183,6 @@ class OutputFormat
     public function __construct() {}
 
     /**
-     * @return string|int|bool|null
-     */
-    public function get(string $name)
-    {
-        $aVarPrefixes = ['a', 's', 'm', 'b', 'f', 'o', 'c', 'i'];
-        foreach ($aVarPrefixes as $prefix) {
-            $sFieldName = $prefix . \ucfirst($name);
-            if (isset($this->$sFieldName)) {
-                return $this->$sFieldName;
-            }
-        }
-        return null;
-    }
-
-    /**
      * @param array<array-key, string>|string $names
      * @param mixed $value
      *


### PR DESCRIPTION
We now have beautiful, cleanly-typed getters to use instead.

Part of #1103