### PR TITLE
[CLEANUP] Avoid Hungarian notation in `OutputFormat` (part 4)

### DIFF
--- a/src/CSSList/AtRuleBlockList.php
+++ b/src/CSSList/AtRuleBlockList.php
@@ -53,7 +53,7 @@ class AtRuleBlockList extends CSSBlockList implements AtRule
     public function render(OutputFormat $outputFormat): string
     {
         $result = $outputFormat->comments($this);
-        $result .= $outputFormat->getBeforeAtRuleBlock();
+        $result .= $outputFormat->getContentBeforeAtRuleBlock();
         $arguments = $this->arguments;
         if ($arguments) {
             $arguments = ' ' . $arguments;
@@ -61,7 +61,7 @@ class AtRuleBlockList extends CSSBlockList implements AtRule
         $result .= "@{$this->type}$arguments{$outputFormat->spaceBeforeOpeningBrace()}{";
         $result .= $this->renderListContents($outputFormat);
         $result .= '}';
-        $result .= $outputFormat->getAfterAtRuleBlock();
+        $result .= $outputFormat->getContentAfterAtRuleBlock();
         return $result;
     }
 

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -75,12 +75,12 @@ class OutputFormat
      *
      * @var string
      */
-    private $sBeforeAtRuleBlock = '';
+    private $contentBeforeAtRuleBlock = '';
 
     /**
      * @var string
      */
-    private $sAfterAtRuleBlock = '';
+    private $contentAfterAtRuleBlock = '';
 
     /**
      * This is what’s printed before and after the comma if a declaration block contains multiple selectors.
@@ -383,9 +383,9 @@ class OutputFormat
     /**
      * @internal
      */
-    public function getBeforeAtRuleBlock(): string
+    public function getContentBeforeAtRuleBlock(): string
     {
-        return $this->sBeforeAtRuleBlock;
+        return $this->contentBeforeAtRuleBlock;
     }
 
     /**
@@ -393,7 +393,7 @@ class OutputFormat
      */
     public function setBeforeAtRuleBlock(string $content): self
     {
-        $this->sBeforeAtRuleBlock = $content;
+        $this->contentBeforeAtRuleBlock = $content;
 
         return $this;
     }
@@ -401,9 +401,9 @@ class OutputFormat
     /**
      * @internal
      */
-    public function getAfterAtRuleBlock(): string
+    public function getContentAfterAtRuleBlock(): string
     {
-        return $this->sAfterAtRuleBlock;
+        return $this->contentAfterAtRuleBlock;
     }
 
     /**
@@ -411,7 +411,7 @@ class OutputFormat
      */
     public function setAfterAtRuleBlock(string $content): self
     {
-        $this->sAfterAtRuleBlock = $content;
+        $this->contentAfterAtRuleBlock = $content;
 
         return $this;
     }

--- a/tests/Unit/OutputFormatTest.php
+++ b/tests/Unit/OutputFormatTest.php
@@ -309,9 +309,9 @@ final class OutputFormatTest extends TestCase
     /**
      * @test
      */
-    public function getBeforeAtRuleBlockInitiallyReturnsEmptyString(): void
+    public function getContentBeforeAtRuleBlockInitiallyReturnsEmptyString(): void
     {
-        self::assertSame('', $this->subject->getBeforeAtRuleBlock());
+        self::assertSame('', $this->subject->getContentBeforeAtRuleBlock());
     }
 
     /**
@@ -322,7 +322,7 @@ final class OutputFormatTest extends TestCase
         $value = ' ';
         $this->subject->setBeforeAtRuleBlock($value);
 
-        self::assertSame($value, $this->subject->getBeforeAtRuleBlock());
+        self::assertSame($value, $this->subject->getContentBeforeAtRuleBlock());
     }
 
     /**
@@ -336,9 +336,9 @@ final class OutputFormatTest extends TestCase
     /**
      * @test
      */
-    public function getAfterAtRuleBlockInitiallyReturnsEmptyString(): void
+    public function getContentAfterAtRuleBlockInitiallyReturnsEmptyString(): void
     {
-        self::assertSame('', $this->subject->getAfterAtRuleBlock());
+        self::assertSame('', $this->subject->getContentAfterAtRuleBlock());
     }
 
     /**
@@ -349,7 +349,7 @@ final class OutputFormatTest extends TestCase
         $value = ' ';
         $this->subject->setAfterAtRuleBlock($value);
 
-        self::assertSame($value, $this->subject->getAfterAtRuleBlock());
+        self::assertSame($value, $this->subject->getContentAfterAtRuleBlock());
     }
 
     /**


### PR DESCRIPTION
Also rename the (internal) getters to match the changed property names.

Part of #756