### PR TITLE
[CLEANUP] Avoid Hungarian notation in `OutputFormat` (part 7)

### DIFF
--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -125,24 +125,24 @@ class OutputFormat
     /**
      * @var string
      */
-    private $sSpaceBeforeOpeningBrace = ' ';
+    private $spaceBeforeOpeningBrace = ' ';
 
     /**
      * Content injected in and around declaration blocks.
      *
      * @var string
      */
-    private $sBeforeDeclarationBlock = '';
+    private $contentBeforeDeclarationBlock = '';
 
     /**
      * @var string
      */
-    private $sAfterDeclarationBlockSelectors = '';
+    private $contentAfterDeclarationBlockSelectors = '';
 
     /**
      * @var string
      */
-    private $sAfterDeclarationBlock = '';
+    private $contentAfterDeclarationBlock = '';
 
     /**
      * Indentation character(s) per level. Only applicable if newlines are used in any of the spacing settings.
@@ -537,7 +537,7 @@ class OutputFormat
      */
     public function getSpaceBeforeOpeningBrace(): string
     {
-        return $this->sSpaceBeforeOpeningBrace;
+        return $this->spaceBeforeOpeningBrace;
     }
 
     /**
@@ -545,7 +545,7 @@ class OutputFormat
      */
     public function setSpaceBeforeOpeningBrace(string $whitespace): self
     {
-        $this->sSpaceBeforeOpeningBrace = $whitespace;
+        $this->spaceBeforeOpeningBrace = $whitespace;
 
         return $this;
     }
@@ -553,9 +553,9 @@ class OutputFormat
     /**
      * @internal
      */
-    public function getBeforeDeclarationBlock(): string
+    public function getContentBeforeDeclarationBlock(): string
     {
-        return $this->sBeforeDeclarationBlock;
+        return $this->contentBeforeDeclarationBlock;
     }
 
     /**
@@ -563,7 +563,7 @@ class OutputFormat
      */
     public function setBeforeDeclarationBlock(string $content): self
     {
-        $this->sBeforeDeclarationBlock = $content;
+        $this->contentBeforeDeclarationBlock = $content;
 
         return $this;
     }
@@ -571,9 +571,9 @@ class OutputFormat
     /**
      * @internal
      */
-    public function getAfterDeclarationBlockSelectors(): string
+    public function getContentAfterDeclarationBlockSelectors(): string
     {
-        return $this->sAfterDeclarationBlockSelectors;
+        return $this->contentAfterDeclarationBlockSelectors;
     }
 
     /**
@@ -581,7 +581,7 @@ class OutputFormat
      */
     public function setAfterDeclarationBlockSelectors(string $content): self
     {
-        $this->sAfterDeclarationBlockSelectors = $content;
+        $this->contentAfterDeclarationBlockSelectors = $content;
 
         return $this;
     }
@@ -589,9 +589,9 @@ class OutputFormat
     /**
      * @internal
      */
-    public function getAfterDeclarationBlock(): string
+    public function getContentAfterDeclarationBlock(): string
     {
-        return $this->sAfterDeclarationBlock;
+        return $this->contentAfterDeclarationBlock;
     }
 
     /**
@@ -599,7 +599,7 @@ class OutputFormat
      */
     public function setAfterDeclarationBlock(string $content): self
     {
-        $this->sAfterDeclarationBlock = $content;
+        $this->contentAfterDeclarationBlock = $content;
 
         return $this;
     }

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -160,16 +160,16 @@ class DeclarationBlock extends RuleSet
             // If all the selectors have been removed, this declaration block becomes invalid
             throw new OutputException('Attempt to print declaration block with missing selector', $this->lineNumber);
         }
-        $result .= $outputFormat->getBeforeDeclarationBlock();
+        $result .= $outputFormat->getContentBeforeDeclarationBlock();
         $result .= $outputFormat->implode(
             $outputFormat->spaceBeforeSelectorSeparator() . ',' . $outputFormat->spaceAfterSelectorSeparator(),
             $this->selectors
         );
-        $result .= $outputFormat->getAfterDeclarationBlockSelectors();
+        $result .= $outputFormat->getContentAfterDeclarationBlockSelectors();
         $result .= $outputFormat->spaceBeforeOpeningBrace() . '{';
         $result .= $this->renderRules($outputFormat);
         $result .= '}';
-        $result .= $outputFormat->getAfterDeclarationBlock();
+        $result .= $outputFormat->getContentAfterDeclarationBlock();
         return $result;
     }
 }

--- a/tests/Unit/OutputFormatTest.php
+++ b/tests/Unit/OutputFormatTest.php
@@ -552,9 +552,9 @@ final class OutputFormatTest extends TestCase
     /**
      * @test
      */
-    public function getBeforeDeclarationBlockInitiallyReturnsEmptyString(): void
+    public function getContentBeforeDeclarationBlockInitiallyReturnsEmptyString(): void
     {
-        self::assertSame('', $this->subject->getBeforeDeclarationBlock());
+        self::assertSame('', $this->subject->getContentBeforeDeclarationBlock());
     }
 
     /**
@@ -565,7 +565,7 @@ final class OutputFormatTest extends TestCase
         $value = ' ';
         $this->subject->setBeforeDeclarationBlock($value);
 
-        self::assertSame($value, $this->subject->getBeforeDeclarationBlock());
+        self::assertSame($value, $this->subject->getContentBeforeDeclarationBlock());
     }
 
     /**
@@ -579,9 +579,9 @@ final class OutputFormatTest extends TestCase
     /**
      * @test
      */
-    public function getAfterDeclarationBlockSelectorsInitiallyReturnsEmptyString(): void
+    public function getContentAfterDeclarationBlockSelectorsInitiallyReturnsEmptyString(): void
     {
-        self::assertSame('', $this->subject->getAfterDeclarationBlockSelectors());
+        self::assertSame('', $this->subject->getContentAfterDeclarationBlockSelectors());
     }
 
     /**
@@ -592,7 +592,7 @@ final class OutputFormatTest extends TestCase
         $value = ' ';
         $this->subject->setAfterDeclarationBlockSelectors($value);
 
-        self::assertSame($value, $this->subject->getAfterDeclarationBlockSelectors());
+        self::assertSame($value, $this->subject->getContentAfterDeclarationBlockSelectors());
     }
 
     /**
@@ -606,9 +606,9 @@ final class OutputFormatTest extends TestCase
     /**
      * @test
      */
-    public function getAfterDeclarationBlockInitiallyReturnsEmptyString(): void
+    public function getContentAfterDeclarationBlockInitiallyReturnsEmptyString(): void
     {
-        self::assertSame('', $this->subject->getAfterDeclarationBlock());
+        self::assertSame('', $this->subject->getContentAfterDeclarationBlock());
     }
 
     /**
@@ -619,7 +619,7 @@ final class OutputFormatTest extends TestCase
         $value = ' ';
         $this->subject->setAfterDeclarationBlock($value);
 
-        self::assertSame($value, $this->subject->getAfterDeclarationBlock());
+        self::assertSame($value, $this->subject->getContentAfterDeclarationBlock());
     }
 
     /**


### PR DESCRIPTION
Also rename the getters to match the new property names.

Part of #756