### PR TITLE
[CLEANUP] Avoid Hungarian notation in `OutputFormat` (part 8)

### DIFF
--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -149,14 +149,14 @@ class OutputFormat
      *
      * @var string
      */
-    private $sIndentation = "\t";
+    private $indentation = "\t";
 
     /**
      * Output exceptions.
      *
      * @var bool
      */
-    private $bIgnoreExceptions = false;
+    private $shouldIgnoreExceptions = false;
 
     /**
      * Render comments for lists and RuleSets
@@ -609,7 +609,7 @@ class OutputFormat
      */
     public function getIndentation(): string
     {
-        return $this->sIndentation;
+        return $this->indentation;
     }
 
     /**
@@ -617,7 +617,7 @@ class OutputFormat
      */
     public function setIndentation(string $indentation): self
     {
-        $this->sIndentation = $indentation;
+        $this->indentation = $indentation;
 
         return $this;
     }
@@ -625,9 +625,9 @@ class OutputFormat
     /**
      * @internal
      */
-    public function getIgnoreExceptions(): bool
+    public function shouldIgnoreExceptions(): bool
     {
-        return $this->bIgnoreExceptions;
+        return $this->shouldIgnoreExceptions;
     }
 
     /**
@@ -635,7 +635,7 @@ class OutputFormat
      */
     public function setIgnoreExceptions(bool $ignoreExceptions): self
     {
-        $this->bIgnoreExceptions = $ignoreExceptions;
+        $this->shouldIgnoreExceptions = $ignoreExceptions;
 
         return $this;
     }
@@ -697,7 +697,7 @@ class OutputFormat
 
     public function beLenient(): void
     {
-        $this->bIgnoreExceptions = true;
+        $this->shouldIgnoreExceptions = true;
     }
 
     /**

--- a/src/OutputFormatter.php
+++ b/src/OutputFormatter.php
@@ -148,7 +148,7 @@ class OutputFormatter
      */
     public function safely(callable $callable): ?string
     {
-        if ($this->outputFormat->getIgnoreExceptions()) {
+        if ($this->outputFormat->shouldIgnoreExceptions()) {
             // If output exceptions are ignored, run the code with exception guards
             try {
                 return $callable();

--- a/tests/Unit/OutputFormatTest.php
+++ b/tests/Unit/OutputFormatTest.php
@@ -660,9 +660,9 @@ final class OutputFormatTest extends TestCase
     /**
      * @test
      */
-    public function getIgnoreExceptionsInitiallyReturnsFalse(): void
+    public function shouldIgnoreExceptionsInitiallyReturnsFalse(): void
     {
-        self::assertFalse($this->subject->getIgnoreExceptions());
+        self::assertFalse($this->subject->shouldIgnoreExceptions());
     }
 
     /**
@@ -674,7 +674,7 @@ final class OutputFormatTest extends TestCase
     {
         $this->subject->setIgnoreExceptions($value);
 
-        self::assertSame($value, $this->subject->getIgnoreExceptions());
+        self::assertSame($value, $this->subject->shouldIgnoreExceptions());
     }
 
     /**
@@ -866,7 +866,7 @@ final class OutputFormatTest extends TestCase
 
         $this->subject->beLenient();
 
-        self::assertTrue($this->subject->getIgnoreExceptions());
+        self::assertTrue($this->subject->shouldIgnoreExceptions());
     }
 
     /**


### PR DESCRIPTION
Also rename the getters to match the new property names.

Part of #756