### PR TITLE
[CLEANUP] Avoid Hungarian notation in `OutputFormat` (part 9)

### DIFF
--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -163,7 +163,7 @@ class OutputFormat
      *
      * @var bool
      */
-    private $bRenderComments = false;
+    private $shouldRenderComments = false;
 
     /**
      * @var OutputFormatter|null
@@ -178,25 +178,25 @@ class OutputFormat
     /**
      * @var int
      */
-    private $iIndentationLevel = 0;
+    private $indendationLevel = 0;
 
     public function __construct() {}
 
     /**
-     * @param non-empty-string $sMethodName
+     * @param non-empty-string $methodName
      * @param array<array-key, mixed> $arguments
      *
      * @return mixed
      *
      * @throws \Exception
      */
-    public function __call(string $sMethodName, array $arguments)
+    public function __call(string $methodName, array $arguments)
     {
-        if (\method_exists(OutputFormatter::class, $sMethodName)) {
+        if (\method_exists(OutputFormatter::class, $methodName)) {
             // @deprecated since 8.8.0, will be removed in 9.0.0. Call the method on the formatter directly instead.
-            return \call_user_func_array([$this->getFormatter(), $sMethodName], $arguments);
+            return \call_user_func_array([$this->getFormatter(), $methodName], $arguments);
         } else {
-            throw new \Exception('Unknown OutputFormat method called: ' . $sMethodName);
+            throw new \Exception('Unknown OutputFormat method called: ' . $methodName);
         }
     }
 
@@ -643,9 +643,9 @@ class OutputFormat
     /**
      * @internal
      */
-    public function getRenderComments(): bool
+    public function shouldRenderComments(): bool
     {
-        return $this->bRenderComments;
+        return $this->shouldRenderComments;
     }
 
     /**
@@ -653,7 +653,7 @@ class OutputFormat
      */
     public function setRenderComments(bool $renderComments): self
     {
-        $this->bRenderComments = $renderComments;
+        $this->shouldRenderComments = $renderComments;
 
         return $this;
     }
@@ -663,7 +663,7 @@ class OutputFormat
      */
     public function getIndentationLevel(): int
     {
-        return $this->iIndentationLevel;
+        return $this->indendationLevel;
     }
 
     /**
@@ -689,7 +689,7 @@ class OutputFormat
     {
         if ($this->nextLevelFormat === null) {
             $this->nextLevelFormat = clone $this;
-            $this->nextLevelFormat->iIndentationLevel++;
+            $this->nextLevelFormat->indendationLevel++;
             $this->nextLevelFormat->outputFormatter = null;
         }
         return $this->nextLevelFormat;

--- a/src/OutputFormatter.php
+++ b/src/OutputFormatter.php
@@ -208,7 +208,7 @@ class OutputFormatter
 
     public function comments(Commentable $commentable): string
     {
-        if (!$this->outputFormat->getRenderComments()) {
+        if (!$this->outputFormat->shouldRenderComments()) {
             return '';
         }
 

--- a/tests/Unit/OutputFormatTest.php
+++ b/tests/Unit/OutputFormatTest.php
@@ -688,9 +688,9 @@ final class OutputFormatTest extends TestCase
     /**
      * @test
      */
-    public function getRenderCommentsInitiallyReturnsFalse(): void
+    public function shouldRenderCommentsInitiallyReturnsFalse(): void
     {
-        self::assertFalse($this->subject->getRenderComments());
+        self::assertFalse($this->subject->shouldRenderComments());
     }
 
     /**
@@ -702,7 +702,7 @@ final class OutputFormatTest extends TestCase
     {
         $this->subject->setRenderComments($value);
 
-        self::assertSame($value, $this->subject->getRenderComments());
+        self::assertSame($value, $this->subject->shouldRenderComments());
     }
 
     /**
@@ -1041,7 +1041,7 @@ final class OutputFormatTest extends TestCase
     {
         $newInstance = OutputFormat::createCompact();
 
-        self::assertFalse($newInstance->getRenderComments());
+        self::assertFalse($newInstance->shouldRenderComments());
     }
 
     /**
@@ -1170,6 +1170,6 @@ final class OutputFormatTest extends TestCase
     {
         $newInstance = OutputFormat::createPretty();
 
-        self::assertTrue($newInstance->getRenderComments());
+        self::assertTrue($newInstance->shouldRenderComments());
     }
 }


### PR DESCRIPTION
Also rename the getters to match the new property names.

Part of #756