### PR TITLE
[CLEANUP] Fix some type annotations in `ParserState`

### DIFF
--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -103,32 +103,8 @@ parameters:
 			path: ../src/CSSList/KeyFrame.php
 
 		-
-			message: '#^Default value of the parameter \#2 \$bIncludeEnd \(false\) of method Sabberworm\\CSS\\Parsing\\ParserState\:\:consumeUntil\(\) is incompatible with type string\.$#'
-			identifier: parameter.defaultValue
-			count: 1
-			path: ../src/Parsing/ParserState.php
-
-		-
-			message: '#^Default value of the parameter \#3 \$consumeEnd \(false\) of method Sabberworm\\CSS\\Parsing\\ParserState\:\:consumeUntil\(\) is incompatible with type string\.$#'
-			identifier: parameter.defaultValue
-			count: 1
-			path: ../src/Parsing/ParserState.php
-
-		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 1
-			path: ../src/Parsing/ParserState.php
-
-		-
-			message: '#^Only booleans are allowed in a negated boolean, string given\.$#'
-			identifier: booleanNot.exprNotBoolean
-			count: 1
-			path: ../src/Parsing/ParserState.php
-
-		-
-			message: '#^Only booleans are allowed in an if condition, string given\.$#'
-			identifier: if.condNotBoolean
 			count: 1
 			path: ../src/Parsing/ParserState.php
 

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -335,8 +335,8 @@ class ParserState
 
     /**
      * @param array<array-key, string>|string $stopCharacters
-     * @param string $bIncludeEnd
-     * @param string $consumeEnd
+     * @param bool $includeEnd
+     * @param bool $consumeEnd
      * @param array<int, Comment> $comments
      *
      * @throws UnexpectedEOFException
@@ -344,7 +344,7 @@ class ParserState
      */
     public function consumeUntil(
         $stopCharacters,
-        $bIncludeEnd = false,
+        $includeEnd = false,
         $consumeEnd = false,
         array &$comments = []
     ): string {
@@ -355,7 +355,7 @@ class ParserState
         while (!$this->isEnd()) {
             $char = $this->consume(1);
             if (\in_array($char, $stopCharacters, true)) {
-                if ($bIncludeEnd) {
+                if ($includeEnd) {
                     $out .= $char;
                 } elseif (!$consumeEnd) {
                     $this->currentPosition -= $this->strlen($char);


### PR DESCRIPTION
Also make the parameter names non-Hungarian.

Part of #756