### PR TITLE
[TASK] Drop `atRuleArgs()` from the `AtRule` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Please also have a look at our
 
 ### Removed
 
+- Drop `atRuleArgs()` from the `AtRule` interface (#1141)
 - Remove `OutputFormat::get()` and `::set()` (#1108, #1110)
 - Drop special support for vendor prefixes (#1083)
 - Remove the IE hack in `Rule` (#995)

--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -121,12 +121,6 @@ parameters:
 			path: ../src/Property/CSSNamespace.php
 
 		-
-			message: '#^Return type \(array\<int, string\>\) of method Sabberworm\\CSS\\Property\\CSSNamespace\:\:atRuleArgs\(\) should be compatible with return type \(string\|null\) of method Sabberworm\\CSS\\Property\\AtRule\:\:atRuleArgs\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: ../src/Property/CSSNamespace.php
-
-		-
 			message: '#^Call to an undefined method Sabberworm\\CSS\\OutputFormat\:\:comments\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -147,12 +141,6 @@ parameters:
 		-
 			message: '#^Only booleans are allowed in an if condition, string given\.$#'
 			identifier: if.condNotBoolean
-			count: 1
-			path: ../src/Property/Import.php
-
-		-
-			message: '#^Return type \(array\<int, Sabberworm\\CSS\\Value\\URL\|string\>\) of method Sabberworm\\CSS\\Property\\Import\:\:atRuleArgs\(\) should be compatible with return type \(string\|null\) of method Sabberworm\\CSS\\Property\\AtRule\:\:atRuleArgs\(\)$#'
-			identifier: method.childReturnType
 			count: 1
 			path: ../src/Property/Import.php
 

--- a/src/Property/AtRule.php
+++ b/src/Property/AtRule.php
@@ -23,9 +23,4 @@ interface AtRule extends Renderable, Commentable
      * @return string|null
      */
     public function atRuleName();
-
-    /**
-     * @return string|null
-     */
-    public function atRuleArgs();
 }


### PR DESCRIPTION
The classes implementing this interface use a wide variaty of inconsistent return types when they implement this method.

This is a hard blocker for introducing native return type declaration for this method.