### PR TITLE
[TASK] Initialize `KeyFrame` properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please also have a look at our
 
 ### Changed
 
+- Initialize `KeyFrame` properties to sensible defaults (#1146)
 - Make `OutputFormat` `final` (#1128)
 - Mark the `OutputFormat` constructor as `@internal` (#1131) 
 - Mark `OutputFormatter` as `@internal` (#896)

--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -97,12 +97,6 @@ parameters:
 			path: ../src/CSSList/KeyFrame.php
 
 		-
-			message: '#^Parameters should have "string" types as the only types passed to this method$#'
-			identifier: typePerfect.narrowPublicClassMethodParamType
-			count: 2
-			path: ../src/CSSList/KeyFrame.php
-
-		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
 			count: 1

--- a/src/CSSList/KeyFrame.php
+++ b/src/CSSList/KeyFrame.php
@@ -10,43 +10,43 @@ use Sabberworm\CSS\Property\AtRule;
 class KeyFrame extends CSSList implements AtRule
 {
     /**
-     * @var string|null
+     * @var non-empty-string
      */
-    private $vendorKeyFrame;
+    private $vendorKeyFrame = 'keyframes';
 
     /**
-     * @var string|null
+     * @var non-empty-string
      */
-    private $animationName;
+    private $animationName = 'none';
 
     /**
-     * @param string $vendorKeyFrame
+     * @param non-empty-string $vendorKeyFrame
      */
-    public function setVendorKeyFrame($vendorKeyFrame): void
+    public function setVendorKeyFrame(string $vendorKeyFrame): void
     {
         $this->vendorKeyFrame = $vendorKeyFrame;
     }
 
     /**
-     * @return string|null
+     * @return non-empty-string
      */
-    public function getVendorKeyFrame()
+    public function getVendorKeyFrame(): string
     {
         return $this->vendorKeyFrame;
     }
 
     /**
-     * @param string $animationName
+     * @param non-empty-string $animationName
      */
-    public function setAnimationName($animationName): void
+    public function setAnimationName(string $animationName): void
     {
         $this->animationName = $animationName;
     }
 
     /**
-     * @return string|null
+     * @return non-empty-string
      */
-    public function getAnimationName()
+    public function getAnimationName(): string
     {
         return $this->animationName;
     }
@@ -74,17 +74,17 @@ class KeyFrame extends CSSList implements AtRule
     }
 
     /**
-     * @return string|null
+     * @return non-empty-string
      */
-    public function atRuleName()
+    public function atRuleName(): string
     {
         return $this->vendorKeyFrame;
     }
 
     /**
-     * @return string|null
+     * @return non-empty-string
      */
-    public function atRuleArgs()
+    public function atRuleArgs(): string
     {
         return $this->animationName;
     }

--- a/tests/Unit/CSSList/KeyFrameTest.php
+++ b/tests/Unit/CSSList/KeyFrameTest.php
@@ -68,4 +68,24 @@ final class KeyFrameTest extends TestCase
 
         self::assertSame($lineNumber, $subject->getLineNo());
     }
+
+    /**
+     * @test
+     */
+    public function getAnimationNameByDefaultReturnsNone(): void
+    {
+        $subject = new KeyFrame();
+
+        self::assertSame('none', $subject->getAnimationName());
+    }
+
+    /**
+     * @test
+     */
+    public function getVendorKeyFrameByDefaultReturnsKeyframes(): void
+    {
+        $subject = new KeyFrame();
+
+        self::assertSame('keyframes', $subject->getVendorKeyFrame());
+    }
 }


### PR DESCRIPTION
They fortunately have obvious default values.
This change means it can be enforced that they are always non-empty strings. Type declarations have been updated to reflect that.