### PR TITLE
[CLEANUP] Avoid magic method forwarding in `Charset`

### DIFF
--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -67,12 +67,6 @@ parameters:
 			path: ../src/Property/CSSNamespace.php
 
 		-
-			message: '#^Call to an undefined method Sabberworm\\CSS\\OutputFormat\:\:comments\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: ../src/Property/Charset.php
-
-		-
 			message: '#^Method Sabberworm\\CSS\\Property\\Charset\:\:atRuleArgs\(\) should return string but returns Sabberworm\\CSS\\Value\\CSSString\.$#'
 			identifier: return.type
 			count: 1

--- a/src/Property/Charset.php
+++ b/src/Property/Charset.php
@@ -81,7 +81,7 @@ class Charset implements AtRule
 
     public function render(OutputFormat $outputFormat): string
     {
-        return "{$outputFormat->comments($this)}@charset {$this->charset->render($outputFormat)};";
+        return "{$outputFormat->getFormatter()->comments($this)}@charset {$this->charset->render($outputFormat)};";
     }
 
     /**


### PR DESCRIPTION
Part of #1147