### PR TITLE
[BUGFIX] Include comments for all rules in declaration block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Please also have a look at our
 
 ### Fixed
 
+- Include comments for all rules in declaration block (#1169)
 - Render rules in line and column number order (#1059)
 - Don't render `rgb` colors with percentage values using hex notation (#803)
 - Parse `@font-face` `src` property as comma-delimited list (#790)

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -68,14 +68,16 @@ class Rule implements Renderable, Commentable
     }
 
     /**
+     * @param list<Comment> $commentsBeforeRule
+     *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      *
      * @internal since V8.8.0
      */
-    public static function parse(ParserState $parserState): Rule
+    public static function parse(ParserState $parserState, array $commentsBeforeRule = []): Rule
     {
-        $comments = $parserState->consumeWhiteSpace();
+        $comments = \array_merge($commentsBeforeRule, $parserState->consumeWhiteSpace());
         $rule = new Rule(
             $parserState->parseIdentifier(!$parserState->comes('--')),
             $parserState->currentLine(),
@@ -97,8 +99,6 @@ class Rule implements Renderable, Commentable
         while ($parserState->comes(';')) {
             $parserState->consume(';');
         }
-
-        $parserState->consumeWhiteSpace();
 
         return $rule;
     }

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -65,11 +65,15 @@ abstract class RuleSet implements Renderable, Commentable
         while ($parserState->comes(';')) {
             $parserState->consume(';');
         }
-        while (!$parserState->comes('}')) {
+        for (;;) {
+            $commentsBeforeRule = $parserState->consumeWhiteSpace();
+            if ($parserState->comes('}')) {
+                break;
+            }
             $rule = null;
             if ($parserState->getSettings()->usesLenientParsing()) {
                 try {
-                    $rule = Rule::parse($parserState);
+                    $rule = Rule::parse($parserState, $commentsBeforeRule);
                 } catch (UnexpectedTokenException $e) {
                     try {
                         $consumedText = $parserState->consumeUntil(["\n", ';', '}'], true);
@@ -87,7 +91,7 @@ abstract class RuleSet implements Renderable, Commentable
                     }
                 }
             } else {
-                $rule = Rule::parse($parserState);
+                $rule = Rule::parse($parserState, $commentsBeforeRule);
             }
             if ($rule instanceof Rule) {
                 $ruleSet->addRule($rule);

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -65,7 +65,7 @@ abstract class RuleSet implements Renderable, Commentable
         while ($parserState->comes(';')) {
             $parserState->consume(';');
         }
-        for (;;) {
+        while (true) {
             $commentsBeforeRule = $parserState->consumeWhiteSpace();
             if ($parserState->comes('}')) {
                 break;

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1103,8 +1103,6 @@ body {background-color: red;}';
      */
     public function flatCommentExtractingTwoComments(): void
     {
-        self::markTestSkipped('This is currently broken.');
-
         $parser = new Parser('div {/*Find Me!*/left:10px; /*Find Me Too!*/text-align:left;}');
         $document = $parser->parse();
         $contents = $document->getContents();

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1091,9 +1091,11 @@ body {background-color: red;}';
     {
         $parser = new Parser('div {/*Find Me!*/left:10px; text-align:left;}');
         $document = $parser->parse();
+
         $contents = $document->getContents();
         $divRules = $contents[0]->getRules();
         $comments = $divRules[0]->getComments();
+
         self::assertCount(1, $comments);
         self::assertSame('Find Me!', $comments[0]->getComment());
     }
@@ -1101,14 +1103,50 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function flatCommentExtractingTwoComments(): void
+    public function flatCommentExtractingTwoConjoinedCommentsForOneRule(): void
+    {
+        $parser = new Parser('div {/*Find Me!*//*Find Me Too!*/left:10px; text-align:left;}');
+        $document = $parser->parse();
+
+        $contents = $document->getContents();
+        $divRules = $contents[0]->getRules();
+        $comments = $divRules[0]->getComments();
+
+        self::assertCount(2, $comments);
+        self::assertSame('Find Me!', $comments[0]->getComment());
+        self::assertSame('Find Me Too!', $comments[1]->getComment());
+    }
+
+    /**
+     * @test
+     */
+    public function flatCommentExtractingTwoSpaceSeparatedCommentsForOneRule(): void
+    {
+        $parser = new Parser('div { /*Find Me!*/ /*Find Me Too!*/ left:10px; text-align:left;}');
+        $document = $parser->parse();
+
+        $contents = $document->getContents();
+        $divRules = $contents[0]->getRules();
+        $comments = $divRules[0]->getComments();
+
+        self::assertCount(2, $comments);
+        self::assertSame('Find Me!', $comments[0]->getComment());
+        self::assertSame('Find Me Too!', $comments[1]->getComment());
+    }
+
+    /**
+     * @test
+     */
+    public function flatCommentExtractingCommentsForTwoRules(): void
     {
         $parser = new Parser('div {/*Find Me!*/left:10px; /*Find Me Too!*/text-align:left;}');
         $document = $parser->parse();
+
         $contents = $document->getContents();
         $divRules = $contents[0]->getRules();
         $rule1Comments = $divRules[0]->getComments();
         $rule2Comments = $divRules[1]->getComments();
+
         self::assertCount(1, $rule1Comments);
         self::assertCount(1, $rule2Comments);
         self::assertSame('Find Me!', $rule1Comments[0]->getComment());


### PR DESCRIPTION
- `Rule::parse()` will no longer consume anything after the semicolon terminating the rule - it does not belong to that rule;
- The whitespace and comments before a rule will be processed by `RuleSet::parseRuleSet()` and passed as a parameter to `Rule::parse()` -
  - This is only required while 'strict mode' parsing is an option, to avoid having an exception thrown during normal operation (i.e. when `Rule::parse()` encounters normal `}` as opposed to some other junk, which is not distinguished).

Fixes #173.
See also #672, #741.