### PR TITLE
[BUGFIX] Include comments for all rules in declaration block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Include comments for all rules in declaration block (#1169)
 - Render rules in line and column number order (#1059)
 - Create `Size` with correct types in `expandBackgroundShorthand` (#814)
 - Parse `@font-face` `src` property as comma-delimited list (#794)

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -75,6 +75,8 @@ class Rule implements Renderable, Commentable
     }
 
     /**
+     * @param array<int, Comment> $commentsBeforeRule
+     *
      * @return Rule
      *
      * @throws UnexpectedEOFException
@@ -82,9 +84,9 @@ class Rule implements Renderable, Commentable
      *
      * @internal since V8.8.0
      */
-    public static function parse(ParserState $oParserState)
+    public static function parse(ParserState $oParserState, $commentsBeforeRule = [])
     {
-        $aComments = $oParserState->consumeWhiteSpace();
+        $aComments = \array_merge($commentsBeforeRule, $oParserState->consumeWhiteSpace());
         $oRule = new Rule(
             $oParserState->parseIdentifier(!$oParserState->comes("--")),
             $oParserState->currentLine(),
@@ -113,8 +115,6 @@ class Rule implements Renderable, Commentable
         while ($oParserState->comes(';')) {
             $oParserState->consume(';');
         }
-
-        $oParserState->consumeWhiteSpace();
 
         return $oRule;
     }

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -67,11 +67,15 @@ abstract class RuleSet implements Renderable, Commentable
         while ($oParserState->comes(';')) {
             $oParserState->consume(';');
         }
-        while (!$oParserState->comes('}')) {
+        while (true) {
+            $commentsBeforeRule = $oParserState->consumeWhiteSpace();
+            if ($oParserState->comes('}')) {
+                break;
+            }
             $oRule = null;
             if ($oParserState->getSettings()->bLenientParsing) {
                 try {
-                    $oRule = Rule::parse($oParserState);
+                    $oRule = Rule::parse($oParserState, $commentsBeforeRule);
                 } catch (UnexpectedTokenException $e) {
                     try {
                         $sConsume = $oParserState->consumeUntil(["\n", ";", '}'], true);
@@ -89,7 +93,7 @@ abstract class RuleSet implements Renderable, Commentable
                     }
                 }
             } else {
-                $oRule = Rule::parse($oParserState);
+                $oRule = Rule::parse($oParserState, $commentsBeforeRule);
             }
             if ($oRule) {
                 $oRuleSet->addRule($oRule);

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1167,9 +1167,11 @@ body {background-color: red;}';
     {
         $parser = new Parser('div {/*Find Me!*/left:10px; text-align:left;}');
         $doc = $parser->parse();
+
         $contents = $doc->getContents();
         $divRules = $contents[0]->getRules();
         $comments = $divRules[0]->getComments();
+
         self::assertCount(1, $comments);
         self::assertSame("Find Me!", $comments[0]->getComment());
     }
@@ -1177,16 +1179,50 @@ body {background-color: red;}';
     /**
      * @test
      */
-    public function flatCommentExtractingTwoComments()
+    public function flatCommentExtractingTwoConjoinedCommentsForOneRule()
     {
-        self::markTestSkipped('This is currently broken.');
+        $parser = new Parser('div {/*Find Me!*//*Find Me Too!*/left:10px; text-align:left;}');
+        $document = $parser->parse();
 
+        $contents = $document->getContents();
+        $divRules = $contents[0]->getRules();
+        $comments = $divRules[0]->getComments();
+
+        self::assertCount(2, $comments);
+        self::assertSame('Find Me!', $comments[0]->getComment());
+        self::assertSame('Find Me Too!', $comments[1]->getComment());
+    }
+
+    /**
+     * @test
+     */
+    public function flatCommentExtractingTwoSpaceSeparatedCommentsForOneRule()
+    {
+        $parser = new Parser('div { /*Find Me!*/ /*Find Me Too!*/ left:10px; text-align:left;}');
+        $document = $parser->parse();
+
+        $contents = $document->getContents();
+        $divRules = $contents[0]->getRules();
+        $comments = $divRules[0]->getComments();
+
+        self::assertCount(2, $comments);
+        self::assertSame('Find Me!', $comments[0]->getComment());
+        self::assertSame('Find Me Too!', $comments[1]->getComment());
+    }
+
+    /**
+     * @test
+     */
+    public function flatCommentExtractingCommentsForTwoRules()
+    {
         $parser = new Parser('div {/*Find Me!*/left:10px; /*Find Me Too!*/text-align:left;}');
         $doc = $parser->parse();
+
         $contents = $doc->getContents();
         $divRules = $contents[0]->getRules();
         $rule1Comments = $divRules[0]->getComments();
         $rule2Comments = $divRules[1]->getComments();
+
         self::assertCount(1, $rule1Comments);
         self::assertCount(1, $rule2Comments);
         self::assertEquals('Find Me!', $rule1Comments[0]->getComment());


### PR DESCRIPTION
This is the v8.x backport of #1169.

- `Rule::parse()` will no longer consume anything after the semicolon terminating the rule - it does not belong to that rule;
- The whitespace and comments before a rule will be processed by `RuleSet::parseRuleSet()` and passed as a parameter to `Rule::parse()` -
  - This is only required while 'strict mode' parsing is an option, to avoid having an exception thrown during normal operation (i.e. when `Rule::parse()` encounters normal `}` as opposed to some other junk, which is not distinguished).

Fixes #173.
See also #663, #672, #741.