### PR TITLE
[CLEANUP] Fix type annotation of `::getSelectors()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Please also have a look at our
 - Use more native type declarations and strict mode
   (#641, #772, #774, #778, #804, #841, #873, #875, #891, #922, #923, #933, #958,
   #964, #967, #1000, #1044, #1134, #1136, #1137, #1139, #1140, #1141, #1145,
-  #1162, #1163, #1166, #1172, #1174, #1178, #1179, #1181)
+  #1162, #1163, #1166, #1172, #1174, #1178, #1179, #1181, #1184)
 - Add visibility to all class/interface constants (#469)
 
 ### Deprecated

--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -7,12 +7,6 @@ parameters:
 			path: ../src/CSSList/AtRuleBlockList.php
 
 		-
-			message: '#^Parameter &\$result by\-ref type of method Sabberworm\\CSS\\CSSList\\CSSBlockList\:\:allSelectors\(\) expects array\<int, Sabberworm\\CSS\\Property\\Selector\>, array\<int, Sabberworm\\CSS\\Property\\Selector\|string\> given\.$#'
-			identifier: parameterByRef.type
-			count: 2
-			path: ../src/CSSList/CSSBlockList.php
-
-		-
 			message: '#^Parameter &\$result by\-ref type of method Sabberworm\\CSS\\CSSList\\CSSBlockList\:\:allValues\(\) expects array\<int, Sabberworm\\CSS\\Value\\Value\>, array\<int, Sabberworm\\CSS\\CSSList\\CSSList\|Sabberworm\\CSS\\Value\\Value\> given\.$#'
 			identifier: parameterByRef.type
 			count: 1

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -25,7 +25,7 @@ use Sabberworm\CSS\Property\Selector;
 class DeclarationBlock extends RuleSet
 {
     /**
-     * @var array<int, Selector|string>
+     * @var array<Selector|string>
      */
     private $selectors = [];
 
@@ -76,7 +76,7 @@ class DeclarationBlock extends RuleSet
     }
 
     /**
-     * @param array<int, Selector|string>|string $selectors
+     * @param array<Selector|string>|string $selectors
      * @param CSSList|null $list
      *
      * @throws UnexpectedTokenException
@@ -133,9 +133,9 @@ class DeclarationBlock extends RuleSet
     }
 
     /**
-     * @return array<int, Selector|string>
+     * @return array<Selector>
      */
-    public function getSelectors()
+    public function getSelectors(): array
     {
         return $this->selectors;
     }


### PR DESCRIPTION
Also add a native type declaration.

This will need more cleanup and refactoring later on.