### PR TITLE
[TASK] Reduce and finetune the scope of `@covers` annotations

### DIFF
--- a/tests/CSSList/AtRuleBlockListTest.php
+++ b/tests/CSSList/AtRuleBlockListTest.php
@@ -10,6 +10,8 @@ use Sabberworm\CSS\Settings;
 
 /**
  * @covers \Sabberworm\CSS\CSSList\AtRuleBlockList
+ * @covers \Sabberworm\CSS\CSSList\CSSBlockList
+ * @covers \Sabberworm\CSS\CSSList\CSSList
  */
 final class AtRuleBlockListTest extends TestCase
 {

--- a/tests/Comment/CommentTest.php
+++ b/tests/Comment/CommentTest.php
@@ -9,9 +9,7 @@ use Sabberworm\CSS\OutputFormat;
 use Sabberworm\CSS\Tests\ParserTest as TestsParserTest;
 
 /**
- * @covers \Sabberworm\CSS\Comment\Comment
- * @covers \Sabberworm\CSS\OutputFormat
- * @covers \Sabberworm\CSS\OutputFormatter
+ * @coversNothing
  */
 final class CommentTest extends TestCase
 {

--- a/tests/OutputFormatTest.php
+++ b/tests/OutputFormatTest.php
@@ -11,7 +11,7 @@ use Sabberworm\CSS\Parser;
 use Sabberworm\CSS\Parsing\OutputException;
 
 /**
- * @covers \Sabberworm\CSS\OutputFormat
+ * @coversNothing
  */
 final class OutputFormatTest extends TestCase
 {

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -28,17 +28,7 @@ use Sabberworm\CSS\Value\URL;
 use Sabberworm\CSS\Value\ValueList;
 
 /**
- * @covers \Sabberworm\CSS\CSSList\Document
  * @covers \Sabberworm\CSS\Parser
- * @covers \Sabberworm\CSS\RuleSet\DeclarationBlock
- * @covers \Sabberworm\CSS\Rule\Rule
- * @covers \Sabberworm\CSS\Value\CSSString
- * @covers \Sabberworm\CSS\Value\CalcFunction
- * @covers \Sabberworm\CSS\Value\Color
- * @covers \Sabberworm\CSS\Value\LineName
- * @covers \Sabberworm\CSS\Value\Size
- * @covers \Sabberworm\CSS\Value\URL
- * @covers \Sabberworm\CSS\Value\Value
  */
 final class ParserTest extends TestCase
 {

--- a/tests/RuleSet/DeclarationBlockTest.php
+++ b/tests/RuleSet/DeclarationBlockTest.php
@@ -13,6 +13,7 @@ use Sabberworm\CSS\Value\Size;
 
 /**
  * @covers \Sabberworm\CSS\RuleSet\DeclarationBlock
+ * @covers \Sabberworm\CSS\RuleSet\RuleSet
  */
 final class DeclarationBlockTest extends TestCase
 {

--- a/tests/RuleSet/LenientParsingTest.php
+++ b/tests/RuleSet/LenientParsingTest.php
@@ -11,16 +11,7 @@ use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 use Sabberworm\CSS\Settings;
 
 /**
- * @covers \Sabberworm\CSS\CSSList\Document
- * @covers \Sabberworm\CSS\Parser
- * @covers \Sabberworm\CSS\RuleSet\DeclarationBlock
- * @covers \Sabberworm\CSS\Rule\Rule
- * @covers \Sabberworm\CSS\Value\CSSString
- * @covers \Sabberworm\CSS\Value\CalcFunction
- * @covers \Sabberworm\CSS\Value\Color
- * @covers \Sabberworm\CSS\Value\LineName
- * @covers \Sabberworm\CSS\Value\Size
- * @covers \Sabberworm\CSS\Value\URL
+ * @coversNothing
  */
 final class LenientParsingTest extends TestCase
 {


### PR DESCRIPTION
The legacy tests are not very focused. Until we have split them up, try to avoid false positives for code coverage.

Also add `@covers` annotations for the parent classes of the tested classes.