### PR TITLE
[TASK] Deprecate `::atRuleArgs()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
+- Deprecate `::atRuleArgs()` (#1191)
 - Support for PHP < 7.2 is deprecated; version 9.0 will require PHP 7.2 or later
   (#1264)
 - Passing a `string` or `null` to `RuleSet::removeRule()` is deprecated

--- a/src/CSSList/AtRuleBlockList.php
+++ b/src/CSSList/AtRuleBlockList.php
@@ -42,6 +42,8 @@ class AtRuleBlockList extends CSSBlockList implements AtRule
 
     /**
      * @return string
+     *
+     * @deprecated since V8.9.0, will be removed in version 9.0.0. Use the specific getter instead.
      */
     public function atRuleArgs()
     {

--- a/src/CSSList/KeyFrame.php
+++ b/src/CSSList/KeyFrame.php
@@ -101,6 +101,8 @@ class KeyFrame extends CSSList implements AtRule
 
     /**
      * @return string|null
+     *
+     * @deprecated since V8.9.0, will be removed in version 9.0.0. Use the specific getter instead.
      */
     public function atRuleArgs()
     {

--- a/src/Property/AtRule.php
+++ b/src/Property/AtRule.php
@@ -33,6 +33,8 @@ interface AtRule extends Renderable, Commentable
 
     /**
      * @return string|null
+     *
+     * @deprecated since V8.9.0, will be removed in version 9.0.0. Use the specific getter(s) instead.
      */
     public function atRuleArgs();
 }

--- a/src/Property/CSSNamespace.php
+++ b/src/Property/CSSNamespace.php
@@ -116,6 +116,8 @@ class CSSNamespace implements AtRule, Positionable
 
     /**
      * @return array<int, string>
+     *
+     * @deprecated since V8.9.0, will be removed in version 9.0.0. Use the specific getters instead.
      */
     public function atRuleArgs()
     {

--- a/src/Property/Charset.php
+++ b/src/Property/Charset.php
@@ -99,6 +99,8 @@ class Charset implements AtRule, Positionable
 
     /**
      * @return string
+     *
+     * @deprecated since V8.9.0, will be removed in version 9.0.0. Use the specific getter instead.
      */
     public function atRuleArgs()
     {

--- a/src/Property/Import.php
+++ b/src/Property/Import.php
@@ -94,6 +94,8 @@ class Import implements AtRule, Positionable
 
     /**
      * @return array<int, URL|string>
+     *
+     * @deprecated since V8.9.0, will be removed in version 9.0.0. Use the specific getters instead.
      */
     public function atRuleArgs()
     {

--- a/src/RuleSet/AtRuleSet.php
+++ b/src/RuleSet/AtRuleSet.php
@@ -45,6 +45,8 @@ class AtRuleSet extends RuleSet implements AtRule
 
     /**
      * @return string
+     *
+     * @deprecated since V8.9.0, will be removed in version 9.0.0. Use the specific getter instead.
      */
     public function atRuleArgs()
     {


### PR DESCRIPTION
These methods

- are not used internally
- are redundant to the existing getters
- have wildly different return types across classes, which reduces the usefulness of the general method