### PR TITLE
[CLEANUP] Return `null` from `DeclarationBlock::parse()` on failure

### DIFF
--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -49,12 +49,6 @@ parameters:
 			path: ../src/RuleSet/DeclarationBlock.php
 
 		-
-			message: '#^Returning false in non return bool class method\. Use null with type\|null instead or add bool return type$#'
-			identifier: typePerfect.nullOverFalse
-			count: 1
-			path: ../src/RuleSet/DeclarationBlock.php
-
-		-
 			message: '#^Only booleans are allowed in a negated boolean, string\|null given\.$#'
 			identifier: booleanNot.exprNotBoolean
 			count: 2

--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -106,6 +106,9 @@ abstract class CSSList implements Renderable, Commentable
 
     /**
      * @return AtRuleBlockList|KeyFrame|Charset|CSSNamespace|Import|AtRuleSet|DeclarationBlock|false|null
+     *         If `null` is returned, it means the end of the list has been reached.
+     *         If `false` is returned, it means an invalid item has been encountered,
+     *         but parsing of the next item should proceed.
      *
      * @throws SourceException
      * @throws UnexpectedEOFException
@@ -139,7 +142,7 @@ abstract class CSSList implements Renderable, Commentable
         } elseif ($parserState->comes('}')) {
             if ($isRoot) {
                 if ($parserState->getSettings()->usesLenientParsing()) {
-                    return DeclarationBlock::parse($parserState);
+                    return DeclarationBlock::parse($parserState) ?? false;
                 } else {
                     throw new SourceException('Unopened {', $parserState->currentLine());
                 }
@@ -148,7 +151,7 @@ abstract class CSSList implements Renderable, Commentable
                 return null;
             }
         } else {
-            return DeclarationBlock::parse($parserState, $list);
+            return DeclarationBlock::parse($parserState, $list) ?? false;
         }
     }
 

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -30,14 +30,12 @@ class DeclarationBlock extends RuleSet
     private $selectors = [];
 
     /**
-     * @return DeclarationBlock|false
-     *
      * @throws UnexpectedTokenException
      * @throws UnexpectedEOFException
      *
      * @internal since V8.8.0
      */
-    public static function parse(ParserState $parserState, ?CSSList $list = null)
+    public static function parse(ParserState $parserState, ?CSSList $list = null): ?DeclarationBlock
     {
         $comments = [];
         $result = new DeclarationBlock($parserState->currentLine());
@@ -63,7 +61,7 @@ class DeclarationBlock extends RuleSet
                 if (!$parserState->comes('}')) {
                     $parserState->consumeUntil('}', false, true);
                 }
-                return false;
+                return null;
             } else {
                 throw $e;
             }

--- a/tests/Functional/RuleSet/DeclarationBlockTest.php
+++ b/tests/Functional/RuleSet/DeclarationBlockTest.php
@@ -6,15 +6,43 @@ namespace Sabberworm\CSS\Tests\Functional\RuleSet;
 
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\OutputFormat;
+use Sabberworm\CSS\Parsing\ParserState;
 use Sabberworm\CSS\Property\Selector;
 use Sabberworm\CSS\Rule\Rule;
 use Sabberworm\CSS\RuleSet\DeclarationBlock;
+use Sabberworm\CSS\Settings;
 
 /**
  * @covers \Sabberworm\CSS\RuleSet\DeclarationBlock
  */
 final class DeclarationBlockTest extends TestCase
 {
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function provideInvalidDeclarationBlock(): array
+    {
+        return [
+            'no selector' => ['{ color: red; }'],
+            'invalid selector' => ['/ { color: red; }'],
+            'no opening brace' => ['body color: red; }'],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideInvalidDeclarationBlock
+     */
+    public function parseReturnsNullForInvalidDeclarationBlock(string $invalidDeclarationBlock): void
+    {
+        $parserState = new ParserState($invalidDeclarationBlock, Settings::create());
+
+        $result = DeclarationBlock::parse($parserState);
+
+        self::assertNull($result);
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
Also add clarification of meaning of return value from `CSSList::parseListItem()`, where `null` and `false` have different meanings.

Part of #1176.