### PR TITLE
[TASK] Prevent Dependabot updating "rawr/cross-data-providers"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
         - dependency-name: "phpstan/*"
         - dependency-name: "phpunit/phpunit"
           versions: [ ">= 9.0.0" ]
+        - dependency-name: "rawr/cross-data-providers"
         - dependency-name: "rector/rector"
       versioning-strategy: "increase"
       commit-message:


### PR DESCRIPTION
Version 3.0 of this package is not compatible.