### PR TITLE
[CLEANUP] Move magic deprecation changelog entry to correct section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Mark the `OutputFormat` the constructor as `@internal` (#1131)
+- Mark the `OutputFormat` constructor as `@internal` (#1131)
 - Mark `OutputFormatter` as `@internal` (#896)
 - Mark `Selector::isValid()` as `@internal` (#1037)
 - Mark parsing-related methods of most CSS elements as `@internal` (#908)
@@ -35,6 +35,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Deprecate extending `OutputFormat` (#1131)
 - Deprecate `OutputFormat::get()` and `::set()` (#1107)
 - Deprecate support for `-webkit-calc` and `-moz-calc` (#1086)
+- Deprecate magic method forwarding from `OutputFormat` to `OutputFormatter`
+  (#894)
 - Deprecate `__toString()` (#1006)
 - Deprecate greedy calculation of selector specificity (#1018)
 - Deprecate the IE hack in `Rule` (#993, #1003)
@@ -61,8 +63,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
-- Deprecate magic method forwarding from `OutputFormat` to `OutputFormatter`
-  (#894)
 - Deprecate the expansion of shorthand properties (#719)
 - Deprecate `Parser::setCharset()` and `Parser::getCharset()` (#703)
 


### PR DESCRIPTION
Also remove superfluous 'the' in another entry.