### PR TITLE
[TASK] Migrate to `rawr/phpunit-data-provider`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,6 @@ updates:
         - dependency-name: "phpstan/*"
         - dependency-name: "phpunit/phpunit"
           versions: [ ">= 9.0.0" ]
-        - dependency-name: "rawr/cross-data-providers"
         - dependency-name: "rector/rector"
       versioning-strategy: "increase"
       commit-message:

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "phpstan/phpstan-phpunit": "1.4.2 || 2.0.4",
         "phpstan/phpstan-strict-rules": "1.6.2 || 2.0.3",
         "phpunit/phpunit": "8.5.41",
-        "rawr/cross-data-providers": "2.4.0",
+        "rawr/phpunit-data-provider": "3.3.1",
         "rector/rector": "1.2.10 || 2.0.7",
         "rector/type-perfect": "1.0.0 || 2.0.2"
     },

--- a/tests/Unit/Comment/CommentContainerTest.php
+++ b/tests/Unit/Comment/CommentContainerTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Constraint\TraversableContains;
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\Comment\Comment;
 use Sabberworm\CSS\Tests\Unit\Comment\Fixtures\ConcreteCommentContainer;
-use TRegx\DataProvider\DataProviders;
+use TRegx\PhpUnit\DataProviders\DataProvider;
 
 /**
  * @covers \Sabberworm\CSS\Comment\CommentContainer
@@ -114,19 +114,19 @@ final class CommentContainerTest extends TestCase
      * This provider crosses two comment arrays (0, 1 or 2 comments) with different comments,
      * so that all combinations can be tested.
      *
-     * @return array<non-empty-string, array{0: list<Comment>, 1: list<Comment>}>
+     * @return DataProvider<non-empty-string, array{0: list<Comment>, 1: list<Comment>}>
      */
-    public function provideTwoDistinctCommentArrays(): array
+    public function provideTwoDistinctCommentArrays(): DataProvider
     {
-        return DataProviders::cross($this->provideCommentArray(), $this->provideAlternativeCommentArray());
+        return DataProvider::cross($this->provideCommentArray(), $this->provideAlternativeCommentArray());
     }
 
     /**
-     * @return array<non-empty-string, array{0: list<Comment>, 1: non-empty-list<Comment>}>
+     * @return DataProvider<non-empty-string, array{0: list<Comment>, 1: non-empty-list<Comment>}>
      */
-    public function provideTwoDistinctCommentArraysWithSecondNonempty(): array
+    public function provideTwoDistinctCommentArraysWithSecondNonempty(): DataProvider
     {
-        return DataProviders::cross($this->provideCommentArray(), $this->provideAlternativeNonemptyCommentArray());
+        return DataProvider::cross($this->provideCommentArray(), $this->provideAlternativeNonemptyCommentArray());
     }
 
     private static function createContainsConstraint(Comment $comment): TraversableContains

--- a/tests/Unit/Position/PositionTest.php
+++ b/tests/Unit/Position/PositionTest.php
@@ -6,7 +6,7 @@ namespace Sabberworm\CSS\Tests\Unit\Position;
 
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\Tests\Unit\Position\Fixtures\ConcretePosition;
-use TRegx\DataProvider\DataProviders;
+use TRegx\PhpUnit\DataProviders\DataProvider;
 
 /**
  * @covers \Sabberworm\CSS\Position\Position
@@ -157,11 +157,11 @@ final class PositionTest extends TestCase
     }
 
     /**
-     * @return array<non-empty-string, array{0: int<1, max>, 1: int<0, max>}>
+     * @return DataProvider<non-empty-string, array{0: int<1, max>, 1: int<0, max>}>
      */
-    public function provideLineAndColumnNumber(): array
+    public function provideLineAndColumnNumber(): DataProvider
     {
-        return DataProviders::cross($this->provideLineNumber(), $this->provideColumnNumber());
+        return DataProvider::cross($this->provideLineNumber(), $this->provideColumnNumber());
     }
 
     /**


### PR DESCRIPTION
The package `rawr/cross-data-providers` that we used has been abandoned and should not be used anymore.