### PR TITLE
[TASK] Deprecate `getLineNo()` etc. in v8.9.0

### DIFF
--- a/src/Position/Positionable.php
+++ b/src/Position/Positionable.php
@@ -19,7 +19,7 @@ interface Positionable
     /**
      * @return int<0, max>
      *
-     * @deprecated in version 9.0.0, will be removed in v10.0. Use `getLineNumber()` instead.
+     * @deprecated in version 8.9.0, will be removed in v9.0. Use `getLineNumber()` instead.
      */
     public function getLineNo(): int;
 
@@ -31,13 +31,13 @@ interface Positionable
     /**
      * @return int<0, max>
      *
-     * @deprecated in version 9.0.0, will be removed in v10.0. Use `getColumnNumber()` instead.
+     * @deprecated in version 8.9.0, will be removed in v9.0. Use `getColumnNumber()` instead.
      */
     public function getColNo(): int;
 
     /**
      * @param int<0, max>|null $lineNumber
-     *        Providing zero for this parameter is deprecated in version 9.0.0, and will not be supported from v10.0.
+     *        Providing zero for this parameter is deprecated in version 8.9.0, and will not be supported from v9.0.
      *        Use `null` instead when no line number is available.
      * @param int<0, max>|null $columnNumber
      */


### PR DESCRIPTION
The deprecation and changes from #1207 can be merged to 8.x. See #1232.

So the deprecation can be brought forward.