### PR TITLE
[TASK] Add `assertInstanceOf` tests for `CSSListItem`

### DIFF
--- a/tests/Unit/CSSList/AtRuleBlockListTest.php
+++ b/tests/Unit/CSSList/AtRuleBlockListTest.php
@@ -9,6 +9,7 @@ use Sabberworm\CSS\Comment\Commentable;
 use Sabberworm\CSS\CSSList\AtRuleBlockList;
 use Sabberworm\CSS\CSSList\CSSBlockList;
 use Sabberworm\CSS\CSSList\CSSList;
+use Sabberworm\CSS\CSSList\CSSListItem;
 use Sabberworm\CSS\Property\AtRule;
 use Sabberworm\CSS\Renderable;
 
@@ -47,6 +48,16 @@ final class AtRuleBlockListTest extends TestCase
         $subject = new AtRuleBlockList('supports');
 
         self::assertInstanceOf(Commentable::class, $subject);
+    }
+
+    /**
+     * @test
+     */
+    public function implementsCSSListItem(): void
+    {
+        $subject = new AtRuleBlockList('supports');
+
+        self::assertInstanceOf(CSSListItem::class, $subject);
     }
 
     /**

--- a/tests/Unit/CSSList/CSSListTest.php
+++ b/tests/Unit/CSSList/CSSListTest.php
@@ -7,6 +7,7 @@ namespace Sabberworm\CSS\Tests\Unit\CSSList;
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\Comment\Commentable;
 use Sabberworm\CSS\CSSElement;
+use Sabberworm\CSS\CSSList\CSSListItem;
 use Sabberworm\CSS\Renderable;
 use Sabberworm\CSS\RuleSet\DeclarationBlock;
 use Sabberworm\CSS\Tests\Unit\CSSList\Fixtures\ConcreteCSSList;
@@ -44,6 +45,16 @@ final class CSSListTest extends TestCase
         $subject = new ConcreteCSSList();
 
         self::assertInstanceOf(Commentable::class, $subject);
+    }
+
+    /**
+     * @test
+     */
+    public function implementsCSSListItem(): void
+    {
+        $subject = new ConcreteCSSList();
+
+        self::assertInstanceOf(CSSListItem::class, $subject);
     }
 
     /**

--- a/tests/Unit/CSSList/KeyFrameTest.php
+++ b/tests/Unit/CSSList/KeyFrameTest.php
@@ -7,6 +7,7 @@ namespace Sabberworm\CSS\Tests\Unit\CSSList;
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\Comment\Commentable;
 use Sabberworm\CSS\CSSList\CSSList;
+use Sabberworm\CSS\CSSList\CSSListItem;
 use Sabberworm\CSS\CSSList\KeyFrame;
 use Sabberworm\CSS\Property\AtRule;
 use Sabberworm\CSS\Renderable;
@@ -45,6 +46,16 @@ final class KeyFrameTest extends TestCase
         $subject = new KeyFrame();
 
         self::assertInstanceOf(Commentable::class, $subject);
+    }
+
+    /**
+     * @test
+     */
+    public function implementsCSSListItem(): void
+    {
+        $subject = new KeyFrame();
+
+        self::assertInstanceOf(CSSListItem::class, $subject);
     }
 
     /**

--- a/tests/Unit/Property/CSSNamespaceTest.php
+++ b/tests/Unit/Property/CSSNamespaceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabberworm\CSS\Tests\Unit\Property;
+
+use PHPUnit\Framework\TestCase;
+use Sabberworm\CSS\CSSList\CSSListItem;
+use Sabberworm\CSS\Property\CSSNamespace;
+use Sabberworm\CSS\Value\CSSString;
+
+/**
+ * @covers \Sabberworm\CSS\Property\CSSNamespace
+ */
+final class CSSNamespaceTest extends TestCase
+{
+    /**
+     * @var CSSNamespace
+     */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new CSSNamespace(new CSSString('http://www.w3.org/2000/svg'));
+    }
+
+    /**
+     * @test
+     */
+    public function implementsCSSListItem(): void
+    {
+        self::assertInstanceOf(CSSListItem::class, $this->subject);
+    }
+}

--- a/tests/Unit/Property/CharsetTest.php
+++ b/tests/Unit/Property/CharsetTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabberworm\CSS\Tests\Unit\Property;
+
+use PHPUnit\Framework\TestCase;
+use Sabberworm\CSS\CSSList\CSSListItem;
+use Sabberworm\CSS\Property\Charset;
+use Sabberworm\CSS\Value\CSSString;
+
+/**
+ * @covers \Sabberworm\CSS\Property\Charset
+ */
+final class CharsetTest extends TestCase
+{
+    /**
+     * @var Charset
+     */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Charset(new CSSString('UTF-8'));
+    }
+
+    /**
+     * @test
+     */
+    public function implementsCSSListItem(): void
+    {
+        self::assertInstanceOf(CSSListItem::class, $this->subject);
+    }
+}

--- a/tests/Unit/Property/ImportTest.php
+++ b/tests/Unit/Property/ImportTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabberworm\CSS\Tests\Unit\Property;
+
+use PHPUnit\Framework\TestCase;
+use Sabberworm\CSS\CSSList\CSSListItem;
+use Sabberworm\CSS\Property\Import;
+use Sabberworm\CSS\Value\CSSString;
+use Sabberworm\CSS\Value\URL;
+
+/**
+ * @covers \Sabberworm\CSS\Property\Import
+ */
+final class ImportTest extends TestCase
+{
+    /**
+     * @var Import
+     */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Import(new URL(new CSSString('https://example.org/')), null);
+    }
+
+    /**
+     * @test
+     */
+    public function implementsCSSListItem(): void
+    {
+        self::assertInstanceOf(CSSListItem::class, $this->subject);
+    }
+}

--- a/tests/Unit/RuleSet/AtRuleSetTest.php
+++ b/tests/Unit/RuleSet/AtRuleSetTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabberworm\CSS\Tests\Unit\RuleSet;
+
+use PHPUnit\Framework\TestCase;
+use Sabberworm\CSS\CSSList\CSSListItem;
+use Sabberworm\CSS\RuleSet\AtRuleSet;
+
+/**
+ * @covers \Sabberworm\CSS\RuleSet\AtRuleSet
+ */
+final class AtRuleSetTest extends TestCase
+{
+    /**
+     * @var AtRuleSet
+     */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new AtRuleSet('supports');
+    }
+
+    /**
+     * @test
+     */
+    public function implementsCSSListItem(): void
+    {
+        self::assertInstanceOf(CSSListItem::class, $this->subject);
+    }
+}

--- a/tests/Unit/RuleSet/DeclarationBlockTest.php
+++ b/tests/Unit/RuleSet/DeclarationBlockTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabberworm\CSS\Tests\Unit\RuleSet;
+
+use PHPUnit\Framework\TestCase;
+use Sabberworm\CSS\CSSList\CSSListItem;
+use Sabberworm\CSS\RuleSet\DeclarationBlock;
+
+/**
+ * @covers \Sabberworm\CSS\RuleSet\DeclarationBlock
+ */
+final class DeclarationBlockTest extends TestCase
+{
+    /**
+     * @var DeclarationBlock
+     */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new DeclarationBlock();
+    }
+
+    /**
+     * @test
+     */
+    public function implementsCSSListItem(): void
+    {
+        self::assertInstanceOf(CSSListItem::class, $this->subject);
+    }
+}

--- a/tests/Unit/RuleSet/RuleSetTest.php
+++ b/tests/Unit/RuleSet/RuleSetTest.php
@@ -6,6 +6,7 @@ namespace Sabberworm\CSS\Tests\Unit\RuleSet;
 
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\CSSElement;
+use Sabberworm\CSS\CSSList\CSSListItem;
 use Sabberworm\CSS\Tests\Unit\RuleSet\Fixtures\ConcreteRuleSet;
 
 /**
@@ -14,12 +15,28 @@ use Sabberworm\CSS\Tests\Unit\RuleSet\Fixtures\ConcreteRuleSet;
 final class RuleSetTest extends TestCase
 {
     /**
+     * @var ConcreteRuleSet
+     */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new ConcreteRuleSet();
+    }
+
+    /**
      * @test
      */
     public function implementsCSSElement(): void
     {
-        $subject = new ConcreteRuleSet();
+        self::assertInstanceOf(CSSElement::class, $this->subject);
+    }
 
-        self::assertInstanceOf(CSSElement::class, $subject);
+    /**
+     * @test
+     */
+    public function implementsCSSListItem(): void
+    {
+        self::assertInstanceOf(CSSListItem::class, $this->subject);
     }
 }


### PR DESCRIPTION
These should probably have been added as part of #1212. They confirm that the various types supplanted by `CSSListItem` in the API all implement the new interface.

Resolves #1236.