### PR TITLE
[TASK] Remove original `getAllValues()` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ Please also have a look at our
 
 ### Removed
 
+- Passing a string as the first argument to `getAllValues()` is no longer
+  supported and will not work;
+  the search pattern should now be passed as the second argument (#1243)
+- Passing a Boolean as the second argument to `getAllValues()` is no longer
+  supported and will not work; the flag for searching in function arguments
+  should now be passed as the third argument (#1243)
 - Remove `__toString()` (#1046)
 - Drop magic method forwarding in `OutputFormat` (#898)
 - Drop `atRuleArgs()` from the `AtRule` interface (#1141)

--- a/src/CSSList/CSSBlockList.php
+++ b/src/CSSList/CSSBlockList.php
@@ -64,46 +64,26 @@ abstract class CSSBlockList extends CSSList
     /**
      * Returns all `Value` objects found recursively in `Rule`s in the tree.
      *
-     * @param CSSElement|string|null $element
+     * @param CSSElement|null $element
      *        This is the `CSSList` or `RuleSet` to start the search from (defaults to the whole document).
-     *        If a string is given, it is used as a rule name filter.
-     *        Passing a string for this parameter is deprecated in version 8.9.0, and will not work from v9.0;
-     *        use the following parameter to pass a rule name filter instead.
-     * @param string|bool|null $ruleSearchPatternOrSearchInFunctionArguments
+     * @param string|null $ruleSearchPattern
      *        This allows filtering rules by property name
      *        (e.g. if "color" is passed, only `Value`s from `color` properties will be returned,
      *        or if "font-" is provided, `Value`s from all font rules, like `font-size`, and including `font` itself,
      *        will be returned).
-     *        If a Boolean is provided, it is treated as the `$searchInFunctionArguments` argument.
-     *        Passing a Boolean for this parameter is deprecated in version 8.9.0, and will not work from v9.0;
-     *        use the `$searchInFunctionArguments` parameter instead.
-     * @param bool $searchInFunctionArguments whether to also return Value objects used as Function arguments.
+     * @param bool $searchInFunctionArguments whether to also return `Value` objects used as `CSSFunction` arguments.
      *
      * @return array<int, Value>
      *
      * @see RuleSet->getRules()
      */
     public function getAllValues(
-        $element = null,
-        $ruleSearchPatternOrSearchInFunctionArguments = null,
+        ?CSSElement $element = null,
+        ?string $ruleSearchPattern = null,
         bool $searchInFunctionArguments = false
     ): array {
-        if (\is_bool($ruleSearchPatternOrSearchInFunctionArguments)) {
-            $searchInFunctionArguments = $ruleSearchPatternOrSearchInFunctionArguments;
-            $searchString = null;
-        } else {
-            $searchString = $ruleSearchPatternOrSearchInFunctionArguments;
-        }
-
-        if ($element === null) {
-            $element = $this;
-        } elseif (\is_string($element)) {
-            $searchString = $element;
-            $element = $this;
-        }
-
         $result = [];
-        $this->allValues($element, $result, $searchString, $searchInFunctionArguments);
+        $this->allValues($element ?? $this, $result, $ruleSearchPattern, $searchInFunctionArguments);
         return $result;
     }
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -153,7 +153,7 @@ final class ParserTest extends TestCase
                 self::assertEmpty($colorRules);
             }
         }
-        foreach ($document->getAllValues('color') as $colorValue) {
+        foreach ($document->getAllValues(null, 'color') as $colorValue) {
             self::assertSame('red', $colorValue);
         }
         self::assertSame(
@@ -455,7 +455,7 @@ body {color: green;}',
             . '.collapser.expanded + * {height: auto;}';
         self::assertSame($expected, $document->render());
 
-        foreach ($document->getAllValues(null, true) as $value) {
+        foreach ($document->getAllValues(null, null, true) as $value) {
             if ($value instanceof Size && $value->isSize()) {
                 $value->setSize($value->getSize() * 3);
             }
@@ -463,7 +463,7 @@ body {color: green;}',
         $expected = \str_replace(['1.2em', '.2em', '60%'], ['3.6em', '.6em', '180%'], $expected);
         self::assertSame($expected, $document->render());
 
-        foreach ($document->getAllValues(null, true) as $value) {
+        foreach ($document->getAllValues(null, null, true) as $value) {
             if ($value instanceof Size && !$value->isRelative() && !$value->isColorComponent()) {
                 $value->setSize($value->getSize() * 2);
             }

--- a/tests/Unit/CSSList/CSSBlockListTest.php
+++ b/tests/Unit/CSSList/CSSBlockListTest.php
@@ -425,30 +425,6 @@ final class CSSBlockListTest extends TestCase
         $declarationBlock->addRule($rule2);
         $subject->setContents([$declarationBlock]);
 
-        $result = $subject->getAllValues('font-');
-
-        self::assertSame([$value1], $result);
-    }
-
-    /**
-     * @test
-     */
-    public function getAllValuesWithSearchStringProvidedInNewMethodSignatureReturnsOnlyValuesFromMatchingRules(): void
-    {
-        $subject = new ConcreteCSSBlockList();
-
-        $value1 = new CSSString('Superfont');
-        $value2 = new CSSString('aquamarine');
-
-        $declarationBlock = new DeclarationBlock();
-        $rule1 = new Rule('font-family');
-        $rule1->setValue($value1);
-        $declarationBlock->addRule($rule1);
-        $rule2 = new Rule('color');
-        $rule2->setValue($value2);
-        $declarationBlock->addRule($rule2);
-        $subject->setContents([$declarationBlock]);
-
         $result = $subject->getAllValues(null, 'font-');
 
         self::assertSame([$value1], $result);
@@ -479,27 +455,6 @@ final class CSSBlockListTest extends TestCase
      * @test
      */
     public function getAllValuesWithSearchInFunctionArgumentsReturnsValuesInFunctionArguments(): void
-    {
-        $subject = new ConcreteCSSBlockList();
-
-        $value1 = new Size(10, 'px');
-        $value2 = new Size(2, '%');
-
-        $declarationBlock = new DeclarationBlock();
-        $rule = new Rule('margin');
-        $rule->setValue(new CSSFunction('max', [$value1, $value2]));
-        $declarationBlock->addRule($rule);
-        $subject->setContents([$declarationBlock]);
-
-        $result = $subject->getAllValues(null, true);
-
-        self::assertSame([$value1, $value2], $result);
-    }
-
-    /**
-     * @test
-     */
-    public function getAllValuesWithSearchInFunctionArgumentsInNewMethodSignatureReturnsValuesInFunctionArguments(): void
     {
         $subject = new ConcreteCSSBlockList();
 


### PR DESCRIPTION
The method still exists with the same (slightly improved) functionality, but the optional arguments have been refactored, and may require changes.

Part of #994.  Closes #1230.