### PR TITLE
[CLEANUP] `allSelectors()` -> `getAllSelectors()`

### DIFF
--- a/src/CSSList/CSSBlockList.php
+++ b/src/CSSList/CSSBlockList.php
@@ -131,10 +131,12 @@ abstract class CSSBlockList extends CSSList
     }
 
     /**
-     * @param list<Selector> $result
+     * @return list<Selector>
      */
-    protected function allSelectors(array &$result, ?string $specificitySearch = null): void
+    protected function getAllSelectors(?string $specificitySearch = null): array
     {
+        $result = [];
+
         foreach ($this->getAllDeclarationBlocks() as $declarationBlock) {
             foreach ($declarationBlock->getSelectors() as $selector) {
                 if ($specificitySearch === null) {
@@ -173,5 +175,7 @@ abstract class CSSBlockList extends CSSList
                 }
             }
         }
+
+        return $result;
     }
 }

--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -38,15 +38,13 @@ class Document extends CSSBlockList
      *        An optional filter by specificity.
      *        May contain a comparison operator and a number or just a number (defaults to "==").
      *
-     * @return array<int, Selector>
+     * @return list<Selector>
+     *
      * @example `getSelectorsBySpecificity('>= 100')`
      */
     public function getSelectorsBySpecificity(?string $specificitySearch = null): array
     {
-        /** @var array<int, Selector> $result */
-        $result = [];
-        $this->allSelectors($result, $specificitySearch);
-        return $result;
+        return $this->getAllSelectors($specificitySearch);
     }
 
     /**


### PR DESCRIPTION
The renamed (internal) method now returns the result, instead of having a reference parameter for it.

Closes #994.