### PR TITLE
[CLEANUP] Avoid negated non-Boolean in `RuleSet`

### DIFF
--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -55,12 +55,6 @@ parameters:
 			path: ../src/RuleSet/DeclarationBlock.php
 
 		-
-			message: '#^Only booleans are allowed in a negated boolean, string\|null given\.$#'
-			identifier: booleanNot.exprNotBoolean
-			count: 2
-			path: ../src/RuleSet/RuleSet.php
-
-		-
 			message: '#^Parameters should have "string" types as the only types passed to this method$#'
 			identifier: typePerfect.narrowPublicClassMethodParamType
 			count: 1

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -149,7 +149,7 @@ abstract class RuleSet implements CSSElement, CSSListItem, Positionable
             // Either no search rule is given or the search rule matches the found rule exactly
             // or the search rule ends in “-” and the found rule starts with the search rule.
             if (
-                !$searchPattern || $propertyName === $searchPattern
+                $searchPattern === null || $propertyName === $searchPattern
                 || (
                     \strrpos($searchPattern, '-') === \strlen($searchPattern) - \strlen('-')
                     && (\strpos($propertyName, $searchPattern) === 0
@@ -240,7 +240,7 @@ abstract class RuleSet implements CSSElement, CSSListItem, Positionable
                 // or the search rule ends in “-” and the found rule starts with the search rule or equals it
                 // (without the trailing dash).
                 if (
-                    !$searchPattern || $propertyName === $searchPattern
+                    $searchPattern === null || $propertyName === $searchPattern
                     || (\strrpos($searchPattern, '-') === \strlen($searchPattern) - \strlen('-')
                         && (\strpos($propertyName, $searchPattern) === 0
                             || $propertyName === \substr($searchPattern, 0, -1)))


### PR DESCRIPTION
Use `=== null` instead to be more precise.