### PR TITLE
[CLEANUP] Use `RuleSet::removeMatchingRules()` in tests

### DIFF
--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -55,12 +55,6 @@ parameters:
 			path: ../src/RuleSet/DeclarationBlock.php
 
 		-
-			message: '#^Parameters should have "string" types as the only types passed to this method$#'
-			identifier: typePerfect.narrowPublicClassMethodParamType
-			count: 1
-			path: ../src/RuleSet/RuleSet.php
-
-		-
 			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
 			identifier: notEqual.notAllowed
 			count: 3

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -348,7 +348,7 @@ body {color: green;font: 75% "Lucida Grande","Trebuchet MS",Verdana,sans-serif;}
             $document->render()
         );
         foreach ($document->getAllRuleSets() as $ruleSet) {
-            $ruleSet->removeRule('font-');
+            $ruleSet->removeMatchingRules('font-');
         }
         self::assertSame(
             '#header {margin: 10px 2em 1cm 2%;color: red !important;background-color: green;'
@@ -357,7 +357,7 @@ body {color: green;}',
             $document->render()
         );
         foreach ($document->getAllRuleSets() as $ruleSet) {
-            $ruleSet->removeRule('background-');
+            $ruleSet->removeMatchingRules('background-');
         }
         self::assertSame(
             '#header {margin: 10px 2em 1cm 2%;color: red !important;frequency: 30Hz;transform: rotate(1turn);}


### PR DESCRIPTION
Now this method has been added, using it appropriately in the tests, rather than the deprecated functionality, will eliminate a PHPStan warning.

Note that PHPStan seems to erroneously place the warning against the callee rather than the caller.