### PR TITLE
[TASK] Have `setPosition()` implement fluent interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Please also have a look at our
 
 ### Changed
 
+- `setPosition()` (in `Rule` and other classes) now has fluent interface,
+  returning itself (#1259)
 - `RuleSet::removeRule()` now only allows `Rule` as the parameter
   (implementing classes are `AtRuleSet` and `DeclarationBlock`);
   use `removeMatchingRules()` or `removeAllRules()` for other functions (#1255)

--- a/src/Position/Position.php
+++ b/src/Position/Position.php
@@ -58,11 +58,15 @@ trait Position
     /**
      * @param int<0, max>|null $lineNumber
      * @param int<0, max>|null $columnNumber
+     *
+     * @return $this fluent interface
      */
-    public function setPosition(?int $lineNumber, ?int $columnNumber = null): void
+    public function setPosition(?int $lineNumber, ?int $columnNumber = null): Positionable
     {
         // The conditional is for backwards compatibility (backcompat); `0` will not be allowed in future.
         $this->lineNumber = $lineNumber !== 0 ? $lineNumber : null;
         $this->columnNumber = $columnNumber;
+
+        return $this;
     }
 }

--- a/src/Position/Positionable.php
+++ b/src/Position/Positionable.php
@@ -40,6 +40,8 @@ interface Positionable
      *        Providing zero for this parameter is deprecated in version 8.9.0, and will not be supported from v9.0.
      *        Use `null` instead when no line number is available.
      * @param int<0, max>|null $columnNumber
+     *
+     * @return $this fluent interface
      */
-    public function setPosition(?int $lineNumber, ?int $columnNumber = null): void;
+    public function setPosition(?int $lineNumber, ?int $columnNumber = null): Positionable;
 }


### PR DESCRIPTION
This will aid writing tests for `RuleSet`.

Note that the PHP type annotation cannot be `self` because an interface is involved and PHP 7 is still supported.

Part of #974.