### PR TITLE
[BUGFIX] Ensure column number set after `RuleSet::addRule()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Please also have a look at our
 - Methods `getLineNumber` and `getColumnNumber` which return a nullable `int`
   for the following classes:
   `Comment`, `CSSList`, `SourceException`, `Charset`, `CSSNamespace`, `Import`,
-  `Rule`, `DeclarationBlock`, `RuleSet`, `CSSFunction`, `Value` (#1225)
+  `Rule`, `DeclarationBlock`, `RuleSet`, `CSSFunction`, `Value` (#1225, #1263)
 - `Positionable` interface for CSS items that may have a position
   (line and perhaps column number) in the parsed CSS (#1221)
 - Partial support for CSS Color Module Level 4:

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -118,6 +118,8 @@ abstract class RuleSet implements CSSElement, CSSListItem, Positionable, RuleCon
                 $last = $rules[$rulesCount - 1];
                 $ruleToAdd->setPosition($last->getLineNo() + 1, 0);
             }
+        } elseif ($ruleToAdd->getColumnNumber() === null) {
+            $ruleToAdd->setPosition($ruleToAdd->getLineNumber(), 0);
         }
 
         \array_splice($this->rules[$propertyName], $position, 0, [$ruleToAdd]);

--- a/tests/Unit/RuleSet/RuleSetTest.php
+++ b/tests/Unit/RuleSet/RuleSetTest.php
@@ -123,8 +123,6 @@ final class RuleSetTest extends TestCase
         array $initialPropertyNames,
         string $propertyNameToAdd
     ): void {
-        self::markTestSkipped('currently broken - does not set column number');
-
         $ruleToAdd = new Rule($propertyNameToAdd);
         $ruleToAdd->setPosition(42);
         $this->setRulesFromPropertyNames($initialPropertyNames);


### PR DESCRIPTION
Note that this bug (or inconsistency) only occurs following the addtion of `getColumnNumber()` returning a nullable `int` (#1221 and #1225). These changes are not yet included in any release.

Part of #974.