### PR TITLE
[BUGFIX] Set line number for `addRule()` with only column number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@ Please also have a look at our
 
 ### Fixed
 
+- Set line number when `RuleSet::addRule()` called with only column number set
+  (#1265)
 - Ensure first rule added with `RuleSet::addRule()` has valid position (#1262)
 - Don't render `rgb` colors with percentage values using hex notation (#803)
 

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -110,15 +110,16 @@ abstract class RuleSet implements CSSElement, CSSListItem, Positionable, RuleCon
                 $ruleToAdd->setPosition($sibling->getLineNo(), $sibling->getColNo() - 1);
             }
         }
-        if ($ruleToAdd->getLineNo() === 0 && $ruleToAdd->getColNo() === 0) {
+        if ($ruleToAdd->getLineNumber() === null) {
             //this node is added manually, give it the next best line
+            $columnNumber = $ruleToAdd->getColumnNumber() ?? 0;
             $rules = $this->getRules();
             $rulesCount = \count($rules);
             if ($rulesCount > 0) {
                 $last = $rules[$rulesCount - 1];
-                $ruleToAdd->setPosition($last->getLineNo() + 1, 0);
+                $ruleToAdd->setPosition($last->getLineNo() + 1, $columnNumber);
             } else {
-                $ruleToAdd->setPosition(1, 0);
+                $ruleToAdd->setPosition(1, $columnNumber);
             }
         } elseif ($ruleToAdd->getColumnNumber() === null) {
             $ruleToAdd->setPosition($ruleToAdd->getLineNumber(), 0);

--- a/tests/Unit/RuleSet/RuleSetTest.php
+++ b/tests/Unit/RuleSet/RuleSetTest.php
@@ -138,19 +138,18 @@ final class RuleSetTest extends TestCase
      *
      * @param list<string> $initialPropertyNames
      */
-    public function addRuleWithOnlyColumnNumberAddsRuleAndSetsLineNumberPreservingColumnNumber(
+    public function addRuleWithOnlyColumnNumberAddsRuleAfterInitialRulesAndSetsLineNumberPreservingColumnNumber(
         array $initialPropertyNames,
         string $propertyNameToAdd
     ): void {
-        self::markTestSkipped('currently broken - does not preserve column number');
-
         $ruleToAdd = new Rule($propertyNameToAdd);
         $ruleToAdd->setPosition(null, 42);
         $this->setRulesFromPropertyNames($initialPropertyNames);
 
         $this->subject->addRule($ruleToAdd);
 
-        self::assertContains($ruleToAdd, $this->subject->getRules());
+        $rules = $this->subject->getRules();
+        self::assertSame($ruleToAdd, \end($rules));
         self::assertIsInt($ruleToAdd->getLineNumber(), 'line number not set');
         self::assertGreaterThanOrEqual(1, $ruleToAdd->getLineNumber(), 'line number not valid');
         self::assertSame(42, $ruleToAdd->getColumnNumber(), 'column number not preserved');


### PR DESCRIPTION
Continue to preserve the column number.
Also tighten the test to confirm the `Rule` is added at the end.

Note that the reason for `markTestSkipped()` was incorrect - the line number was not being set at all.