### PR TITLE
[BUGFIX] Ensure non-negative column number in `RuleSet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@ Please also have a look at our
 
 ### Fixed
 
+- Ensure `RuleSet::addRule()` sets non-negative column number when sibling
+  provided (#1268)
 - Set line number when `RuleSet::addRule()` called with only column number set
   (#1265)
 - Ensure first rule added with `RuleSet::addRule()` has valid position (#1262)

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -107,7 +107,20 @@ abstract class RuleSet implements CSSElement, CSSListItem, Positionable, RuleCon
             $siblingPosition = \array_search($sibling, $this->rules[$propertyName], true);
             if ($siblingPosition !== false) {
                 $position = $siblingPosition;
-                $ruleToAdd->setPosition($sibling->getLineNo(), $sibling->getColNo() - 1);
+                // Increment column number of all existing rules on same line, starting at sibling
+                $siblingLineNumber = $sibling->getLineNumber();
+                $siblingColumnNumber = $sibling->getColumnNumber();
+                foreach ($this->rules as $rulesForAProperty) {
+                    foreach ($rulesForAProperty as $rule) {
+                        if (
+                            $rule->getLineNumber() === $siblingLineNumber &&
+                            $rule->getColumnNumber() >= $siblingColumnNumber
+                        ) {
+                            $rule->setPosition($siblingLineNumber, $rule->getColumnNumber() + 1);
+                        }
+                    }
+                }
+                $ruleToAdd->setPosition($siblingLineNumber, $siblingColumnNumber);
             }
         }
         if ($ruleToAdd->getLineNumber() === null) {

--- a/tests/Unit/RuleSet/RuleSetTest.php
+++ b/tests/Unit/RuleSet/RuleSetTest.php
@@ -271,8 +271,6 @@ final class RuleSetTest extends TestCase
         int $siblingIndex,
         string $propertyNameToAdd
     ): void {
-        self::markTestSkipped('tofix: sometimes a negative column number results');
-
         $ruleToAdd = new Rule($propertyNameToAdd);
         $this->setRulesFromPropertyNames($initialPropertyNames);
         $sibling = $this->subject->getRules()[$siblingIndex];


### PR DESCRIPTION
When inserting a `Rule` before a sibling, increment the column number of other `Rule`s, instead of assigning a lower column number.

Part of #974.