### PR TITLE
[CLEANUP] Extract method `RuleSet::comparePositionable`

### DIFF
--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -173,12 +173,7 @@ abstract class RuleSet implements CSSElement, CSSListItem, Positionable, RuleCon
                 $result = \array_merge($result, $rules);
             }
         }
-        \usort($result, static function (Rule $first, Rule $second): int {
-            if ($first->getLineNo() === $second->getLineNo()) {
-                return $first->getColNo() - $second->getColNo();
-            }
-            return $first->getLineNo() - $second->getLineNo();
-        });
+        \usort($result, [self::class, 'comparePositionable']);
 
         return $result;
     }
@@ -298,5 +293,16 @@ abstract class RuleSet implements CSSElement, CSSListItem, Positionable, RuleCon
         }
 
         return $formatter->removeLastSemicolon($result);
+    }
+
+    /**
+     * @return int negative if `$first` is before `$second`; zero if they have the same position; positive otherwise
+     */
+    private static function comparePositionable(Positionable $first, Positionable $second): int
+    {
+        if ($first->getLineNo() === $second->getLineNo()) {
+            return $first->getColNo() - $second->getColNo();
+        }
+        return $first->getLineNo() - $second->getLineNo();
     }
 }


### PR DESCRIPTION
As well as being used with `usort()`, it may have other uses.

The deprecated `getLineNo()` and `getColNo()` are still used for now. Replacing these will be done separately.

Relates to #974.