### PR TITLE
[TASK] Add tests for `getLineNumber`

### DIFF
--- a/tests/Unit/CSSList/AtRuleBlockListTest.php
+++ b/tests/Unit/CSSList/AtRuleBlockListTest.php
@@ -129,6 +129,27 @@ final class AtRuleBlockListTest extends TestCase
     /**
      * @test
      */
+    public function getLineNumberByDefaultReturnsNull(): void
+    {
+        $subject = new AtRuleBlockList('');
+
+        self::assertNull($subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
+    public function getLineNumberReturnsLineNumberProvidedToConstructor(): void
+    {
+        $lineNumber = 42;
+        $subject = new AtRuleBlockList('', '', $lineNumber);
+
+        self::assertSame($lineNumber, $subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
     public function isRootListAlwaysReturnsFalse(): void
     {
         $subject = new AtRuleBlockList('supports');

--- a/tests/Unit/CSSList/CSSListTest.php
+++ b/tests/Unit/CSSList/CSSListTest.php
@@ -82,6 +82,27 @@ final class CSSListTest extends TestCase
     /**
      * @test
      */
+    public function getLineNumberByDefaultReturnsNull(): void
+    {
+        $subject = new ConcreteCSSList();
+
+        self::assertNull($subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
+    public function getLineNumberReturnsLineNumberProvidedToConstructor(): void
+    {
+        $lineNumber = 42;
+        $subject = new ConcreteCSSList($lineNumber);
+
+        self::assertSame($lineNumber, $subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
     public function getContentsInitiallyReturnsEmptyArray(): void
     {
         $subject = new ConcreteCSSList();

--- a/tests/Unit/CSSList/KeyFrameTest.php
+++ b/tests/Unit/CSSList/KeyFrameTest.php
@@ -83,6 +83,27 @@ final class KeyFrameTest extends TestCase
     /**
      * @test
      */
+    public function getLineNumberByDefaultReturnsNull(): void
+    {
+        $subject = new KeyFrame();
+
+        self::assertNull($subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
+    public function getLineNumberReturnsLineNumberProvidedToConstructor(): void
+    {
+        $lineNumber = 42;
+        $subject = new KeyFrame($lineNumber);
+
+        self::assertSame($lineNumber, $subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
     public function getAnimationNameByDefaultReturnsNone(): void
     {
         $subject = new KeyFrame();

--- a/tests/Unit/Comment/CommentTest.php
+++ b/tests/Unit/Comment/CommentTest.php
@@ -77,4 +77,25 @@ final class CommentTest extends TestCase
 
         self::assertSame($lineNumber, $subject->getLineNo());
     }
+
+    /**
+     * @test
+     */
+    public function getLineNumberByDefaultReturnsNull(): void
+    {
+        $subject = new Comment();
+
+        self::assertNull($subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
+    public function getLineNumberReturnsLineNumberProvidedToConstructor(): void
+    {
+        $lineNumber = 42;
+        $subject = new Comment('', $lineNumber);
+
+        self::assertSame($lineNumber, $subject->getLineNumber());
+    }
 }

--- a/tests/Unit/Parsing/OutputExceptionTest.php
+++ b/tests/Unit/Parsing/OutputExceptionTest.php
@@ -56,6 +56,27 @@ final class OutputExceptionTest extends TestCase
     /**
      * @test
      */
+    public function getLineNumberByDefaultReturnsNull(): void
+    {
+        $subject = new OutputException('foo');
+
+        self::assertNull($subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
+    public function getLineNumberReturnsLineNumberProvidedToConstructor(): void
+    {
+        $lineNumber = 42;
+        $subject = new OutputException('foo', $lineNumber);
+
+        self::assertSame($lineNumber, $subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
     public function getMessageWithLineNumberProvidedIncludesLineNumber(): void
     {
         $lineNumber = 17;

--- a/tests/Unit/Parsing/SourceExceptionTest.php
+++ b/tests/Unit/Parsing/SourceExceptionTest.php
@@ -47,6 +47,27 @@ final class SourceExceptionTest extends TestCase
     /**
      * @test
      */
+    public function getLineNumberByDefaultReturnsNull(): void
+    {
+        $subject = new SourceException('foo');
+
+        self::assertNull($subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
+    public function getLineNumberReturnsLineNumberProvidedToConstructor(): void
+    {
+        $lineNumber = 42;
+        $subject = new SourceException('foo', $lineNumber);
+
+        self::assertSame($lineNumber, $subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
     public function getMessageWithLineNumberProvidedIncludesLineNumber(): void
     {
         $lineNumber = 17;

--- a/tests/Unit/Parsing/UnexpectedEOFExceptionTest.php
+++ b/tests/Unit/Parsing/UnexpectedEOFExceptionTest.php
@@ -45,6 +45,27 @@ final class UnexpectedEOFExceptionTest extends TestCase
     /**
      * @test
      */
+    public function getLineNumberByDefaultReturnsNull(): void
+    {
+        $subject = new UnexpectedEOFException('expected', 'found');
+
+        self::assertNull($subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
+    public function getLineNumberReturnsLineNumberProvidedToConstructor(): void
+    {
+        $lineNumber = 42;
+        $subject = new UnexpectedEOFException('expected', 'found', 'literal', $lineNumber);
+
+        self::assertSame($lineNumber, $subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
     public function getMessageWithLineNumberProvidedIncludesLineNumber(): void
     {
         $lineNumber = 17;

--- a/tests/Unit/Parsing/UnexpectedTokenExceptionTest.php
+++ b/tests/Unit/Parsing/UnexpectedTokenExceptionTest.php
@@ -45,6 +45,27 @@ final class UnexpectedTokenExceptionTest extends TestCase
     /**
      * @test
      */
+    public function getLineNumberByDefaultReturnsNull(): void
+    {
+        $subject = new UnexpectedTokenException('expected', 'found');
+
+        self::assertNull($subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
+    public function getLineNumberReturnsLineNumberProvidedToConstructor(): void
+    {
+        $lineNumber = 42;
+        $subject = new UnexpectedTokenException('expected', 'found', 'literal', $lineNumber);
+
+        self::assertSame($lineNumber, $subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
     public function getMessageWithLineNumberProvidedIncludesLineNumber(): void
     {
         $lineNumber = 17;

--- a/tests/Unit/Value/CSSStringTest.php
+++ b/tests/Unit/Value/CSSStringTest.php
@@ -81,4 +81,25 @@ final class CSSStringTest extends TestCase
 
         self::assertSame($lineNumber, $subject->getLineNo());
     }
+
+    /**
+     * @test
+     */
+    public function getLineNumberByDefaultReturnsNull(): void
+    {
+        $subject = new CSSString('');
+
+        self::assertNull($subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
+    public function getLineNumberReturnsLineNumberProvidedToConstructor(): void
+    {
+        $lineNumber = 42;
+        $subject = new CSSString('', $lineNumber);
+
+        self::assertSame($lineNumber, $subject->getLineNumber());
+    }
 }

--- a/tests/Unit/Value/CalcRuleValueListTest.php
+++ b/tests/Unit/Value/CalcRuleValueListTest.php
@@ -29,7 +29,7 @@ final class CalcRuleValueListTest extends TestCase
     /**
      * @test
      */
-    public function getLineNumberByDefaultReturnsZero(): void
+    public function getLineNoByDefaultReturnsZero(): void
     {
         $subject = new CalcRuleValueList();
 
@@ -46,6 +46,27 @@ final class CalcRuleValueListTest extends TestCase
         $subject = new CalcRuleValueList($lineNumber);
 
         self::assertSame($lineNumber, $subject->getLineNo());
+    }
+
+    /**
+     * @test
+     */
+    public function getLineNumberByDefaultReturnsNull(): void
+    {
+        $subject = new CalcRuleValueList();
+
+        self::assertNull($subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
+    public function getLineNumberReturnsLineNumberProvidedToConstructor(): void
+    {
+        $lineNumber = 42;
+        $subject = new CalcRuleValueList($lineNumber);
+
+        self::assertSame($lineNumber, $subject->getLineNumber());
     }
 
     /**

--- a/tests/Unit/Value/URLTest.php
+++ b/tests/Unit/Value/URLTest.php
@@ -81,4 +81,25 @@ final class URLTest extends TestCase
 
         self::assertSame($lineNumber, $subject->getLineNo());
     }
+
+    /**
+     * @test
+     */
+    public function getLineNumberByDefaultReturnsNull(): void
+    {
+        $subject = new URL(new CSSString('http://example.com'));
+
+        self::assertNull($subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
+    public function getLineNumberReturnsLineNumberProvidedToConstructor(): void
+    {
+        $lineNumber = 42;
+        $subject = new URL(new CSSString('http://example.com'), $lineNumber);
+
+        self::assertSame($lineNumber, $subject->getLineNumber());
+    }
 }


### PR DESCRIPTION
These correspond to the existing tests for `getLineNo` for classes that implement `Positionable`.

Also correct an existing test method name to refer to `getLineNo`.