### PR TITLE
[TASK] Remove `getColNo()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Please also have a look at our
 
 ### Removed
 
+- Remove `Rule::getColNo()` (use `getColumnNumber()` instead) (#1287)
 - Passing a string as the first argument to `getAllValues()` is no longer
   supported and will not work;
   the search pattern should now be passed as the second argument (#1243)

--- a/src/Position/Position.php
+++ b/src/Position/Position.php
@@ -48,14 +48,6 @@ trait Position
     }
 
     /**
-     * @return int<0, max>
-     */
-    public function getColNo(): int
-    {
-        return $this->getColumnNumber() ?? 0;
-    }
-
-    /**
      * @param int<0, max>|null $lineNumber
      * @param int<0, max>|null $columnNumber
      *

--- a/src/Position/Positionable.php
+++ b/src/Position/Positionable.php
@@ -29,13 +29,6 @@ interface Positionable
     public function getColumnNumber(): ?int;
 
     /**
-     * @return int<0, max>
-     *
-     * @deprecated in version 8.9.0, will be removed in v9.0. Use `getColumnNumber()` instead.
-     */
-    public function getColNo(): int;
-
-    /**
      * @param int<0, max>|null $lineNumber
      *        Providing zero for this parameter is deprecated in version 8.9.0, and will not be supported from v9.0.
      *        Use `null` instead when no line number is available.

--- a/tests/UnitDeprecated/Position/PositionTest.php
+++ b/tests/UnitDeprecated/Position/PositionTest.php
@@ -80,38 +80,6 @@ final class PositionTest extends TestCase
     /**
      * @test
      */
-    public function getColNoInitiallyReturnsZero(): void
-    {
-        self::assertSame(0, $this->subject->getColNo());
-    }
-
-    /**
-     * @test
-     *
-     * @dataProvider provideColumnNumber
-     */
-    public function getColNoReturnsColumnNumberSet(int $columnNumber): void
-    {
-        $this->subject->setPosition(1, $columnNumber);
-
-        self::assertSame($columnNumber, $this->subject->getColNo());
-    }
-
-    /**
-     * @test
-     */
-    public function getColNoReturnsZeroAfterColumnNumberCleared(): void
-    {
-        $this->subject->setPosition(1, 99);
-
-        $this->subject->setPosition(2);
-
-        self::assertSame(0, $this->subject->getColNo());
-    }
-
-    /**
-     * @test
-     */
     public function setPositionWithZeroClearsLineNumber(): void
     {
         $this->subject->setPosition(99);


### PR DESCRIPTION
Note that the removed tests are in `UnitDeprecated`. Equivalent tests already exist for the replacement `getColumnNumber()`.

Part of #974