### PR TITLE
[BUGFIX] Exclude absent line number from exception message

### DIFF
--- a/src/Parsing/SourceException.php
+++ b/src/Parsing/SourceException.php
@@ -17,7 +17,7 @@ class SourceException extends \Exception implements Positionable
     public function __construct(string $message, ?int $lineNumber = null)
     {
         $this->setPosition($lineNumber);
-        if ($lineNumber !== 0) {
+        if ($lineNumber !== null) {
             $message .= " [line no: $lineNumber]";
         }
         parent::__construct($message);

--- a/tests/Unit/Parsing/SourceExceptionTest.php
+++ b/tests/Unit/Parsing/SourceExceptionTest.php
@@ -20,7 +20,7 @@ final class SourceExceptionTest extends TestCase
         $message = 'The cake is a lie.';
         $exception = new SourceException($message);
 
-        self::assertStringContainsString($message, $exception->getMessage());
+        self::assertSame($message, $exception->getMessage());
     }
 
     /**
@@ -53,6 +53,17 @@ final class SourceExceptionTest extends TestCase
         $exception = new SourceException('foo', $lineNumber);
 
         self::assertStringContainsString(' [line no: ' . $lineNumber . ']', $exception->getMessage());
+    }
+
+    /**
+     * @test
+     */
+    public function getMessageWithLineNumberProvidedIncludesMessage(): void
+    {
+        $message = 'There is no flatware.';
+        $exception = new SourceException($message, 17);
+
+        self::assertStringContainsString($message, $exception->getMessage());
     }
 
     /**


### PR DESCRIPTION
The bug was introduced by #1288, so has not been included in any release; thus a changelog entry is not justified.