### PR TITLE
[BUGFIX] Allow comma in selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ Please also have a look at our
 
 ### Fixed
 
+- Allow comma in selectors (e.g. `:not(html, body)`) (#1293)
 - Insert `Rule` before sibling even with different property name
   (in `RuleSet::addRule()`) (#1270)
 - Ensure `RuleSet::addRule()` sets non-negative column number when sibling

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -24,9 +24,9 @@ class Selector implements Renderable
     public const SELECTOR_VALIDATION_RX = '/
         ^(
             (?:
-                [a-zA-Z0-9\\x{00A0}-\\x{FFFF}_^$|*="\'~\\[\\]()\\-\\s\\.:#+>]* # any sequence of valid unescaped characters
-                (?:\\\\.)?                                                     # a single escaped character
-                (?:([\'"]).*?(?<!\\\\)\\2)?                                    # a quoted text like [id="example"]
+                [a-zA-Z0-9\\x{00A0}-\\x{FFFF}_^$|*="\'~\\[\\]()\\-\\s\\.:#+>,]* # any sequence of valid unescaped characters
+                (?:\\\\.)?                                                      # a single escaped character
+                (?:([\'"]).*?(?<!\\\\)\\2)?                                     # a quoted text like [id="example"]
             )*
         )$
         /ux';

--- a/tests/Unit/Property/SelectorTest.php
+++ b/tests/Unit/Property/SelectorTest.php
@@ -60,6 +60,9 @@ final class SelectorTest extends TestCase
             'class with pseudo-selector' => ['.help:hover', 20],
             'ID' => ['#file', 100],
             'ID and descendant class' => ['#test .help', 110],
+            '`not`' => [':not(#your-mug)', 100],
+            // TODO, broken: The specificity should be the highest of the `:not` arguments, not the sum.
+            '`not` with multiple arguments' => [':not(#your-mug, .their-mug)', 110],
         ];
     }
 


### PR DESCRIPTION
Also add a note that the specificity is incorrectly calculated in such cases. This will be addressed with a separate fix.