### PR TITLE
[DOCS] Fix class list in class diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,11 +713,13 @@ classDiagram
     }
     class SourceException {
     }
+    class SpecificityCalculator {
+    }
+    class URL {
+    }
     class UnexpectedEOFException {
     }
     class UnexpectedTokenException {
-    }
-    class URL {
     }
     class Value {
         <<abstract>>


### PR DESCRIPTION
- adapt the sorting to how the diagram generator sorts
- add `SpecificityCalculator` which had been missing