### PR TITLE
[CLEANUP] Use static variable for stop characters

### DIFF
--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -42,9 +42,10 @@ class DeclarationBlock extends RuleSet
         try {
             $selectorParts = [];
             $stringWrapperCharacter = null;
+            static $stopCharacters = ['{', '}', '\'', '"'];
             do {
                 $selectorParts[] = $parserState->consume(1)
-                    . $parserState->consumeUntil(['{', '}', '\'', '"'], false, false, $comments);
+                    . $parserState->consumeUntil($stopCharacters, false, false, $comments);
                 $nextCharacter = $parserState->peek();
                 switch ($nextCharacter) {
                     case '\'':


### PR DESCRIPTION
... in `DeclarationBlock::parse()`.

This improves readability in preparation for #1292 which will extend the list. (It may also slightly improve performance.)