### PR TITLE
[CLEANUP] Remove impossible conditional

### DIFF
--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Call to function is_string\(\) with Sabberworm\\CSS\\Parsing\\ParserState will always evaluate to false\.$#'
-			identifier: function.impossibleType
-			count: 1
-			path: ../src/CSSList/CSSList.php
-
-		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
 			count: 1

--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -21,7 +21,6 @@ use Sabberworm\CSS\Property\Selector;
 use Sabberworm\CSS\RuleSet\AtRuleSet;
 use Sabberworm\CSS\RuleSet\DeclarationBlock;
 use Sabberworm\CSS\RuleSet\RuleSet;
-use Sabberworm\CSS\Settings;
 use Sabberworm\CSS\Value\CSSString;
 use Sabberworm\CSS\Value\URL;
 use Sabberworm\CSS\Value\Value;
@@ -64,9 +63,6 @@ abstract class CSSList implements CSSElement, CSSListItem, Positionable
     public static function parseList(ParserState $parserState, CSSList $list): void
     {
         $isRoot = $list instanceof Document;
-        if (\is_string($parserState)) {
-            $parserState = new ParserState($parserState, Settings::create());
-        }
         $usesLenientParsing = $parserState->getSettings()->usesLenientParsing();
         $comments = [];
         while (!$parserState->isEnd()) {


### PR DESCRIPTION
The parameter `$parserState` is specified to be a `ParserState`, so it can never be a string.