### PR TITLE
[BUGFIX] Correct DocBlock for `ParserState::consumeUntil()`

### DIFF
--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -19,12 +19,6 @@ parameters:
 			path: ../src/CSSList/Document.php
 
 		-
-			message: '#^Call to function in_array\(\) with arguments null, list\<string\> and true will always evaluate to false\.$#'
-			identifier: function.impossibleType
-			count: 1
-			path: ../src/Parsing/ParserState.php
-
-		-
 			message: '#^Negated boolean expression is always true\.$#'
 			identifier: booleanNot.alwaysTrue
 			count: 1

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -328,7 +328,7 @@ class ParserState
     }
 
     /**
-     * @param list<string>|string $stopCharacters
+     * @param list<string|null>|string|null $stopCharacters
      * @param array<int, Comment> $comments
      *
      * @throws UnexpectedEOFException


### PR DESCRIPTION
The special `EOF` constant is actually defined as `null`, so the stop characters may be strings or `null`.