### PR TITLE
[BUGFIX] Update class diagram to show `RuleSet` as concrete

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,7 +699,6 @@ classDiagram
         <<interface>>
     }
     class RuleSet {
-        <<abstract>>
     }
     class RuleValueList {
     }


### PR DESCRIPTION
Missed in #1341.