### PR TITLE
[TASK] Add `thecodingmachine/safe` (#1453)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,7 @@ updates:
         - dependency-name: "phpunit/phpunit"
           versions: [ ">= 9.0.0" ]
         - dependency-name: "rector/rector"
+        - dependency-name: "thecodingmachine/safe"
       versioning-strategy: "increase"
       commit-message:
           prefix: "[Dependabot] "

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "homepage": "https://www.sabberworm.com/blog/2010/6/10/php-css-parser",
     "require": {
         "php": "^7.2.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-        "ext-iconv": "*"
+        "ext-iconv": "*",
+        "thecodingmachine/safe": "^1.3 || ^2.5 || ^3.3"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "1.4.0",

--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -40,7 +40,6 @@ return (new \PhpCsFixer\Config())
             'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
 
             // function notation
-            'native_function_invocation' => ['include' => ['@all']],
             'nullable_type_declaration_for_default_null_value' => true,
 
             // import


### PR DESCRIPTION
Safe-PHP https://github.com/thecodingmachine/safe provides rewrites of PHP functions to throw an exception instead of returning `false` when an error is encountered.

This will allow us to drop out custom `preg_*` wrapper class and to increase type safety in our codebase.

Also drop the PHP-CS-Fixer rule that adds a trailing backslash to calls to native PHP functions (as this would change the Safe-PHP calls back to their unsafe versions).

The actual code changes will come in subsequent commits.

Part of #1168