### PR TITLE
[BUGFIX] Use the safe regexp functions in `ParserState`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Please also have a look at our
 
 ### Fixed
 
-- Use typesafe versions of PHP functions (#1368)
+- Use typesafe versions of PHP functions (#1368, #1370)
 
 ### Documentation
 


### PR DESCRIPTION
Part of #1168