### PR TITLE
[BUGFIX] Use safe `file_get_contents` in `LenientParsingTest`

### DIFF
--- a/tests/RuleSet/LenientParsingTest.php
+++ b/tests/RuleSet/LenientParsingTest.php
@@ -10,6 +10,8 @@ use Sabberworm\CSS\Parser;
 use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 use Sabberworm\CSS\Settings;
 
+use function Safe\file_get_contents;
+
 /**
  * @coversNothing
  */
@@ -23,7 +25,7 @@ final class LenientParsingTest extends TestCase
         $this->expectException(UnexpectedTokenException::class);
 
         $pathToFile = __DIR__ . '/../fixtures/-fault-tolerance.css';
-        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->beStrict());
+        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->beStrict());
         $parser->parse();
     }
 
@@ -33,7 +35,7 @@ final class LenientParsingTest extends TestCase
     public function faultToleranceOn(): void
     {
         $pathToFile = __DIR__ . '/../fixtures/-fault-tolerance.css';
-        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
+        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
         $result = $parser->parse();
         self::assertSame(
             '.test1 {}' . "\n" . '.test2 {hello: 2.2;hello: 2000000000000.2;}' . "\n" . '#test {}' . "\n"
@@ -50,7 +52,7 @@ final class LenientParsingTest extends TestCase
         $this->expectException(UnexpectedTokenException::class);
 
         $pathToFile = __DIR__ . '/../fixtures/-end-token.css';
-        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->beStrict());
+        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->beStrict());
         $parser->parse();
     }
 
@@ -62,7 +64,7 @@ final class LenientParsingTest extends TestCase
         $this->expectException(UnexpectedTokenException::class);
 
         $pathToFile = __DIR__ . '/../fixtures/-end-token-2.css';
-        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->beStrict());
+        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->beStrict());
         $parser->parse();
     }
 
@@ -72,7 +74,7 @@ final class LenientParsingTest extends TestCase
     public function endTokenPositive(): void
     {
         $pathToFile = __DIR__ . '/../fixtures/-end-token.css';
-        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
+        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
         $result = $parser->parse();
         self::assertSame('', $result->render());
     }
@@ -83,7 +85,7 @@ final class LenientParsingTest extends TestCase
     public function endToken2Positive(): void
     {
         $pathToFile = __DIR__ . '/../fixtures/-end-token-2.css';
-        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
+        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
         $result = $parser->parse();
         self::assertSame(
             '#home .bg-layout {background-image: url("/bundles/main/img/bg1.png?5");}',
@@ -98,7 +100,7 @@ final class LenientParsingTest extends TestCase
     {
         \setlocale(LC_ALL, 'pt_PT', 'no');
         $pathToFile = __DIR__ . '/../fixtures/-fault-tolerance.css';
-        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
+        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
         $result = $parser->parse();
         self::assertSame(
             '.test1 {}' . "\n" . '.test2 {hello: 2.2;hello: 2000000000000.2;}' . "\n" . '#test {}' . "\n"
@@ -113,7 +115,7 @@ final class LenientParsingTest extends TestCase
     public function caseInsensitivity(): void
     {
         $pathToFile = __DIR__ . '/../fixtures/case-insensitivity.css';
-        $parser = new Parser(\file_get_contents($pathToFile));
+        $parser = new Parser(file_get_contents($pathToFile));
         $result = $parser->parse();
 
         self::assertSame(
@@ -132,7 +134,7 @@ final class LenientParsingTest extends TestCase
     public function cssWithInvalidColorStillGetsParsedAsDocument(): void
     {
         $pathToFile = __DIR__ . '/../fixtures/invalid-color.css';
-        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
+        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
         $result = $parser->parse();
 
         self::assertInstanceOf(Document::class, $result);
@@ -146,7 +148,7 @@ final class LenientParsingTest extends TestCase
         $this->expectException(UnexpectedTokenException::class);
 
         $pathToFile = __DIR__ . '/../fixtures/invalid-color.css';
-        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->beStrict());
+        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->beStrict());
         $parser->parse();
     }
 }


### PR DESCRIPTION
Part of #1168