### PR TITLE
[BUGFIX] Use safe preg functions in `CSSString`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Please also have a look at our
 
 ### Fixed
 
-- Use typesafe versions of PHP functions (#1379, #1380)
+- Use typesafe versions of PHP functions (#1379, #1380, #1381)
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Please also have a look at our
 
 ### Fixed
 
-- Use typesafe versions of PHP functions (#1379, #1380, #1381)
+- Use typesafe versions of PHP functions (#1379, #1380, #1382)
 
 ### Documentation
 

--- a/src/Value/CSSString.php
+++ b/src/Value/CSSString.php
@@ -10,6 +10,8 @@ use Sabberworm\CSS\Parsing\SourceException;
 use Sabberworm\CSS\Parsing\UnexpectedEOFException;
 use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 
+use function Safe\preg_match;
+
 /**
  * This class is a wrapper for quoted strings to distinguish them from keywords.
  *
@@ -54,7 +56,7 @@ class CSSString extends PrimitiveValue
         $content = null;
         if ($quote === null) {
             // Unquoted strings end in whitespace or with braces, brackets, parentheses
-            while (\preg_match('/[\\s{}()<>\\[\\]]/isu', $parserState->peek()) !== 1) {
+            while (preg_match('/[\\s{}()<>\\[\\]]/isu', $parserState->peek()) === 0) {
                 $result .= $parserState->parseCharacter(false);
             }
         } else {


### PR DESCRIPTION
Part of #1168