### PR TITLE
[BUGFIX] Use safe preg functions in `SpecificityCalculator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Please also have a look at our
 
 ### Fixed
 
-- Use typesafe versions of PHP functions (#1379, #1380, #1382, #1383)
+- Use typesafe versions of PHP functions (#1379, #1380, #1382, #1383, #1384)
 
 ### Documentation
 

--- a/src/Property/Selector/SpecificityCalculator.php
+++ b/src/Property/Selector/SpecificityCalculator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sabberworm\CSS\Property\Selector;
 
+use function Safe\preg_match_all;
+
 /**
  * Utility class to calculate the specificity of a CSS selector.
  *
@@ -67,8 +69,8 @@ final class SpecificityCalculator
             /// @todo should exclude \# as well as "#"
             $matches = null;
             $b = \substr_count($selector, '#');
-            $c = \preg_match_all(self::NON_ID_ATTRIBUTES_AND_PSEUDO_CLASSES_RX, $selector, $matches);
-            $d = \preg_match_all(self::ELEMENTS_AND_PSEUDO_ELEMENTS_RX, $selector, $matches);
+            $c = preg_match_all(self::NON_ID_ATTRIBUTES_AND_PSEUDO_CLASSES_RX, $selector, $matches);
+            $d = preg_match_all(self::ELEMENTS_AND_PSEUDO_ELEMENTS_RX, $selector, $matches);
             self::$cache[$selector] = ($a * 1000) + ($b * 100) + ($c * 10) + $d;
         }
 


### PR DESCRIPTION
Part of #1168