### PR TITLE
[TASK] Improve the Composer script naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
                   composer show;
 
             - name: PHP Lint
-              run: composer ci:php:lint
+              run: composer check:php:lint
 
     unit-tests:
         name: Unit tests
@@ -145,4 +145,4 @@ jobs:
                   phive --no-progress install --trust-gpg-keys 0FDE18AE1D09E19F60F6B1CBC00543248C87FB13,BBAB5DF0A0D6672989CF1869E82B2FB314E9906E
 
             - name: Run Command
-              run: composer ci:${{ matrix.command }}
+              run: composer check:${{ matrix.command }}

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -52,7 +52,7 @@ jobs:
                   composer show;
 
             - name: Run Tests
-              run: composer ci:tests:coverage
+              run: composer check:tests:coverage
 
             - name: Show generated coverage files
               run: ls -lah

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ code coverage of the fixed bugs and the new features.
 To run the existing PHPUnit tests, run this command:
 
 ```bash
-composer ci:tests:unit
+composer check:tests:unit
 ```
 
 ## Coding Style
@@ -94,7 +94,7 @@ We will only merge pull requests that follow the project's coding style.
 Please check your code with the provided static code analysis tools:
 
 ```bash
-composer ci:static
+composer check:static
 ```
 
 Please make your code clean, well-readable and easy to understand.

--- a/composer.json
+++ b/composer.json
@@ -67,31 +67,31 @@
         }
     },
     "scripts": {
-        "ci": [
-            "@ci:static",
-            "@ci:dynamic"
+        "check": [
+            "@check:static",
+            "@check:dynamic"
         ],
-        "ci:composer:normalize": "\"./.phive/composer-normalize\" --dry-run",
-        "ci:dynamic": [
-            "@ci:tests"
+        "check:composer:normalize": "\"./.phive/composer-normalize\" --dry-run",
+        "check:dynamic": [
+            "@check:tests"
         ],
-        "ci:php:fixer": "\"./.phive/php-cs-fixer\" --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff bin src tests config",
-        "ci:php:lint": "parallel-lint src tests config bin",
-        "ci:php:rector": "rector --no-progress-bar --dry-run --config=config/rector.php",
-        "ci:php:stan": "phpstan --no-progress --configuration=config/phpstan.neon",
-        "ci:static": [
-            "@ci:composer:normalize",
-            "@ci:php:fixer",
-            "@ci:php:lint",
-            "@ci:php:rector",
-            "@ci:php:stan"
+        "check:php:fixer": "\"./.phive/php-cs-fixer\" --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff bin src tests config",
+        "check:php:lint": "parallel-lint src tests config bin",
+        "check:php:rector": "rector --no-progress-bar --dry-run --config=config/rector.php",
+        "check:php:stan": "phpstan --no-progress --configuration=config/phpstan.neon",
+        "check:static": [
+            "@check:composer:normalize",
+            "@check:php:fixer",
+            "@check:php:lint",
+            "@check:php:rector",
+            "@check:php:stan"
         ],
-        "ci:tests": [
-            "@ci:tests:unit"
+        "check:tests": [
+            "@check:tests:unit"
         ],
-        "ci:tests:coverage": "phpunit --do-not-cache-result --coverage-clover=coverage.xml",
-        "ci:tests:sof": "phpunit --stop-on-failure --do-not-cache-result",
-        "ci:tests:unit": "phpunit --do-not-cache-result",
+        "check:tests:coverage": "phpunit --do-not-cache-result --coverage-clover=coverage.xml",
+        "check:tests:sof": "phpunit --stop-on-failure --do-not-cache-result",
+        "check:tests:unit": "phpunit --do-not-cache-result",
         "fix": [
             "@fix:php"
         ],
@@ -106,18 +106,18 @@
         "phpstan:baseline": "phpstan --configuration=config/phpstan.neon --generate-baseline=config/phpstan-baseline.neon --allow-empty-baseline"
     },
     "scripts-descriptions": {
-        "ci": "Runs all dynamic and static code checks.",
-        "ci:composer:normalize": "Checks the formatting and structure of the composer.json.",
-        "ci:dynamic": "Runs all dynamic code checks (i.e., currently, the unit tests).",
-        "ci:php:fixer": "Checks the code style with PHP CS Fixer.",
-        "ci:php:lint": "Checks the syntax of the PHP code.",
-        "ci:php:rector": "Checks the code for possible code updates and refactoring.",
-        "ci:php:stan": "Checks the types with PHPStan.",
-        "ci:static": "Runs all static code analysis checks for the code.",
-        "ci:tests": "Runs all dynamic tests (i.e., currently, the unit tests).",
-        "ci:tests:coverage": "Runs the unit tests with code coverage.",
-        "ci:tests:sof": "Runs the unit tests and stops at the first failure.",
-        "ci:tests:unit": "Runs all unit tests.",
+        "check": "Runs all dynamic and static code checks.",
+        "check:composer:normalize": "Checks the formatting and structure of the composer.json.",
+        "check:dynamic": "Runs all dynamic code checks (i.e., currently, the unit tests).",
+        "check:php:fixer": "Checks the code style with PHP CS Fixer.",
+        "check:php:lint": "Checks the syntax of the PHP code.",
+        "check:php:rector": "Checks the code for possible code updates and refactoring.",
+        "check:php:stan": "Checks the types with PHPStan.",
+        "check:static": "Runs all static code analysis checks for the code.",
+        "check:tests": "Runs all dynamic tests (i.e., currently, the unit tests).",
+        "check:tests:coverage": "Runs the unit tests with code coverage.",
+        "check:tests:sof": "Runs the unit tests and stops at the first failure.",
+        "check:tests:unit": "Runs all unit tests.",
         "fix": "Runs all fixers",
         "fix:composer:normalize": "Reformats and sorts the composer.json file.",
         "fix:php": "Autofixes all autofixable issues in the PHP code.",


### PR DESCRIPTION
The scripts for checking things are not CI-specific. So rename their shared prefix from `ci:` to `check:`.