### PR TITLE
[CLEANUP] Drop PHPDoc type annotations for constants

### DIFF
--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -16,9 +16,6 @@ use function Safe\preg_split;
  */
 class ParserState
 {
-    /**
-     * @var null
-     */
     public const EOF = null;
 
     /**

--- a/src/Property/AtRule.php
+++ b/src/Property/AtRule.php
@@ -16,8 +16,6 @@ interface AtRule extends CSSListItem
      * Since there are more set rules than block rules,
      * we’re whitelisting the block rules and have anything else be treated as a set rule.
      *
-     * @var non-empty-string
-     *
      * @internal since 8.5.2
      */
     public const BLOCK_RULES = 'media/document/supports/region-style/font-feature-values';

--- a/src/Property/KeyframeSelector.php
+++ b/src/Property/KeyframeSelector.php
@@ -11,8 +11,6 @@ class KeyframeSelector extends Selector
      * - comma is not allowed unless escaped or quoted;
      * - percentage value is allowed by itself.
      *
-     * @var non-empty-string
-     *
      * @internal since 8.5.2
      */
     public const SELECTOR_VALIDATION_RX = '/

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -17,8 +17,6 @@ use function Safe\preg_match;
 class Selector implements Renderable
 {
     /**
-     * @var non-empty-string
-     *
      * @internal since 8.5.2
      */
     public const SELECTOR_VALIDATION_RX = '/

--- a/src/Property/Selector/SpecificityCalculator.php
+++ b/src/Property/Selector/SpecificityCalculator.php
@@ -15,8 +15,6 @@ final class SpecificityCalculator
 {
     /**
      * regexp for specificity calculations
-     *
-     * @var non-empty-string
      */
     private const NON_ID_ATTRIBUTES_AND_PSEUDO_CLASSES_RX = '/
         (\\.[\\w]+)                   # classes
@@ -39,8 +37,6 @@ final class SpecificityCalculator
 
     /**
      * regexp for specificity calculations
-     *
-     * @var non-empty-string
      */
     private const ELEMENTS_AND_PSEUDO_ELEMENTS_RX = '/
         ((^|[\\s\\+\\>\\~]+)[\\w]+   # elements

--- a/src/Value/CalcFunction.php
+++ b/src/Value/CalcFunction.php
@@ -10,14 +10,7 @@ use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 
 class CalcFunction extends CSSFunction
 {
-    /**
-     * @var int
-     */
     private const T_OPERAND = 1;
-
-    /**
-     * @var int
-     */
     private const T_OPERATOR = 2;
 
     /**

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -19,8 +19,6 @@ class Size extends PrimitiveValue
 {
     /**
      * vh/vw/vm(ax)/vmin/rem are absolute insofar as they don’t scale to the immediate parent (only the viewport)
-     *
-     * @var list<non-empty-string>
      */
     private const ABSOLUTE_SIZE_UNITS = [
         'px',
@@ -40,14 +38,8 @@ class Size extends PrimitiveValue
         'rem',
     ];
 
-    /**
-     * @var list<non-empty-string>
-     */
     private const RELATIVE_SIZE_UNITS = ['%', 'em', 'ex', 'ch', 'fr'];
 
-    /**
-     * @var list<non-empty-string>
-     */
     private const NON_SIZE_UNITS = ['deg', 'grad', 'rad', 's', 'ms', 'turn', 'Hz', 'kHz'];
 
     /**

--- a/tests/Functional/Value/ValueTest.php
+++ b/tests/Functional/Value/ValueTest.php
@@ -20,8 +20,6 @@ final class ValueTest extends TestCase
      * the default set of delimiters for parsing most values
      *
      * @see \Sabberworm\CSS\Rule\Rule::listDelimiterForRule
-     *
-     * @var list<non-empty-string>
      */
     private const DEFAULT_DELIMITERS = [',', ' ', '/'];
 

--- a/tests/OutputFormatTest.php
+++ b/tests/OutputFormatTest.php
@@ -15,9 +15,6 @@ use Sabberworm\CSS\Parsing\OutputException;
  */
 final class OutputFormatTest extends TestCase
 {
-    /**
-     * @var string
-     */
     private const TEST_CSS = <<<EOT
 
 .main, .test {

--- a/tests/Unit/Value/ValueTest.php
+++ b/tests/Unit/Value/ValueTest.php
@@ -22,8 +22,6 @@ final class ValueTest extends TestCase
      * the default set of delimiters for parsing most values
      *
      * @see \Sabberworm\CSS\Rule\Rule::listDelimiterForRule
-     *
-     * @var list<non-empty-string>
      */
     private const DEFAULT_DELIMITERS = [',', ' ', '/'];
 


### PR DESCRIPTION
It has turned out that PHPStan does not need them.

Fixes #1396