### PR TITLE
[FEATURE] Parse container queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Please also have a look at our
 
 ### Added
 
+- Support for CSS container queries (#1400)
+
 ### Changed
 
 ### Deprecated

--- a/src/Property/AtRule.php
+++ b/src/Property/AtRule.php
@@ -18,7 +18,7 @@ interface AtRule extends CSSListItem
      *
      * @internal since 8.5.2
      */
-    public const BLOCK_RULES = 'media/document/supports/region-style/font-feature-values';
+    public const BLOCK_RULES = 'media/document/supports/region-style/font-feature-values/container';
 
     /**
      * @return non-empty-string

--- a/tests/CSSList/AtRuleBlockListTest.php
+++ b/tests/CSSList/AtRuleBlockListTest.php
@@ -48,6 +48,9 @@ final class AtRuleBlockListTest extends TestCase
                     }
                 ',
             ],
+            'container' => [
+                '@container (min-width: 60rem) { .items { background: blue; } }',
+            ],
         ];
     }
 

--- a/tests/Unit/Property/AtRuleTest.php
+++ b/tests/Unit/Property/AtRuleTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabberworm\CSS\Tests\Unit\Property;
+
+use PHPUnit\Framework\TestCase;
+use Sabberworm\CSS\Property\AtRule;
+
+final class AtRuleTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function blockRulesConstantIsCorrect(): void
+    {
+        self::assertEqualsCanonicalizing(
+            ['media', 'document', 'supports', 'region-style', 'font-feature-values', 'container'],
+            explode('/', AtRule::BLOCK_RULES)
+        );
+    }
+}


### PR DESCRIPTION
Adds support for CSS container queries.

https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Containment/Container_queries

```
@container (width > 700px) {
  .card h2 {
    font-size: 2em;
  }
}
```