### PR TITLE
[CLEANUP] Tighten `DeclarationBlock::selectors` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Please also have a look at our
 
 ### Changed
 
+- The array keys passed to `DeclarationBlock::setSelectors()` are no longer
+  preserved (#1407)
+
 ### Deprecated
 
 ### Removed

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -36,7 +36,7 @@ class DeclarationBlock implements CSSElement, CSSListItem, Positionable, RuleCon
     use Position;
 
     /**
-     * @var array<Selector|string>
+     * @var list<Selector>
      */
     private $selectors = [];
 
@@ -146,11 +146,13 @@ class DeclarationBlock implements CSSElement, CSSListItem, Positionable, RuleCon
     public function setSelectors($selectors, ?CSSList $list = null): void
     {
         if (\is_array($selectors)) {
-            $this->selectors = $selectors;
+            $selectorsToSet = $selectors;
         } else {
-            $this->selectors = \explode(',', $selectors);
+            $selectorsToSet = \explode(',', $selectors);
         }
-        foreach ($this->selectors as $key => $selector) {
+
+        // Convert all items to a `Selector` if not already
+        foreach ($selectorsToSet as $key => $selector) {
             if (!($selector instanceof Selector)) {
                 if ($list === null || !($list instanceof KeyFrame)) {
                     if (!Selector::isValid($selector)) {
@@ -160,7 +162,7 @@ class DeclarationBlock implements CSSElement, CSSListItem, Positionable, RuleCon
                             'custom'
                         );
                     }
-                    $this->selectors[$key] = new Selector($selector);
+                    $selectorsToSet[$key] = new Selector($selector);
                 } else {
                     if (!KeyframeSelector::isValid($selector)) {
                         throw new UnexpectedTokenException(
@@ -169,10 +171,13 @@ class DeclarationBlock implements CSSElement, CSSListItem, Positionable, RuleCon
                             'custom'
                         );
                     }
-                    $this->selectors[$key] = new KeyframeSelector($selector);
+                    $selectorsToSet[$key] = new KeyframeSelector($selector);
                 }
             }
         }
+
+        // Discard the keys and reindex the array
+        $this->selectors = \array_values($selectorsToSet);
     }
 
     /**
@@ -195,7 +200,7 @@ class DeclarationBlock implements CSSElement, CSSListItem, Positionable, RuleCon
     }
 
     /**
-     * @return array<Selector>
+     * @return list<Selector>
      */
     public function getSelectors(): array
     {

--- a/tests/Unit/RuleSet/DeclarationBlockTest.php
+++ b/tests/Unit/RuleSet/DeclarationBlockTest.php
@@ -278,4 +278,19 @@ final class DeclarationBlockTest extends TestCase
 
         self::assertSame($lineNumber, $result->getLineNumber());
     }
+
+    /**
+     * @test
+     *
+     * Any type of array may be passed to the method, but the resultant property should be a `list`.
+     */
+    public function setSelectorsIgnoresKeys(): void
+    {
+        $subject = new DeclarationBlock();
+        $subject->setSelectors(['Bob' => 'html', 'Mary' => 'body']);
+
+        $result = $subject->getSelectors();
+
+        self::assertSame([0, 1], \array_keys($result));
+    }
 }


### PR DESCRIPTION
Use a local variable in `setSelectors()` rather than temporarily assigning the property with a type it's not supposed to have.

Ensure that the property is set to a non-sparse numerical array.

Also tighten the return type of `getSelectors()`.

(Precursor to #1330.)