### PR TITLE
[DOCS] Sort changelog entries in reverse chronological order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ Please also have a look at our
 
 ### Fixed
 
-- Use typesafe versions of PHP functions (#1379, #1380, #1382, #1383, #1384)
 - Fix parsing of `calc` expressions when a newline immediately precedes or
   follows a `+` or `-` operator (#1399)
+- Use typesafe versions of PHP functions (#1379, #1380, #1382, #1383, #1384)
 
 ### Documentation
 


### PR DESCRIPTION
To be consistent with the git log, new entries in the changelog should be first.

This also makes it easier to see at a glance what was changed recently.