### PR TITLE
[TASK] Add coverage metadata to `AtRuleTest`

### DIFF
--- a/tests/Unit/Property/AtRuleTest.php
+++ b/tests/Unit/Property/AtRuleTest.php
@@ -7,6 +7,9 @@ namespace Sabberworm\CSS\Tests\Unit\Property;
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\Property\AtRule;
 
+/**
+ * @coversNothing
+ */
 final class AtRuleTest extends TestCase
 {
     /**


### PR DESCRIPTION
As interfaces cannot be covered using an `@covers` annotation, we need to use `@coversNothing` instead.

This will allow us to require coverage metadata for testcases later down the road.