### PR TITLE
[TASK] Avoid heredoc in a test

### DIFF
--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -571,9 +571,9 @@ body {font-size: 1.6em;}';
     {
         $document = self::parsedStructureForFile('comments');
 
-        $expected = '@import url("some/url.css") screen;'
-            . "\n.foo, #bar {background-color: #000;}"
-            . "\n@media screen {#foo.bar {position: absolute;}}";
+        $expected = "@import url(\"some/url.css\") screen;\n"
+            . ".foo, #bar {background-color: #000;}\n"
+            . '@media screen {#foo.bar {position: absolute;}}';
         self::assertSame($expected, $document->render());
     }
 


### PR DESCRIPTION
This allows the testcase being autoformatted without breaking the tests for PHP 7.2

https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc