### PR TITLE
[TASK] Avoid heredoc in another test

### DIFF
--- a/tests/OutputFormatTest.php
+++ b/tests/OutputFormatTest.php
@@ -15,20 +15,19 @@ use Sabberworm\CSS\Parsing\OutputException;
  */
 final class OutputFormatTest extends TestCase
 {
-    private const TEST_CSS = '
-.main, .test {
-	font: italic normal bold 16px/1.2 "Helvetica", Verdana, sans-serif;
-	background: white;
-}
-
-@media screen {
-	.main {
-		background-size: 100% 100%;
-		font-size: 1.3em;
-		background-color: #fff;
-	}
-}
-';
+    private const TEST_CSS = "\n"
+        . ".main, .test {\n"
+        . "\tfont: italic normal bold 16px/1.2 \"Helvetica\", Verdana, sans-serif;\n"
+        . "\tbackground: white;\n"
+        . "}\n"
+        . "\n"
+        . "@media screen {\n"
+        . "\t.main {\n"
+        . "\t\tbackground-size: 100% 100%;\n"
+        . "\t\tfont-size: 1.3em;\n"
+        . "\t\tbackground-color: #fff;\n"
+        . "\t}\n"
+        . "}\n";
 
     /**
      * @var Parser


### PR DESCRIPTION
This allows the testcase being autoformatted
without breaking the tests for PHP 7.2.

https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc