### PR TITLE
[DOCS] Capitalize 'CSS' in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Please also have a look at our
 
 ### Changed
 
-- Cleanup extra whitespace in css selector (#1398)
+- Clean up extra whitespace in CSS selector (#1398)
 - The array keys passed to `DeclarationBlock::setSelectors()` are no longer
   preserved (#1407)
 


### PR DESCRIPTION
Also correct grammar of 'clean up',
which is two separate words when used as a verb
(though as a noun or adjective is a single word).