### PR TITLE
[DEVELOPER] Disallow 'heredoc' and 'nowdoc' for strings

### DIFF
--- a/config/phpcs.xml
+++ b/config/phpcs.xml
@@ -9,4 +9,5 @@
       <property name="absoluteLineLimit" value="120"/>
     </properties>
   </rule>
+  <rule ref="Squiz.PHP.Heredoc"/>
 </ruleset>


### PR DESCRIPTION
Part of #1412.