### PR TITLE
[CLEANUP] Extract method `DeclarationBlock::parseSelector`

### DIFF
--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -336,6 +336,7 @@ class DeclarationBlock implements CSSElement, CSSListItem, Positionable, RuleCon
                     }
                     break;
                 case '{':
+                    // The fallthrough is intentional.
                 case '}':
                     if (!\is_string($stringWrapperCharacter)) {
                         break 2;


### PR DESCRIPTION
Closes #1324