### PR TITLE
[BUGFIX] Parse comment(s) immediately preceding selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Please also have a look at our
 
 ### Fixed
 
+- Parse comment(s) immediately preceding a selector (#1421)
+- Parse consecutive comments (#1421)
 - Support attribute selectors with values containing commas in
   `DeclarationBlock::setSelectors()` (#1419)
 - Allow `removeDeclarationBlockBySelector()` to be order-insensitve (#1406)

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -343,6 +343,7 @@ class ParserState
         $consumedCharacters = '';
         $start = $this->currentPosition;
 
+        $comments = \array_merge($comments, $this->consumeComments());
         while (!$this->isEnd()) {
             $character = $this->consume(1);
             if (\in_array($character, $stopCharacters, true)) {
@@ -354,10 +355,7 @@ class ParserState
                 return $consumedCharacters;
             }
             $consumedCharacters .= $character;
-            $comment = $this->consumeComment();
-            if ($comment instanceof Comment) {
-                $comments[] = $comment;
-            }
+            $comments = \array_merge($comments, $this->consumeComments());
         }
 
         if (\in_array(self::EOF, $stopCharacters, true)) {
@@ -454,5 +452,22 @@ class ParserState
         }
 
         return $result;
+    }
+
+    /**
+     * @return list<Comment>
+     */
+    private function consumeComments(): array
+    {
+        $comments = [];
+
+        while (true) {
+            $comment = $this->consumeComment();
+            if ($comment instanceof Comment) {
+                $comments[] = $comment;
+            } else {
+                return $comments;
+            }
+        }
     }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1048,10 +1048,9 @@ body {background-color: red;}';
         $fooBarBlock = $nodes[1];
         self::assertInstanceOf(Commentable::class, $fooBarBlock);
         $fooBarBlockComments = $fooBarBlock->getComments();
-        // TODO Support comments in selectors.
-        // $this->assertCount(2, $fooBarBlockComments);
-        // $this->assertSame("* Number 4 *", $fooBarBlockComments[0]->getComment());
-        // $this->assertSame("* Number 5 *", $fooBarBlockComments[1]->getComment());
+        self::assertCount(2, $fooBarBlockComments);
+        self::assertSame(' Number 4 ', $fooBarBlockComments[0]->getComment());
+        self::assertSame(' Number 5 ', $fooBarBlockComments[1]->getComment());
 
         // Declaration rules.
         self::assertInstanceOf(DeclarationBlock::class, $fooBarBlock);

--- a/tests/Unit/Parsing/ParserStateTest.php
+++ b/tests/Unit/Parsing/ParserStateTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabberworm\CSS\Tests\Unit\Parsing;
+
+use PHPUnit\Framework\TestCase;
+use Sabberworm\CSS\Comment\Comment;
+use Sabberworm\CSS\Parsing\ParserState;
+use Sabberworm\CSS\Settings;
+
+/**
+ * @covers \Sabberworm\CSS\Parsing\ParserState
+ */
+final class ParserStateTest extends TestCase
+{
+    /**
+     * @return array<
+     *             string,
+     *             array{
+     *                 text: non-empty-string,
+     *                 stopCharacter: non-empty-string,
+     *                 expectedConsumedText: non-empty-string,
+     *                 expectedComments: non-empty-list<non-empty-string>
+     *             }
+     *         >
+     */
+    public static function provideTextForConsumptionWithComments(): array
+    {
+        return [
+            'comment at start' => [
+                'text' => '/*comment*/hello{',
+                'stopCharacter' => '{',
+                'expectedConsumedText' => 'hello',
+                'expectedComments' => ['comment'],
+            ],
+            'comment at end' => [
+                'text' => 'hello/*comment*/{',
+                'stopCharacter' => '{',
+                'expectedConsumedText' => 'hello',
+                'expectedComments' => ['comment'],
+            ],
+            'comment in middle' => [
+                'text' => 'hell/*comment*/o{',
+                'stopCharacter' => '{',
+                'expectedConsumedText' => 'hello',
+                'expectedComments' => ['comment'],
+            ],
+            'two comments at start' => [
+                'text' => '/*comment1*//*comment2*/hello{',
+                'stopCharacter' => '{',
+                'expectedConsumedText' => 'hello',
+                'expectedComments' => ['comment1', 'comment2'],
+            ],
+            'two comments at end' => [
+                'text' => 'hello/*comment1*//*comment2*/{',
+                'stopCharacter' => '{',
+                'expectedConsumedText' => 'hello',
+                'expectedComments' => ['comment1', 'comment2'],
+            ],
+            'two comments interspersed' => [
+                'text' => 'he/*comment1*/ll/*comment2*/o{',
+                'stopCharacter' => '{',
+                'expectedConsumedText' => 'hello',
+                'expectedComments' => ['comment1', 'comment2'],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param non-empty-string $text
+     * @param non-empty-string $stopCharacter
+     * @param non-empty-string $expectedConsumedText
+     * @param non-empty-list<non-empty-string> $expectedComments
+     *
+     * @dataProvider provideTextForConsumptionWithComments
+     */
+    public function consumeUntilExtractsComments(
+        string $text,
+        string $stopCharacter,
+        string $expectedConsumedText,
+        array $expectedComments
+    ): void {
+        $subject = new ParserState($text, Settings::create());
+
+        $comments = [];
+        $result = $subject->consumeUntil($stopCharacter, false, false, $comments);
+
+        self::assertSame($expectedConsumedText, $result);
+        $commentsAsText = \array_map(
+            static function (Comment $comment): string {
+                return $comment->getComment();
+            },
+            $comments
+        );
+        self::assertSame($expectedComments, $commentsAsText);
+    }
+}


### PR DESCRIPTION
Also parse consecutive comments.