### PR TITLE
[BUGFIX] Improve recovery parsing upon a rogue `}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Please also have a look at our
 
 ### Fixed
 
+- Improve recovery parsing when a rogue `}` is encountered (#1425)
 - Parse comment(s) immediately preceding a selector (#1421)
 - Parse consecutive comments (#1421)
 - Support attribute selectors with values containing commas in

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -74,7 +74,7 @@ class DeclarationBlock implements CSSElement, CSSListItem, Positionable, RuleCon
             }
         } catch (UnexpectedTokenException $e) {
             if ($parserState->getSettings()->usesLenientParsing()) {
-                if (!$parserState->comes('}')) {
+                if (!$parserState->consumeIfComes('}')) {
                     $parserState->consumeUntil('}', false, true);
                 }
                 return null;

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -718,6 +718,7 @@ div {height: calc;}';
         $document = self::parsedStructureForFile('invalid-selectors', Settings::create()->withMultibyteSupport(true));
         $expected = '@keyframes mymove {from {top: 0px;}}
 #test {color: white;background: green;}
+#test {display: block;background: red;color: white;}
 #test {display: block;background: white;color: black;}';
         self::assertSame($expected, $document->render());
 
@@ -727,6 +728,7 @@ div {height: calc;}';
 	.super-menu > li:last-of-type {border-right-width: 0;}
 	html[dir="rtl"] .super-menu > li:first-of-type {border-left-width: 1px;border-right-width: 0;}
 	html[dir="rtl"] .super-menu > li:last-of-type {border-left-width: 0;}}
+.super-menu.menu-floated {border-right-width: 1px;border-left-width: 1px;border-color: #5a4242;border-style: dotted;}
 body {background-color: red;}';
         self::assertSame($expected, $document->render());
     }
@@ -739,15 +741,6 @@ body {background-color: red;}';
         $document = self::parsedStructureForFile('selector-escapes', Settings::create()->withMultibyteSupport(true));
         $expected = '#\\# {color: red;}
 .col-sm-1\\/5 {width: 20%;}';
-        self::assertSame($expected, $document->render());
-
-        $document = self::parsedStructureForFile('invalid-selectors-2', Settings::create()->withMultibyteSupport(true));
-        $expected = '@media only screen and (max-width: 1215px) {.breadcrumb {padding-left: 10px;}
-	.super-menu > li:first-of-type {border-left-width: 0;}
-	.super-menu > li:last-of-type {border-right-width: 0;}
-	html[dir="rtl"] .super-menu > li:first-of-type {border-left-width: 1px;border-right-width: 0;}
-	html[dir="rtl"] .super-menu > li:last-of-type {border-left-width: 0;}}
-body {background-color: red;}';
         self::assertSame($expected, $document->render());
     }
 

--- a/tests/Unit/RuleSet/DeclarationBlockTest.php
+++ b/tests/Unit/RuleSet/DeclarationBlockTest.php
@@ -193,6 +193,45 @@ final class DeclarationBlockTest extends TestCase
     }
 
     /**
+     * @return array<non-empty-string, array{0: non-empty-string}>
+     */
+    public static function provideClosingBrace(): array
+    {
+        return [
+            'as is' => ['}'],
+            'with space before' => [' }'],
+            'with newline before' => ["\n}"],
+        ];
+    }
+
+    /**
+     * @return DataProvider<non-empty-string, array{0: non-empty-string, 1: non-empty-string}>
+     */
+    public static function provideInvalidSelectorAndClosingBrace(): DataProvider
+    {
+        return DataProvider::cross(self::provideInvalidSelector(), self::provideClosingBrace());
+    }
+
+    /**
+     * TODO: It's probably not the responsibility of `DeclarationBlock` to deal with this.
+     *
+     * @test
+     *
+     * @param non-empty-string $selector
+     * @param non-empty-string $closingBrace
+     *
+     * @dataProvider provideInvalidSelectorAndClosingBrace
+     */
+    public function parseConsumesClosingBraceAfterInvalidSelector(string $selector, string $closingBrace): void
+    {
+        $parserState = new ParserState($selector . $closingBrace, Settings::create());
+
+        DeclarationBlock::parse($parserState);
+
+        self::assertTrue($parserState->isEnd());
+    }
+
+    /**
      * @return array<string>
      */
     private static function getSelectorsAsStrings(DeclarationBlock $declarationBlock): array


### PR DESCRIPTION
(My IDE thinks that the test results now updated should be parsed as such.)

Also remove a duplicated test.