### PR TITLE
[BUGFIX] Skip erroneous `}` when parsing `CSSList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Please also have a look at our
 
 ### Fixed
 
-- Improve recovery parsing when a rogue `}` is encountered (#1425)
+- Improve recovery parsing when a rogue `}` is encountered (#1425, #1426)
 - Parse comment(s) immediately preceding a selector (#1421)
 - Parse consecutive comments (#1421)
 - Support attribute selectors with values containing commas in

--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -133,7 +133,8 @@ abstract class CSSList implements CSSElement, CSSListItem, Positionable
         } elseif ($parserState->comes('}')) {
             if ($isRoot) {
                 if ($parserState->getSettings()->usesLenientParsing()) {
-                    return DeclarationBlock::parse($parserState) ?? false;
+                    $parserState->consume(1);
+                    return self::parseListItem($parserState, $list);
                 } else {
                     throw new SourceException('Unopened {', $parserState->currentLine());
                 }


### PR DESCRIPTION
This allows parsing of the next item, if valid, rather than dropping it.