### PR TITLE
[TASK] Guard against infinite loop in `parseList`

### DIFF
--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -72,9 +72,15 @@ abstract class CSSList implements CSSElement, CSSListItem, Positionable
             $listItem = null;
             if ($usesLenientParsing) {
                 try {
+                    $positionBeforeParse = $parserState->currentColumn();
                     $listItem = self::parseListItem($parserState, $list);
                 } catch (UnexpectedTokenException $e) {
                     $listItem = false;
+                    // If the failed parsing did not consume anything that was to come ...
+                    if ($parserState->currentColumn() === $positionBeforeParse && !$parserState->isEnd()) {
+                        // ... the unexpected token needs to be skipped, otherwise there'll be an infinite loop.
+                        $parserState->consume(1);
+                    }
                 }
             } else {
                 $listItem = self::parseListItem($parserState, $list);

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -192,6 +192,10 @@ class ParserState
      *
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
+     *
+     * @phpstan-impure
+     * This method may change the state of the object by advancing the internal position;
+     * it does not simply 'get' a value.
      */
     public function consumeWhiteSpace(): array
     {


### PR DESCRIPTION
This can't be tested because there are currently no cases that would fail the test without the change.

It is there as a preventative double-lock measure to make sure any future code changes do not introduce an infinite loop.

It's a slight unoptimization,
as it adds what should be a redundant runtime check, but at miniscule performance cost versus the value of preventing a waste of CPU power and memory in the case that something goes wrong.