### PR TITLE
[TASK] Consume to EOF in `DeclarationBlock::parse()` upon failure

### DIFF
--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -75,7 +75,7 @@ class DeclarationBlock implements CSSElement, CSSListItem, Positionable, RuleCon
         } catch (UnexpectedTokenException $e) {
             if ($parserState->getSettings()->usesLenientParsing()) {
                 if (!$parserState->consumeIfComes('}')) {
-                    $parserState->consumeUntil('}', false, true);
+                    $parserState->consumeUntil(['}', ParserState::EOF], false, true);
                 }
                 return null;
             } else {

--- a/tests/Unit/RuleSet/DeclarationBlockTest.php
+++ b/tests/Unit/RuleSet/DeclarationBlockTest.php
@@ -232,6 +232,46 @@ final class DeclarationBlockTest extends TestCase
     }
 
     /**
+     * @return array<non-empty-string, array{0: string}>
+     */
+    public static function provideOptionalWhitespace(): array
+    {
+        return [
+            'none' => [''],
+            'space' => [' '],
+            'newline' => ["\n"],
+        ];
+    }
+
+    /**
+     * @return DataProvider<non-empty-string, array{0: non-empty-string, 1: string}>
+     */
+    public static function provideInvalidSelectorAndOptionalWhitespace(): DataProvider
+    {
+        return DataProvider::cross(self::provideInvalidSelector(), self::provideOptionalWhitespace());
+    }
+
+    /**
+     * TODO: It's probably not the responsibility of `DeclarationBlock` to deal with this.
+     *
+     * @test
+     *
+     * @param non-empty-string $selector
+     *
+     * @dataProvider provideInvalidSelectorAndOptionalWhitespace
+     */
+    public function parseConsumesToEofIfNoClosingBraceAfterInvalidSelector(
+        string $selector,
+        string $optionalWhitespace
+    ): void {
+        $parserState = new ParserState($selector . $optionalWhitespace, Settings::create());
+
+        DeclarationBlock::parse($parserState);
+
+        self::assertTrue($parserState->isEnd());
+    }
+
+    /**
      * @return array<string>
      */
     private static function getSelectorsAsStrings(DeclarationBlock $declarationBlock): array


### PR DESCRIPTION
This is not the right long-term fix - see #1430.

For now it is a sticking-plaster to help complete #1424.