### PR TITLE
[FEATURE] Convert legacy color notation to modern css 4 notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ Please also have a look at our
 
 ### Documentation
 
+## 9.2.0:
+
+### Added
+
+- Add use modern CSS color syntax option to `OutputFormat` (#1442)
+
 ## 9.1.0: Add support for PHP 8.5
 
 ### Added

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -21,6 +21,13 @@ final class OutputFormat
     private $usesRgbHashNotation = true;
 
     /**
+     * Output RGB colors in CSS 4 notation if possible
+     *
+     * @var bool
+     */
+    private $usesModernColorSyntax = false;
+
+    /**
      * Declaration format
      *
      * Semicolon after the last rule of a declaration block can be omitted. To do that, set this false.
@@ -216,6 +223,24 @@ final class OutputFormat
     public function setRGBHashNotation(bool $usesRgbHashNotation): self
     {
         $this->usesRgbHashNotation = $usesRgbHashNotation;
+
+        return $this;
+    }
+
+    /**
+     * @internal
+     */
+    public function usesModernColorSyntax(): bool
+    {
+        return $this->usesModernColorSyntax;
+    }
+
+    /**
+     * @return $this fluent interface
+     */
+    public function setUseModernColorSyntax(bool $usesModernColorSyntax): self
+    {
+        $this->usesModernColorSyntax = $usesModernColorSyntax;
 
         return $this;
     }

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -324,7 +324,10 @@ class Color extends CSSFunction
         foreach ($this->components as $key => $value) {
             if ($key === 'a') {
                 // Alpha can have units that don't match those of the RGB components in the "legacy" syntax.
-                // So it is not necessary to check it.  It's also always last, hence `break` rather than `continue`.
+                if ($value->getUnit() === '%' || is_float($value->getSize())) {
+                    $hasPercentage = true;
+                }
+
                 break;
             }
             if (!($value instanceof Size)) {

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -311,16 +311,12 @@ class Color extends CSSFunction
      */
     private function shouldRenderInModernSyntax(OutputFormat $outputFormat): bool
     {
-        if ($this->hasNoneAsComponentValue()) {
+        if ($this->hasNoneAsComponentValue() || $outputFormat->usesModernColorSyntax()) {
             return true;
         }
 
         if (!$this->colorFunctionMayHaveMixedValueTypes($this->getRealName())) {
             return false;
-        }
-
-        if ($outputFormat->usesModernColorSyntax()) {
-            return true;
         }
 
         $hasPercentage = false;

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -232,7 +232,7 @@ class Color extends CSSFunction
             return $this->renderAsHex();
         }
 
-        if ($this->shouldRenderInModernSyntax()) {
+        if ($this->shouldRenderInModernSyntax($outputFormat)) {
             return $this->renderInModernSyntax($outputFormat);
         }
 
@@ -309,7 +309,7 @@ class Color extends CSSFunction
      *     The same in the CSS Color Module Level 4 W3C Candidate Recommendation Draft
      *   } (as of 13 February 2024, at time of writing).
      */
-    private function shouldRenderInModernSyntax(): bool
+    private function shouldRenderInModernSyntax(OutputFormat $outputFormat): bool
     {
         if ($this->hasNoneAsComponentValue()) {
             return true;
@@ -317,6 +317,10 @@ class Color extends CSSFunction
 
         if (!$this->colorFunctionMayHaveMixedValueTypes($this->getRealName())) {
             return false;
+        }
+
+        if ($outputFormat->usesModernColorSyntax()) {
+            return true;
         }
 
         $hasPercentage = false;

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -324,7 +324,7 @@ class Color extends CSSFunction
         foreach ($this->components as $key => $value) {
             if ($key === 'a') {
                 // Alpha can have units that don't match those of the RGB components in the "legacy" syntax.
-                if ($value->getUnit() === '%' || is_float($value->getSize())) {
+                if ($value->getUnit() === '%' || \is_float($value->getSize())) {
                     $hasPercentage = true;
                 }
 

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -324,10 +324,7 @@ class Color extends CSSFunction
         foreach ($this->components as $key => $value) {
             if ($key === 'a') {
                 // Alpha can have units that don't match those of the RGB components in the "legacy" syntax.
-                if ($value->getUnit() === '%' || \is_float($value->getSize())) {
-                    $hasPercentage = true;
-                }
-
+                // So it is not necessary to check it.  It's also always last, hence `break` rather than `continue`.
                 break;
             }
             if (!($value instanceof Size)) {

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -385,6 +385,12 @@ class Color extends CSSFunction
             $arguments = $formatter->implode($separator, [$arguments, $alpha]);
         }
 
-        return $this->getName() . '(' . $arguments . ')';
+        $name = $this->getName();
+
+        if ($outputFormat->usesModernColorSyntax()) {
+            $name = str_replace('a', '', $name);
+        }
+
+        return $name . '(' . $arguments . ')';
     }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -155,7 +155,7 @@ final class ParserTest extends TestCase
             self::assertSame('red', $colorValue);
         }
         self::assertSame(
-            '#mine {color: red;border-color: #0a64e6;border-color: rgba(10,100,231,.3);outline-color: #222;'
+            '#mine {color: red;border-color: #0a64e6;border-color: rgba(10 100 231/.3);outline-color: #222;'
             . "background-color: #232323;}\n"
             . "#yours {background-color: hsl(220,10%,220%);background-color: hsla(220,10%,220%,.3);}\n"
             . '#variables {background-color: rgb(var(--some-rgb));background-color: rgb(var(--r),var(--g),var(--b));'
@@ -310,7 +310,7 @@ final class ParserTest extends TestCase
         self::assertSame(
             '#header {margin: 10px 2em 1cm 2%;font-family: Verdana,Helvetica,"Gill Sans",sans-serif;'
             . 'font-size: 10px;color: red !important;background-color: green;'
-            . 'background-color: rgba(0,128,0,.7);frequency: 30Hz;transform: rotate(1turn);}
+            . 'background-color: rgba(0 128 0/.7);frequency: 30Hz;transform: rotate(1turn);}
 body {color: green;font: 75% "Lucida Grande","Trebuchet MS",Verdana,sans-serif;}',
             $document->render()
         );
@@ -319,7 +319,7 @@ body {color: green;font: 75% "Lucida Grande","Trebuchet MS",Verdana,sans-serif;}
         }
         self::assertSame(
             '#header {margin: 10px 2em 1cm 2%;color: red !important;background-color: green;'
-            . 'background-color: rgba(0,128,0,.7);frequency: 30Hz;transform: rotate(1turn);}
+            . 'background-color: rgba(0 128 0/.7);frequency: 30Hz;transform: rotate(1turn);}
 body {color: green;}',
             $document->render()
         );
@@ -559,8 +559,8 @@ body {background-url: url("https://somesite.com/images/someimage.gif");}';
     public function hexAlphaInFile(): void
     {
         $document = self::parsedStructureForFile('hex-alpha', Settings::create()->withMultibyteSupport(true));
-        $expected = 'div {background: rgba(17,34,51,.27);}
-div {background: rgba(17,34,51,.27);}';
+        $expected = 'div {background: rgba(17 34 51/.27);}
+div {background: rgba(17 34 51/.27);}';
         self::assertSame($expected, $document->render());
     }
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -155,7 +155,7 @@ final class ParserTest extends TestCase
             self::assertSame('red', $colorValue);
         }
         self::assertSame(
-            '#mine {color: red;border-color: #0a64e6;border-color: rgba(10 100 231/.3);outline-color: #222;'
+            '#mine {color: red;border-color: #0a64e6;border-color: rgba(10,100,231,.3);outline-color: #222;'
             . "background-color: #232323;}\n"
             . "#yours {background-color: hsl(220,10%,220%);background-color: hsla(220,10%,220%,.3);}\n"
             . '#variables {background-color: rgb(var(--some-rgb));background-color: rgb(var(--r),var(--g),var(--b));'
@@ -310,7 +310,7 @@ final class ParserTest extends TestCase
         self::assertSame(
             '#header {margin: 10px 2em 1cm 2%;font-family: Verdana,Helvetica,"Gill Sans",sans-serif;'
             . 'font-size: 10px;color: red !important;background-color: green;'
-            . 'background-color: rgba(0 128 0/.7);frequency: 30Hz;transform: rotate(1turn);}
+            . 'background-color: rgba(0,128,0,.7);frequency: 30Hz;transform: rotate(1turn);}
 body {color: green;font: 75% "Lucida Grande","Trebuchet MS",Verdana,sans-serif;}',
             $document->render()
         );
@@ -319,7 +319,7 @@ body {color: green;font: 75% "Lucida Grande","Trebuchet MS",Verdana,sans-serif;}
         }
         self::assertSame(
             '#header {margin: 10px 2em 1cm 2%;color: red !important;background-color: green;'
-            . 'background-color: rgba(0 128 0/.7);frequency: 30Hz;transform: rotate(1turn);}
+            . 'background-color: rgba(0,128,0,.7);frequency: 30Hz;transform: rotate(1turn);}
 body {color: green;}',
             $document->render()
         );
@@ -559,8 +559,8 @@ body {background-url: url("https://somesite.com/images/someimage.gif");}';
     public function hexAlphaInFile(): void
     {
         $document = self::parsedStructureForFile('hex-alpha', Settings::create()->withMultibyteSupport(true));
-        $expected = 'div {background: rgba(17 34 51/.27);}
-div {background: rgba(17 34 51/.27);}';
+        $expected = 'div {background: rgba(17,34,51,.27);}
+div {background: rgba(17,34,51,.27);}';
         self::assertSame($expected, $document->render());
     }
 

--- a/tests/Unit/Value/ColorTest.php
+++ b/tests/Unit/Value/ColorTest.php
@@ -41,11 +41,11 @@ final class ColorTest extends TestCase
             ],
             '4-digit hex color (with alpha)' => [
                 '#0707',
-                'rgba(0,119,0,.47)',
+                'rgba(0 119 0/.47)',
             ],
             '8-digit hex color (with alpha)' => [
                 '#0077007F',
-                'rgba(0,119,0,.5)',
+                'rgba(0 119 0/.5)',
             ],
             'legacy rgb that can be represented as 3-digit hex' => [
                 'rgb(0, 119, 0)',
@@ -61,11 +61,11 @@ final class ColorTest extends TestCase
             ],
             'legacy rgba with fractional alpha' => [
                 'rgba(0, 119, 0, 0.5)',
-                'rgba(0,119,0,.5)',
+                'rgba(0 119 0/.5)',
             ],
             'legacy rgba with percentage alpha' => [
                 'rgba(0, 119, 0, 50%)',
-                'rgba(0,119,0,50%)',
+                'rgba(0 119 0/50%)',
             ],
             'legacy rgba with percentage components and fractional alpha' => [
                 'rgba(0%, 60%, 0%, 0.5)',
@@ -81,7 +81,7 @@ final class ColorTest extends TestCase
             ],
             'legacy rgba as rgb' => [
                 'rgb(0, 119, 0, 0.5)',
-                'rgba(0,119,0,.5)',
+                'rgba(0 119 0/.5)',
             ],
             'modern rgb' => [
                 'rgb(0 119 0)',
@@ -129,11 +129,11 @@ final class ColorTest extends TestCase
             ],
             'modern rgba with fractional alpha' => [
                 'rgb(0 119 0 / 0.5)',
-                'rgba(0,119,0,.5)',
+                'rgba(0 119 0/.5)',
             ],
             'modern rgba with percentage alpha' => [
                 'rgb(0 119 0 / 50%)',
-                'rgba(0,119,0,50%)',
+                'rgba(0 119 0/50%)',
             ],
             'modern rgba with percentage R' => [
                 'rgb(0% 119 0 / 0.5)',

--- a/tests/Unit/Value/ColorTest.php
+++ b/tests/Unit/Value/ColorTest.php
@@ -41,11 +41,11 @@ final class ColorTest extends TestCase
             ],
             '4-digit hex color (with alpha)' => [
                 '#0707',
-                'rgba(0 119 0/.47)',
+                'rgba(0,119,0,.47)',
             ],
             '8-digit hex color (with alpha)' => [
                 '#0077007F',
-                'rgba(0 119 0/.5)',
+                'rgba(0,119,0,.5)',
             ],
             'legacy rgb that can be represented as 3-digit hex' => [
                 'rgb(0, 119, 0)',
@@ -61,11 +61,11 @@ final class ColorTest extends TestCase
             ],
             'legacy rgba with fractional alpha' => [
                 'rgba(0, 119, 0, 0.5)',
-                'rgba(0 119 0/.5)',
+                'rgba(0,119,0,.5)',
             ],
             'legacy rgba with percentage alpha' => [
                 'rgba(0, 119, 0, 50%)',
-                'rgba(0 119 0/50%)',
+                'rgba(0,119,0,50%)',
             ],
             'legacy rgba with percentage components and fractional alpha' => [
                 'rgba(0%, 60%, 0%, 0.5)',
@@ -81,7 +81,7 @@ final class ColorTest extends TestCase
             ],
             'legacy rgba as rgb' => [
                 'rgb(0, 119, 0, 0.5)',
-                'rgba(0 119 0/.5)',
+                'rgba(0,119,0,.5)',
             ],
             'modern rgb' => [
                 'rgb(0 119 0)',
@@ -129,11 +129,11 @@ final class ColorTest extends TestCase
             ],
             'modern rgba with fractional alpha' => [
                 'rgb(0 119 0 / 0.5)',
-                'rgba(0 119 0/.5)',
+                'rgba(0,119,0,.5)',
             ],
             'modern rgba with percentage alpha' => [
                 'rgb(0 119 0 / 50%)',
-                'rgba(0 119 0/50%)',
+                'rgba(0,119,0,50%)',
             ],
             'modern rgba with percentage R' => [
                 'rgb(0% 119 0 / 0.5)',

--- a/tests/Unit/Value/ColorTest.php
+++ b/tests/Unit/Value/ColorTest.php
@@ -30,310 +30,387 @@ final class ColorTest extends TestCase
             '3-digit hex color' => [
                 '#070',
                 '#070',
+                '#070',
             ],
             '6-digit hex color that can be represented as 3-digit' => [
                 '#007700',
                 '#070',
+                '#070',
             ],
             '6-digit hex color that cannot be represented as 3-digit' => [
+                '#007600',
                 '#007600',
                 '#007600',
             ],
             '4-digit hex color (with alpha)' => [
                 '#0707',
                 'rgba(0,119,0,.47)',
+                'rgb(0 119 0/.47)',
             ],
             '8-digit hex color (with alpha)' => [
                 '#0077007F',
                 'rgba(0,119,0,.5)',
+                'rgb(0 119 0/.5)',
             ],
             'legacy rgb that can be represented as 3-digit hex' => [
                 'rgb(0, 119, 0)',
+                '#070',
                 '#070',
             ],
             'legacy rgb that cannot be represented as 3-digit hex' => [
                 'rgb(0, 118, 0)',
                 '#007600',
+                '#007600',
             ],
             'legacy rgb with percentage components' => [
                 'rgb(0%, 60%, 0%)',
                 'rgb(0%,60%,0%)',
+                'rgb(0% 60% 0%)',
             ],
             'legacy rgba with fractional alpha' => [
                 'rgba(0, 119, 0, 0.5)',
                 'rgba(0,119,0,.5)',
+                'rgb(0 119 0/.5)',
             ],
             'legacy rgba with percentage alpha' => [
                 'rgba(0, 119, 0, 50%)',
                 'rgba(0,119,0,50%)',
+                'rgb(0 119 0/50%)',
             ],
             'legacy rgba with percentage components and fractional alpha' => [
                 'rgba(0%, 60%, 0%, 0.5)',
                 'rgba(0%,60%,0%,.5)',
+                'rgb(0% 60% 0%/.5)',
             ],
             'legacy rgba with percentage components and percentage alpha' => [
                 'rgba(0%, 60%, 0%, 50%)',
                 'rgba(0%,60%,0%,50%)',
+                'rgb(0% 60% 0%/50%)',
             ],
             'legacy rgb as rgba' => [
                 'rgba(0, 119, 0)',
+                '#070',
                 '#070',
             ],
             'legacy rgba as rgb' => [
                 'rgb(0, 119, 0, 0.5)',
                 'rgba(0,119,0,.5)',
+                'rgb(0 119 0/.5)',
             ],
             'modern rgb' => [
                 'rgb(0 119 0)',
                 '#070',
+                '#070',
             ],
             'modern rgb with percentage R' => [
+                'rgb(0% 119 0)',
                 'rgb(0% 119 0)',
                 'rgb(0% 119 0)',
             ],
             'modern rgb with percentage G' => [
                 'rgb(0 60% 0)',
                 'rgb(0 60% 0)',
+                'rgb(0 60% 0)',
             ],
             'modern rgb with percentage B' => [
+                'rgb(0 119 0%)',
                 'rgb(0 119 0%)',
                 'rgb(0 119 0%)',
             ],
             'modern rgb with percentage R&G' => [
                 'rgb(0% 60% 0)',
                 'rgb(0% 60% 0)',
+                'rgb(0% 60% 0)',
             ],
             'modern rgb with percentage R&B' => [
+                'rgb(0% 119 0%)',
                 'rgb(0% 119 0%)',
                 'rgb(0% 119 0%)',
             ],
             'modern rgb with percentage G&B' => [
                 'rgb(0 60% 0%)',
                 'rgb(0 60% 0%)',
+                'rgb(0 60% 0%)',
             ],
             'modern rgb with percentage components' => [
                 'rgb(0% 60% 0%)',
                 'rgb(0%,60%,0%)',
+                'rgb(0% 60% 0%)',
             ],
             'modern rgb with none as red' => [
+                'rgb(none 119 0)',
                 'rgb(none 119 0)',
                 'rgb(none 119 0)',
             ],
             'modern rgb with none as green' => [
                 'rgb(0 none 0)',
                 'rgb(0 none 0)',
+                'rgb(0 none 0)',
             ],
             'modern rgb with none as blue' => [
+                'rgb(0 119 none)',
                 'rgb(0 119 none)',
                 'rgb(0 119 none)',
             ],
             'modern rgba with fractional alpha' => [
                 'rgb(0 119 0 / 0.5)',
                 'rgba(0,119,0,.5)',
+                'rgb(0 119 0/.5)',
             ],
             'modern rgba with percentage alpha' => [
-                'rgb(0 119 0 / 50%)',
+                'rgb(0 119 0/50%)',
                 'rgba(0,119,0,50%)',
+                'rgb(0 119 0/50%)',
             ],
             'modern rgba with percentage R' => [
                 'rgb(0% 119 0 / 0.5)',
                 'rgba(0% 119 0/.5)',
+                'rgb(0% 119 0/.5)',
             ],
             'modern rgba with percentage G' => [
                 'rgb(0 60% 0 / 0.5)',
                 'rgba(0 60% 0/.5)',
+                'rgb(0 60% 0/.5)',
             ],
             'modern rgba with percentage B' => [
                 'rgb(0 119 0% / 0.5)',
                 'rgba(0 119 0%/.5)',
+                'rgb(0 119 0%/.5)',
             ],
             'modern rgba with percentage RGB' => [
                 'rgb(0% 60% 0% / 0.5)',
                 'rgba(0%,60%,0%,.5)',
+                'rgb(0% 60% 0%/.5)',
             ],
             'modern rgba with percentage components' => [
                 'rgb(0% 60% 0% / 50%)',
                 'rgba(0%,60%,0%,50%)',
+                'rgb(0% 60% 0%/50%)',
             ],
             'modern rgba with none as alpha' => [
                 'rgb(0 119 0 / none)',
                 'rgba(0 119 0/none)',
+                'rgb(0 119 0/none)',
             ],
             'legacy rgb with var for R' => [
                 'rgb(var(--r), 119, 0)',
+                'rgb(var(--r),119,0)',
                 'rgb(var(--r),119,0)',
             ],
             'legacy rgb with var for G' => [
                 'rgb(0, var(--g), 0)',
                 'rgb(0,var(--g),0)',
+                'rgb(0,var(--g),0)',
             ],
             'legacy rgb with var for B' => [
                 'rgb(0, 119, var(--b))',
+                'rgb(0,119,var(--b))',
                 'rgb(0,119,var(--b))',
             ],
             'legacy rgb with var for RG' => [
                 'rgb(var(--rg), 0)',
                 'rgb(var(--rg),0)',
+                'rgb(var(--rg),0)',
             ],
             'legacy rgb with var for GB' => [
                 'rgb(0, var(--gb))',
+                'rgb(0,var(--gb))',
                 'rgb(0,var(--gb))',
             ],
             'legacy rgba with var for R' => [
                 'rgba(var(--r), 119, 0, 0.5)',
                 'rgba(var(--r),119,0,.5)',
+                'rgba(var(--r),119,0,.5)',
             ],
             'legacy rgba with var for G' => [
                 'rgba(0, var(--g), 0, 0.5)',
+                'rgba(0,var(--g),0,.5)',
                 'rgba(0,var(--g),0,.5)',
             ],
             'legacy rgba with var for B' => [
                 'rgb(0, 119, var(--b), 0.5)',
                 'rgb(0,119,var(--b),.5)',
+                'rgb(0,119,var(--b),.5)',
             ],
             'legacy rgba with var for A' => [
                 'rgba(0, 119, 0, var(--a))',
+                'rgba(0,119,0,var(--a))',
                 'rgba(0,119,0,var(--a))',
             ],
             'legacy rgba with var for RG' => [
                 'rgba(var(--rg), 0, 0.5)',
                 'rgba(var(--rg),0,.5)',
+                'rgba(var(--rg),0,.5)',
             ],
             'legacy rgba with var for GB' => [
                 'rgba(0, var(--gb), 0.5)',
+                'rgba(0,var(--gb),.5)',
                 'rgba(0,var(--gb),.5)',
             ],
             'legacy rgba with var for BA' => [
                 'rgba(0, 119, var(--ba))',
                 'rgba(0,119,var(--ba))',
+                'rgba(0,119,var(--ba))',
             ],
             'legacy rgba with var for RGB' => [
                 'rgba(var(--rgb), 0.5)',
+                'rgba(var(--rgb),.5)',
                 'rgba(var(--rgb),.5)',
             ],
             'legacy rgba with var for GBA' => [
                 'rgba(0, var(--gba))',
                 'rgba(0,var(--gba))',
+                'rgba(0,var(--gba))',
             ],
             'modern rgb with var for R' => [
                 'rgb(var(--r) 119 0)',
                 'rgb(var(--r),119,0)',
+                'rgb(var(--r) 119 0)',
             ],
             'modern rgb with var for G' => [
                 'rgb(0 var(--g) 0)',
                 'rgb(0,var(--g),0)',
+                'rgb(0 var(--g) 0)',
             ],
             'modern rgb with var for B' => [
                 'rgb(0 119 var(--b))',
                 'rgb(0,119,var(--b))',
+                'rgb(0 119 var(--b))',
             ],
             'modern rgb with var for RG' => [
                 'rgb(var(--rg) 0)',
                 'rgb(var(--rg),0)',
+                'rgb(var(--rg) 0)',
             ],
             'modern rgb with var for GB' => [
                 'rgb(0 var(--gb))',
                 'rgb(0,var(--gb))',
+                'rgb(0 var(--gb))',
             ],
             'modern rgba with var for R' => [
                 'rgba(var(--r) 119 0 / 0.5)',
                 'rgba(var(--r),119,0,.5)',
+                'rgb(var(--r) 119 0/.5)',
             ],
             'modern rgba with var for G' => [
                 'rgba(0 var(--g) 0 / 0.5)',
                 'rgba(0,var(--g),0,.5)',
+                'rgb(0 var(--g) 0/.5)',
             ],
             'modern rgba with var for B' => [
                 'rgba(0 119 var(--b) / 0.5)',
                 'rgba(0,119,var(--b),.5)',
+                'rgb(0 119 var(--b)/.5)',
             ],
             'modern rgba with var for A' => [
                 'rgba(0 119 0 / var(--a))',
                 'rgba(0,119,0,var(--a))',
+                'rgb(0 119 0/var(--a))',
             ],
             'modern rgba with var for RG' => [
                 'rgba(var(--rg) 0 / 0.5)',
                 'rgba(var(--rg),0,.5)',
+                'rgb(var(--rg) 0/.5)',
             ],
             'modern rgba with var for GB' => [
                 'rgba(0 var(--gb) / 0.5)',
                 'rgba(0,var(--gb),.5)',
+                'rgb(0 var(--gb)/.5)',
             ],
             'modern rgba with var for BA' => [
                 'rgba(0 119 var(--ba))',
                 'rgba(0,119,var(--ba))',
+                'rgb(0 119 var(--ba))',
             ],
             'modern rgba with var for RGB' => [
                 'rgba(var(--rgb) / 0.5)',
                 'rgba(var(--rgb),.5)',
+                'rgb(var(--rgb) /.5)',
             ],
             'modern rgba with var for GBA' => [
                 'rgba(0 var(--gba))',
                 'rgba(0,var(--gba))',
+                'rgb(0 var(--gba))',
             ],
             'rgba with var for RGBA' => [
                 'rgba(var(--rgba))',
                 'rgba(var(--rgba))',
+                'rgb(var(--rgba))',
             ],
             'legacy hsl' => [
                 'hsl(120, 100%, 25%)',
                 'hsl(120,100%,25%)',
+                'hsl(120 100% 25%)',
             ],
             'legacy hsl with deg' => [
                 'hsl(120deg, 100%, 25%)',
                 'hsl(120deg,100%,25%)',
+                'hsl(120deg 100% 25%)',
             ],
             'legacy hsl with grad' => [
                 'hsl(133grad, 100%, 25%)',
                 'hsl(133grad,100%,25%)',
+                'hsl(133grad 100% 25%)',
             ],
             'legacy hsl with rad' => [
                 'hsl(2.094rad, 100%, 25%)',
                 'hsl(2.094rad,100%,25%)',
+                'hsl(2.094rad 100% 25%)',
             ],
             'legacy hsl with turn' => [
                 'hsl(0.333turn, 100%, 25%)',
                 'hsl(.333turn,100%,25%)',
+                'hsl(.333turn 100% 25%)',
             ],
             'legacy hsla with fractional alpha' => [
                 'hsla(120, 100%, 25%, 0.5)',
                 'hsla(120,100%,25%,.5)',
+                'hsl(120 100% 25%/.5)',
             ],
             'legacy hsla with percentage alpha' => [
                 'hsla(120, 100%, 25%, 50%)',
                 'hsla(120,100%,25%,50%)',
+                'hsl(120 100% 25%/50%)',
             ],
             'legacy hsl as hsla' => [
                 'hsla(120, 100%, 25%)',
                 'hsl(120,100%,25%)',
+                'hsl(120 100% 25%)',
             ],
             'legacy hsla as hsl' => [
                 'hsl(120, 100%, 25%, 0.5)',
                 'hsla(120,100%,25%,.5)',
+                'hsl(120 100% 25%/.5)',
             ],
             'modern hsl' => [
                 'hsl(120 100% 25%)',
                 'hsl(120,100%,25%)',
+                'hsl(120 100% 25%)',
             ],
             'modern hsl with none as hue' => [
+                'hsl(none 100% 25%)',
                 'hsl(none 100% 25%)',
                 'hsl(none 100% 25%)',
             ],
             'modern hsl with none as saturation' => [
                 'hsl(120 none 25%)',
                 'hsl(120 none 25%)',
+                'hsl(120 none 25%)',
             ],
             'modern hsl with none as lightness' => [
+                'hsl(120 100% none)',
                 'hsl(120 100% none)',
                 'hsl(120 100% none)',
             ],
             'modern hsla' => [
                 'hsl(120 100% 25% / 0.5)',
                 'hsla(120,100%,25%,.5)',
+                'hsl(120 100% 25%/.5)',
             ],
             'modern hsla with none as alpha' => [
                 'hsl(120 100% 25% / none)',
                 'hsla(120 100% 25%/none)',
+                'hsl(120 100% 25%/none)',
             ],
         ];
     }
@@ -343,13 +420,16 @@ final class ColorTest extends TestCase
      *
      * @dataProvider provideValidColorAndExpectedRendering
      */
-    public function parsesAndRendersValidColor(string $color, string $expectedRendering): void
+    public function parsesAndRendersValidColor(string $color, string $expectedRendering, string $expectedModernRendering): void
     {
         $subject = Color::parse(new ParserState($color, Settings::create()));
+        $outputFormat = OutputFormat::create();
 
-        $renderedResult = $subject->render(OutputFormat::create());
+        self::assertSame($expectedRendering, $subject->render($outputFormat));
 
-        self::assertSame($expectedRendering, $renderedResult);
+        $outputFormat->setUseModernColorSyntax(true);
+
+        self::assertSame($expectedModernRendering, $subject->render($outputFormat));
     }
 
     /**


### PR DESCRIPTION
Hello guys, happy holidays :) Please don't review the PR until after the festivities, I'm just not that type of person.

This PR draft aims at converting the legacy color notation: `rgba(0,128,0,.7)` into the modern variant `rgba(0 128 0/.7)`.

I'm no css specialist so your feedback is going to be welcome.

There are no specific tests yet, and there are improvements that can be made, I just want to get your approval before I polish things up.

Question:
- should we also convert the `rgba` notation to `rgb`? my understanding is that `rgba` is deprecated. I also noticed that the current code does the opposite:

```css
a {
   color: rgb(0 0 0/50%);
}
```

into this:

```css
a {
   color: rgba(0 0 0/50%);
}
```
