### PR TITLE
[TASK] Add `getArrayRepresentation()` to `Renderable`

### DIFF
--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -436,6 +436,16 @@ abstract class CSSList implements CSSElement, CSSListItem, Positionable
     }
 
     /**
+     * @internal
+     *
+     * @return array<string, bool|int|float|string|list<array<string, mixed>>>
+     */
+    public function getArrayRepresentation(): array
+    {
+        throw new \BadMethodCallException('`getArrayRepresentation` is not yet implemented for `' . self::class . '`');
+    }
+
+    /**
      * @param list<Selector> $selectors1
      * @param list<Selector> $selectors2
      */

--- a/src/Comment/Comment.php
+++ b/src/Comment/Comment.php
@@ -46,4 +46,14 @@ class Comment implements Positionable, Renderable
     {
         return '/*' . $this->commentText . '*/';
     }
+
+    /**
+     * @internal
+     *
+     * @return array<string, bool|int|float|string|list<array<string, mixed>>>
+     */
+    public function getArrayRepresentation(): array
+    {
+        throw new \BadMethodCallException('`getArrayRepresentation` is not yet implemented for `' . self::class . '`');
+    }
 }

--- a/src/Property/CSSNamespace.php
+++ b/src/Property/CSSNamespace.php
@@ -94,4 +94,14 @@ class CSSNamespace implements AtRule, Positionable
         }
         return $result;
     }
+
+    /**
+     * @internal
+     *
+     * @return array<string, bool|int|float|string|list<array<string, mixed>>>
+     */
+    public function getArrayRepresentation(): array
+    {
+        throw new \BadMethodCallException('`getArrayRepresentation` is not yet implemented for `' . self::class . '`');
+    }
 }

--- a/src/Property/Charset.php
+++ b/src/Property/Charset.php
@@ -71,4 +71,14 @@ class Charset implements AtRule, Positionable
     {
         return $this->charset;
     }
+
+    /**
+     * @internal
+     *
+     * @return array<string, bool|int|float|string|list<array<string, mixed>>>
+     */
+    public function getArrayRepresentation(): array
+    {
+        throw new \BadMethodCallException('`getArrayRepresentation` is not yet implemented for `' . self::class . '`');
+    }
 }

--- a/src/Property/Import.php
+++ b/src/Property/Import.php
@@ -82,4 +82,14 @@ class Import implements AtRule, Positionable
     {
         return $this->mediaQuery;
     }
+
+    /**
+     * @internal
+     *
+     * @return array<string, bool|int|float|string|list<array<string, mixed>>>
+     */
+    public function getArrayRepresentation(): array
+    {
+        throw new \BadMethodCallException('`getArrayRepresentation` is not yet implemented for `' . self::class . '`');
+    }
 }

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -95,4 +95,14 @@ class Selector implements Renderable
     {
         return $this->getSelector();
     }
+
+    /**
+     * @internal
+     *
+     * @return array<string, bool|int|float|string|list<array<string, mixed>>>
+     */
+    public function getArrayRepresentation(): array
+    {
+        throw new \BadMethodCallException('`getArrayRepresentation` is not yet implemented for `' . self::class . '`');
+    }
 }

--- a/src/Renderable.php
+++ b/src/Renderable.php
@@ -7,4 +7,11 @@ namespace Sabberworm\CSS;
 interface Renderable
 {
     public function render(OutputFormat $outputFormat): string;
+
+    /**
+     * @internal
+     *
+     * @return array<string, bool|int|float|string|list<array<string, mixed>>>
+     */
+    public function getArrayRepresentation(): array;
 }

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -197,4 +197,14 @@ class Rule implements Commentable, CSSElement, Positionable
         $result .= ';';
         return $result;
     }
+
+    /**
+     * @internal
+     *
+     * @return array<string, bool|int|float|string|list<array<string, mixed>>>
+     */
+    public function getArrayRepresentation(): array
+    {
+        throw new \BadMethodCallException('`getArrayRepresentation` is not yet implemented for `' . self::class . '`');
+    }
 }

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -274,6 +274,16 @@ class DeclarationBlock implements CSSElement, CSSListItem, Positionable, RuleCon
     }
 
     /**
+     * @internal
+     *
+     * @return array<string, bool|int|float|string|list<array<string, mixed>>>
+     */
+    public function getArrayRepresentation(): array
+    {
+        throw new \BadMethodCallException('`getArrayRepresentation` is not yet implemented for `' . self::class . '`');
+    }
+
+    /**
      * @param list<Comment> $comments
      *
      * @return list<string>

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -332,6 +332,16 @@ class RuleSet implements CSSElement, CSSListItem, Positionable, RuleContainer
     }
 
     /**
+     * @internal
+     *
+     * @return array<string, bool|int|float|string|list<array<string, mixed>>>
+     */
+    public function getArrayRepresentation(): array
+    {
+        throw new \BadMethodCallException('`getArrayRepresentation` is not yet implemented for `' . self::class . '`');
+    }
+
+    /**
      * @return int negative if `$first` is before `$second`; zero if they have the same position; positive otherwise
      *
      * @throws \UnexpectedValueException if either argument does not have a valid position, which should never happen

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -182,6 +182,16 @@ abstract class Value implements CSSElement, Positionable
     }
 
     /**
+     * @internal
+     *
+     * @return array<string, bool|int|float|string|list<array<string, mixed>>>
+     */
+    public function getArrayRepresentation(): array
+    {
+        throw new \BadMethodCallException('`getArrayRepresentation` is not yet implemented for `' . self::class . '`');
+    }
+
+    /**
      * @throws UnexpectedEOFException
      * @throws UnexpectedTokenException
      */

--- a/tests/Unit/CSSList/CSSListTest.php
+++ b/tests/Unit/CSSList/CSSListTest.php
@@ -380,4 +380,16 @@ final class CSSListTest extends TestCase
 
         self::assertSame($followingContent, $subject->render(new OutputFormat()));
     }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationThrowsException(): void
+    {
+        $this->expectException(\BadMethodCallException::class);
+
+        $subject = new ConcreteCSSList();
+
+        $subject->getArrayRepresentation();
+    }
 }

--- a/tests/Unit/Comment/CommentTest.php
+++ b/tests/Unit/Comment/CommentTest.php
@@ -77,4 +77,16 @@ final class CommentTest extends TestCase
 
         self::assertSame($lineNumber, $subject->getLineNumber());
     }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationThrowsException(): void
+    {
+        $this->expectException(\BadMethodCallException::class);
+
+        $subject = new Comment();
+
+        $subject->getArrayRepresentation();
+    }
 }

--- a/tests/Unit/Property/CSSNamespaceTest.php
+++ b/tests/Unit/Property/CSSNamespaceTest.php
@@ -31,4 +31,14 @@ final class CSSNamespaceTest extends TestCase
     {
         self::assertInstanceOf(CSSListItem::class, $this->subject);
     }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationThrowsException(): void
+    {
+        $this->expectException(\BadMethodCallException::class);
+
+        $this->subject->getArrayRepresentation();
+    }
 }

--- a/tests/Unit/Property/CharsetTest.php
+++ b/tests/Unit/Property/CharsetTest.php
@@ -31,4 +31,14 @@ final class CharsetTest extends TestCase
     {
         self::assertInstanceOf(CSSListItem::class, $this->subject);
     }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationThrowsException(): void
+    {
+        $this->expectException(\BadMethodCallException::class);
+
+        $this->subject->getArrayRepresentation();
+    }
 }

--- a/tests/Unit/Property/ImportTest.php
+++ b/tests/Unit/Property/ImportTest.php
@@ -32,4 +32,14 @@ final class ImportTest extends TestCase
     {
         self::assertInstanceOf(CSSListItem::class, $this->subject);
     }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationThrowsException(): void
+    {
+        $this->expectException(\BadMethodCallException::class);
+
+        $this->subject->getArrayRepresentation();
+    }
 }

--- a/tests/Unit/Property/SelectorTest.php
+++ b/tests/Unit/Property/SelectorTest.php
@@ -188,4 +188,16 @@ final class SelectorTest extends TestCase
 
         self::assertSame('a[title="extra  space"]', $subject->getSelector());
     }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationThrowsException(): void
+    {
+        $this->expectException(\BadMethodCallException::class);
+
+        $subject = new Selector('a');
+
+        $subject->getArrayRepresentation();
+    }
 }

--- a/tests/Unit/Rule/RuleTest.php
+++ b/tests/Unit/Rule/RuleTest.php
@@ -70,4 +70,16 @@ final class RuleTest extends TestCase
 
         self::assertSame($expectedTypeClassnames, $actualClassnames);
     }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationThrowsException(): void
+    {
+        $this->expectException(\BadMethodCallException::class);
+
+        $subject = new Rule('todo');
+
+        $subject->getArrayRepresentation();
+    }
 }

--- a/tests/Unit/RuleSet/DeclarationBlockTest.php
+++ b/tests/Unit/RuleSet/DeclarationBlockTest.php
@@ -536,6 +536,16 @@ final class DeclarationBlockTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function getArrayRepresentationThrowsException(): void
+    {
+        $this->expectException(\BadMethodCallException::class);
+
+        $this->subject->getArrayRepresentation();
+    }
+
+    /**
      * @return list<string>
      */
     private static function getSelectorsAsStrings(DeclarationBlock $declarationBlock): array

--- a/tests/Unit/RuleSet/RuleSetTest.php
+++ b/tests/Unit/RuleSet/RuleSetTest.php
@@ -79,4 +79,14 @@ final class RuleSetTest extends TestCase
 
         self::assertSame($lineNumber, $result);
     }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationThrowsException(): void
+    {
+        $this->expectException(\BadMethodCallException::class);
+
+        $this->subject->getArrayRepresentation();
+    }
 }

--- a/tests/Unit/Value/ValueTest.php
+++ b/tests/Unit/Value/ValueTest.php
@@ -141,4 +141,16 @@ final class ValueTest extends TestCase
             $subject->render(OutputFormat::createCompact())
         );
     }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationThrowsException(): void
+    {
+        $this->expectException(\BadMethodCallException::class);
+
+        $subject = new ConcreteValue();
+
+        $subject->getArrayRepresentation();
+    }
 }


### PR DESCRIPTION
This method will make it easier to test the parsing independently of the rendering.

Placeholder implementations are currently all stubs that will throw an exception, confirmed by tests.
They can be implemented as and when required, with the tests updated.

Part of #1440.