### PR TITLE
[TASK] Implement `getArrayRepresentation()` for `ValueList`

### DIFF
--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -113,4 +113,14 @@ class CSSFunction extends ValueList
         $arguments = parent::render($outputFormat);
         return "{$this->name}({$arguments})";
     }
+
+    /**
+     * @return array<string, bool|int|float|string|list<array<string, mixed>>>
+     *
+     * @internal
+     */
+    public function getArrayRepresentation(): array
+    {
+        throw new \BadMethodCallException('`getArrayRepresentation` is not yet implemented for `' . self::class . '`');
+    }
 }

--- a/src/Value/LineName.php
+++ b/src/Value/LineName.php
@@ -56,4 +56,14 @@ class LineName extends ValueList
     {
         return '[' . parent::render(OutputFormat::createCompact()) . ']';
     }
+
+    /**
+     * @return array<string, bool|int|float|string|list<array<string, mixed>>>
+     *
+     * @internal
+     */
+    public function getArrayRepresentation(): array
+    {
+        throw new \BadMethodCallException('`getArrayRepresentation` is not yet implemented for `' . self::class . '`');
+    }
 }

--- a/src/Value/RuleValueList.php
+++ b/src/Value/RuleValueList.php
@@ -19,4 +19,14 @@ class RuleValueList extends ValueList
     {
         parent::__construct([], $separator, $lineNumber);
     }
+
+    /**
+     * @return array<string, bool|int|float|string|list<array<string, mixed>>>
+     *
+     * @internal
+     */
+    public function getArrayRepresentation(): array
+    {
+        throw new \BadMethodCallException('`getArrayRepresentation` is not yet implemented for `' . self::class . '`');
+    }
 }

--- a/src/Value/ValueList.php
+++ b/src/Value/ValueList.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sabberworm\CSS\Value;
 
 use Sabberworm\CSS\OutputFormat;
+use Sabberworm\CSS\ShortClassNameProvider;
 
 /**
  * A `ValueList` represents a lists of `Value`s, separated by some separation character
@@ -14,6 +15,8 @@ use Sabberworm\CSS\OutputFormat;
  */
 abstract class ValueList extends Value
 {
+    use ShortClassNameProvider;
+
     /**
      * @var array<Value|string>
      *
@@ -92,5 +95,30 @@ abstract class ValueList extends Value
             . $formatter->spaceAfterListArgumentSeparator($this->separator),
             $this->components
         );
+    }
+
+    /**
+     * @return array<string, bool|int|float|string|list<array<string, mixed>>>
+     *
+     * @internal
+     */
+    public function getArrayRepresentation(): array
+    {
+        return [
+            'class' => $this->getShortClassName(),
+            'components' => \array_map(
+                /**
+                 * @parm Value|string $component
+                 */
+                function ($component): array {
+                    if (\is_string($component)) {
+                        return ['class' => 'string', 'value' => $component];
+                    }
+                    return $component->getArrayRepresentation();
+                },
+                $this->components
+            ),
+            'separator' => $this->separator,
+        ];
     }
 }

--- a/tests/Unit/Value/Fixtures/ConcreteValueList.php
+++ b/tests/Unit/Value/Fixtures/ConcreteValueList.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabberworm\CSS\Tests\Unit\Value\Fixtures;
+
+use Sabberworm\CSS\Value\ValueList;
+
+final class ConcreteValueList extends ValueList {}

--- a/tests/Unit/Value/ValueListTest.php
+++ b/tests/Unit/Value/ValueListTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabberworm\CSS\Tests\Unit\Value;
+
+use PHPUnit\Framework\TestCase;
+use Sabberworm\CSS\Tests\Unit\Value\Fixtures\ConcreteValueList;
+use Sabberworm\CSS\Value\Size;
+
+/**
+ * @covers \Sabberworm\CSS\Value\ValueList
+ */
+final class ValueListTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function getArrayRepresentationIncludesClassName(): void
+    {
+        $subject = new ConcreteValueList();
+
+        $result = $subject->getArrayRepresentation();
+
+        self::assertArrayHasKey('class', $result);
+        self::assertSame('ConcreteValueList', $result['class']);
+    }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationIncludesStringComponent(): void
+    {
+        $subject = new ConcreteValueList(['Helvetica']);
+
+        $result = $subject->getArrayRepresentation();
+
+        self::assertArrayHasKey('components', $result);
+        self::assertIsArray($result['components']);
+        self::assertArrayHasKey(0, $result['components']);
+        self::assertArrayHasKey('value', $result['components'][0]);
+        self::assertSame('Helvetica', $result['components'][0]['value']);
+    }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationIncludesValueComponent(): void
+    {
+        $subject = new ConcreteValueList([new Size(1)]);
+
+        $result = $subject->getArrayRepresentation();
+
+        self::assertArrayHasKey('components', $result);
+        self::assertIsArray($result['components']);
+        self::assertArrayHasKey(0, $result['components']);
+        self::assertArrayHasKey('class', $result['components'][0]);
+        self::assertSame('Size', $result['components'][0]['class']);
+    }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationIncludesMultipleMixedComponents(): void
+    {
+        $subject = new ConcreteValueList([new Size(1), '+', new Size(2)]);
+
+        $result = $subject->getArrayRepresentation();
+
+        self::assertArrayHasKey('components', $result);
+        self::assertIsArray($result['components']);
+
+        self::assertArrayHasKey(0, $result['components']);
+        self::assertArrayHasKey('class', $result['components'][0]);
+        self::assertSame('Size', $result['components'][0]['class']);
+
+        self::assertArrayHasKey(1, $result['components']);
+        self::assertArrayHasKey('value', $result['components'][1]);
+        self::assertSame('+', $result['components'][1]['value']);
+
+        self::assertArrayHasKey(2, $result['components']);
+        self::assertArrayHasKey('class', $result['components'][2]);
+        self::assertSame('Size', $result['components'][2]['class']);
+    }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationIncludesSeparator(): void
+    {
+        $subject = new ConcreteValueList();
+
+        $result = $subject->getArrayRepresentation();
+
+        self::assertArrayHasKey('separator', $result);
+        self::assertSame(',', $result['separator']);
+    }
+}


### PR DESCRIPTION
Note that `ValueList` is an abstract class.  The implementation can be reused by the concrete subclasses.  In the case of `LineName` and `RuleValueList` it can be inherited as is, because they don't have any additional properties. `CSSFunction` will need to add the `name` property.

For now, exception-throwing stubs are added to the subclasses, pending implementation on a case-by-case basis.

Part of #1440.