### PR TITLE
[TASK] Implement `RuleValueList::getArrayRepresentation()`

### DIFF
--- a/src/Value/CalcRuleValueList.php
+++ b/src/Value/CalcRuleValueList.php
@@ -20,4 +20,14 @@ class CalcRuleValueList extends RuleValueList
     {
         return $outputFormat->getFormatter()->implode(' ', $this->components);
     }
+
+    /**
+     * @return array<string, bool|int|float|string|list<array<string, mixed>>>
+     *
+     * @internal
+     */
+    public function getArrayRepresentation(): array
+    {
+        throw new \BadMethodCallException('`getArrayRepresentation` is not yet implemented for `' . self::class . '`');
+    }
 }

--- a/src/Value/RuleValueList.php
+++ b/src/Value/RuleValueList.php
@@ -19,14 +19,4 @@ class RuleValueList extends ValueList
     {
         parent::__construct([], $separator, $lineNumber);
     }
-
-    /**
-     * @return array<string, bool|int|float|string|list<array<string, mixed>>>
-     *
-     * @internal
-     */
-    public function getArrayRepresentation(): array
-    {
-        throw new \BadMethodCallException('`getArrayRepresentation` is not yet implemented for `' . self::class . '`');
-    }
 }

--- a/tests/Unit/Value/RuleValueListTest.php
+++ b/tests/Unit/Value/RuleValueListTest.php
@@ -17,12 +17,13 @@ final class RuleValueListTest extends TestCase
     /**
      * @test
      */
-    public function getArrayRepresentationThrowsException(): void
+    public function getArrayRepresentationIncludesClassName(): void
     {
-        $this->expectException(\BadMethodCallException::class);
-
         $subject = new RuleValueList();
 
-        $subject->getArrayRepresentation();
+        $result = $subject->getArrayRepresentation();
+
+        self::assertArrayHasKey('class', $result);
+        self::assertSame('RuleValueList', $result['class']);
     }
 }


### PR DESCRIPTION
The class has no additional properties, so this is a simple case of removing the stub method so it inherits its parent implementation, and adding a test.

A stub exception-throwing method is added (pushed down the chain) to the subclass `CalcRuleValueList` pending implementation.