### PR TITLE
[TASK] Add `Selector::parse()`

### DIFF
--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -133,6 +133,12 @@ class Selector implements Renderable
                         break 2;
                     }
                     break;
+                default:
+                    // This will never happen unless something gets broken in `ParserState`.
+                    throw new \UnexpectedValueException(
+                        'Unexpected character \'' . $nextCharacter
+                        . '\' returned from `ParserState::peek()` in `Selector::parse()`'
+                    );
             }
             $selectorParts[] = $parserState->consume(1);
         }

--- a/tests/Unit/Property/SelectorTest.php
+++ b/tests/Unit/Property/SelectorTest.php
@@ -226,7 +226,6 @@ final class SelectorTest extends TestCase
         $result = [];
         Selector::parse(new ParserState($selector, Settings::create()), $result);
 
-        self::assertArrayHasKey(0, $result);
         self::assertInstanceOf(Comment::class, $result[0]);
         self::assertSame('comment', $result[0]->getComment());
     }
@@ -250,10 +249,8 @@ final class SelectorTest extends TestCase
         $result = [];
         Selector::parse(new ParserState('/*comment1*/a/*comment2*/', Settings::create()), $result);
 
-        self::assertArrayHasKey(0, $result);
         self::assertInstanceOf(Comment::class, $result[0]);
         self::assertSame('comment1', $result[0]->getComment());
-        self::assertArrayHasKey(1, $result);
         self::assertInstanceOf(Comment::class, $result[1]);
         self::assertSame('comment2', $result[1]->getComment());
     }


### PR DESCRIPTION
The implementation is based on `DeclarationBlock::parseSelector()`, which will be updated to use this instead in #1470.

Part of #1325.