### PR TITLE
[CLEANUP] Simplify tests that use `getArrayRepresenation()`

### DIFF
--- a/tests/Unit/Comment/CommentTest.php
+++ b/tests/Unit/Comment/CommentTest.php
@@ -87,7 +87,6 @@ final class CommentTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('class', $result);
         self::assertSame('Comment', $result['class']);
     }
 
@@ -101,7 +100,6 @@ final class CommentTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('contents', $result);
         self::assertSame($contents, $result['contents']);
     }
 }

--- a/tests/Unit/Property/CharsetTest.php
+++ b/tests/Unit/Property/CharsetTest.php
@@ -39,7 +39,6 @@ final class CharsetTest extends TestCase
     {
         $result = $this->subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('class', $result);
         self::assertSame('Charset', $result['class']);
     }
 
@@ -53,7 +52,12 @@ final class CharsetTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('charset', $result);
-        self::assertSame(['class' => 'CSSString', 'contents' => $charset], $result['charset']);
+        self::assertSame(
+            [
+                'class' => 'CSSString',
+                'contents' => $charset,
+            ],
+            $result['charset']
+        );
     }
 }

--- a/tests/Unit/Value/CSSFunctionTest.php
+++ b/tests/Unit/Value/CSSFunctionTest.php
@@ -23,7 +23,6 @@ final class CSSFunctionTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('class', $result);
         self::assertSame('CSSFunction', $result['class']);
     }
 
@@ -36,7 +35,6 @@ final class CSSFunctionTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('name', $result);
         self::assertSame('filter', $result['name']);
     }
 }

--- a/tests/Unit/Value/CSSStringTest.php
+++ b/tests/Unit/Value/CSSStringTest.php
@@ -91,7 +91,6 @@ final class CSSStringTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('class', $result);
         self::assertSame('CSSString', $result['class']);
     }
 
@@ -105,7 +104,6 @@ final class CSSStringTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('contents', $result);
         self::assertSame($contents, $result['contents']);
     }
 

--- a/tests/Unit/Value/RuleValueListTest.php
+++ b/tests/Unit/Value/RuleValueListTest.php
@@ -23,7 +23,6 @@ final class RuleValueListTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('class', $result);
         self::assertSame('RuleValueList', $result['class']);
     }
 }

--- a/tests/Unit/Value/SizeTest.php
+++ b/tests/Unit/Value/SizeTest.php
@@ -108,7 +108,6 @@ final class SizeTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('class', $result);
         self::assertSame('Size', $result['class']);
     }
 
@@ -121,7 +120,6 @@ final class SizeTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('number', $result);
         self::assertSame(1.0, $result['number']);
     }
 
@@ -134,7 +132,6 @@ final class SizeTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('unit', $result);
         self::assertSame('px', $result['unit']);
     }
 }

--- a/tests/Unit/Value/URLTest.php
+++ b/tests/Unit/Value/URLTest.php
@@ -90,7 +90,6 @@ final class URLTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('class', $result);
         self::assertSame('URL', $result['class']);
     }
 
@@ -104,7 +103,12 @@ final class URLTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('uri', $result);
-        self::assertSame(['class' => 'CSSString', 'contents' => $uri], $result['uri']);
+        self::assertSame(
+            [
+                'class' => 'CSSString',
+                'contents' => $uri,
+            ],
+            $result['uri']
+        );
     }
 }

--- a/tests/Unit/Value/ValueListTest.php
+++ b/tests/Unit/Value/ValueListTest.php
@@ -22,7 +22,6 @@ final class ValueListTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('class', $result);
         self::assertSame('ConcreteValueList', $result['class']);
     }
 
@@ -35,10 +34,6 @@ final class ValueListTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('components', $result);
-        self::assertIsArray($result['components']);
-        self::assertArrayHasKey(0, $result['components']);
-        self::assertArrayHasKey('value', $result['components'][0]);
         self::assertSame('Helvetica', $result['components'][0]['value']);
     }
 
@@ -51,10 +46,6 @@ final class ValueListTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('components', $result);
-        self::assertIsArray($result['components']);
-        self::assertArrayHasKey(0, $result['components']);
-        self::assertArrayHasKey('class', $result['components'][0]);
         self::assertSame('Size', $result['components'][0]['class']);
     }
 
@@ -67,19 +58,8 @@ final class ValueListTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('components', $result);
-        self::assertIsArray($result['components']);
-
-        self::assertArrayHasKey(0, $result['components']);
-        self::assertArrayHasKey('class', $result['components'][0]);
         self::assertSame('Size', $result['components'][0]['class']);
-
-        self::assertArrayHasKey(1, $result['components']);
-        self::assertArrayHasKey('value', $result['components'][1]);
         self::assertSame('+', $result['components'][1]['value']);
-
-        self::assertArrayHasKey(2, $result['components']);
-        self::assertArrayHasKey('class', $result['components'][2]);
         self::assertSame('Size', $result['components'][2]['class']);
     }
 
@@ -92,7 +72,6 @@ final class ValueListTest extends TestCase
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertArrayHasKey('separator', $result);
         self::assertSame(',', $result['separator']);
     }
 }


### PR DESCRIPTION
We don't need to check for `arrayKeyExists` as PHPUnit will warn anyway if the code tries to access an array element that does not exist.