### PR TITLE
[TASK] Implement `Value::getArrayRepresentation()`

### DIFF
--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -11,6 +11,7 @@ use Sabberworm\CSS\Parsing\UnexpectedEOFException;
 use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 use Sabberworm\CSS\Position\Position;
 use Sabberworm\CSS\Position\Positionable;
+use Sabberworm\CSS\ShortClassNameProvider;
 
 use function Safe\preg_match;
 
@@ -21,6 +22,7 @@ use function Safe\preg_match;
 abstract class Value implements CSSElement, Positionable
 {
     use Position;
+    use ShortClassNameProvider;
 
     /**
      * @param int<1, max>|null $lineNumber
@@ -188,9 +190,9 @@ abstract class Value implements CSSElement, Positionable
      */
     public function getArrayRepresentation(): array
     {
-        throw new \BadMethodCallException(
-            '`getArrayRepresentation` is not yet implemented for `' . static::class . '`'
-        );
+        return [
+            'class' => $this->getShortClassName(),
+        ];
     }
 
     /**

--- a/tests/Unit/Value/ValueTest.php
+++ b/tests/Unit/Value/ValueTest.php
@@ -179,12 +179,12 @@ final class ValueTest extends TestCase
     /**
      * @test
      */
-    public function getArrayRepresentationThrowsException(): void
+    public function getArrayRepresentationIncludesClassName(): void
     {
-        $this->expectException(\BadMethodCallException::class);
-
         $subject = new ConcreteValue();
 
-        $subject->getArrayRepresentation();
+        $result = $subject->getArrayRepresentation();
+
+        self::assertSame('ConcreteValue', $result['class']);
     }
 }


### PR DESCRIPTION
This implementation might get removed if all subclasses have their own implementation without needing the parent class implementation.

Part of #1440.