### PR TITLE
[TASK] Rename `SelectorComponent` to `Component`

### DIFF
--- a/src/Property/Selector/Component.php
+++ b/src/Property/Selector/Component.php
@@ -20,7 +20,7 @@ namespace Sabberworm\CSS\Property\Selector;
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Selectors/Selector_structure
  * @see https://www.w3.org/TR/selectors-4/#structure
  */
-interface SelectorComponent
+interface Component
 {
     /**
      * @return non-empty-string


### PR DESCRIPTION
It's already in the `Selector` namespace, so having 'Selector' in the name is redundant.