### PR TITLE
[CLEANUP] Combine some test methods in `SelectorTest`

### DIFF
--- a/tests/Unit/Property/SelectorTest.php
+++ b/tests/Unit/Property/SelectorTest.php
@@ -84,6 +84,7 @@ final class SelectorTest extends TestCase
      * @param non-empty-string $selector
      *
      * @dataProvider provideSelectorsAndSpecificities
+     * @dataProvider provideSelectorsWithEscapedQuotes
      */
     public function parsesValidSelector(string $selector): void
     {
@@ -295,6 +296,7 @@ final class SelectorTest extends TestCase
      * @test
      *
      * @dataProvider provideSelectorsAndSpecificities
+     * @dataProvider provideSelectorsWithEscapedQuotes
      */
     public function isValidForValidSelectorReturnsTrue(string $selector): void
     {
@@ -386,33 +388,6 @@ final class SelectorTest extends TestCase
             'escaped backslash before escaped quote' => ['a[data-test="test\\\\\\"value"]'],
             'triple backslash before quote' => ['a[data-test="test\\\\\\""]'],
         ];
-    }
-
-    /**
-     * @test
-     *
-     * @param non-empty-string $selector
-     *
-     * @dataProvider provideSelectorsWithEscapedQuotes
-     */
-    public function parsesSelectorsWithEscapedQuotes(string $selector): void
-    {
-        $result = Selector::parse(new ParserState($selector, Settings::create()));
-
-        self::assertInstanceOf(Selector::class, $result);
-        self::assertSame($selector, $result->getSelector());
-    }
-
-    /**
-     * @test
-     *
-     * @param non-empty-string $selector
-     *
-     * @dataProvider provideSelectorsWithEscapedQuotes
-     */
-    public function isValidForSelectorsWithEscapedQuotesReturnsTrue(string $selector): void
-    {
-        self::assertTrue(Selector::isValid($selector));
     }
 
     /**


### PR DESCRIPTION
Multiple data providers can be specified for a test method which does exactly the same thing as another, to avoid having the 'another'.