### PR TITLE
[CLEANUP] Correct assert argument order in `SelectorTest`

### DIFF
--- a/tests/Unit/Property/SelectorTest.php
+++ b/tests/Unit/Property/SelectorTest.php
@@ -90,7 +90,7 @@ final class SelectorTest extends TestCase
         $result = Selector::parse(new ParserState($selector, Settings::create()));
 
         self::assertInstanceOf(Selector::class, $result);
-        self::assertSame($result->getSelector(), $selector);
+        self::assertSame($selector, $result->getSelector());
     }
 
     /**


### PR DESCRIPTION
The first parameter is `$expected`, the second `$actual`.