### PR TITLE
[TASK] Have `Selector\Component` extend `Renderable`

### DIFF
--- a/src/Property/Selector/Combinator.php
+++ b/src/Property/Selector/Combinator.php
@@ -8,7 +8,6 @@ use Sabberworm\CSS\Comment\Comment;
 use Sabberworm\CSS\OutputFormat;
 use Sabberworm\CSS\Parsing\ParserState;
 use Sabberworm\CSS\Parsing\UnexpectedTokenException;
-use Sabberworm\CSS\Renderable;
 use Sabberworm\CSS\ShortClassNameProvider;
 
 /**
@@ -16,7 +15,7 @@ use Sabberworm\CSS\ShortClassNameProvider;
  *
  * @phpstan-type ValidCombinatorValue ' '|'>'|'+'|'~'
  */
-class Combinator implements Component, Renderable
+class Combinator implements Component
 {
     use ShortClassNameProvider;
 

--- a/src/Property/Selector/Component.php
+++ b/src/Property/Selector/Component.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sabberworm\CSS\Property\Selector;
 
+use Sabberworm\CSS\Renderable;
+
 /**
  * This interface is for a class that represents a part of a selector which is either a compound selector (or a simple
  * selector, which is effectively a compound selector without any compounding) or a selector combinator.
@@ -20,7 +22,7 @@ namespace Sabberworm\CSS\Property\Selector;
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Selectors/Selector_structure
  * @see https://www.w3.org/TR/selectors-4/#structure
  */
-interface Component
+interface Component extends Renderable
 {
     /**
      * @return non-empty-string

--- a/src/Property/Selector/CompoundSelector.php
+++ b/src/Property/Selector/CompoundSelector.php
@@ -8,7 +8,6 @@ use Sabberworm\CSS\Comment\Comment;
 use Sabberworm\CSS\OutputFormat;
 use Sabberworm\CSS\Parsing\ParserState;
 use Sabberworm\CSS\Parsing\UnexpectedTokenException;
-use Sabberworm\CSS\Renderable;
 use Sabberworm\CSS\ShortClassNameProvider;
 
 use function Safe\preg_match;
@@ -17,7 +16,7 @@ use function Safe\preg_match;
  * Class representing a CSS compound selector.
  * Selectors have to be split at combinators (space, `>`, `+`, `~`) before being passed to this class.
  */
-class CompoundSelector implements Renderable, Component
+class CompoundSelector implements Component
 {
     use ShortClassNameProvider;
 


### PR DESCRIPTION
This will allow the `render()` method to be called on `Selector\Component` objects without knowing their specific type.

Part of #1325.