### PR TITLE
[CLEANUP] Untighten a parameter definition in `SelectorTest`

### DIFF
--- a/tests/Unit/Property/SelectorTest.php
+++ b/tests/Unit/Property/SelectorTest.php
@@ -198,8 +198,6 @@ final class SelectorTest extends TestCase
     /**
      * @test
      *
-     * @param non-empty-string $selector
-     *
      * @dataProvider provideInvalidSelectors
      * @dataProvider provideInvalidSelectorsForParse
      */


### PR DESCRIPTION
One of the data providers includes an empty string in its provision, so `non-empty-string` is not appropriate.