### PR TITLE
[TASK] Throw exception upon invalid selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Please also have a look at our
 
 ### Changed
 
+- `Selector::setSelector()` and `Selector` constructor will now throw exception
+  upon provision of an invalid selectior (#1498)
 - Clean up extra whitespace in CSS selector (#1398)
 - The array keys passed to `DeclarationBlock::setSelectors()` are no longer
   preserved (#1407)

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -69,6 +69,9 @@ class Selector implements Renderable
         return $numberOfMatches === 1;
     }
 
+    /**
+     * @throws \UnexpectedValueException if the selector is not valid
+     */
     final public function __construct(string $selector)
     {
         $this->setSelector($selector);
@@ -152,8 +155,15 @@ class Selector implements Renderable
         return $this->selector;
     }
 
+    /**
+     * @throws \UnexpectedValueException if the selector is not valid
+     */
     public function setSelector(string $selector): void
     {
+        if (!self::isValid($selector)) {
+            throw new \UnexpectedValueException("Selector `$selector` is not valid.");
+        }
+
         $selector = \trim($selector);
 
         $hasAttribute = \strpos($selector, '[') !== false;

--- a/tests/Unit/Property/SelectorTest.php
+++ b/tests/Unit/Property/SelectorTest.php
@@ -317,6 +317,42 @@ final class SelectorTest extends TestCase
 
     /**
      * @test
+     */
+    public function canConstructObjectWithEmptyState(): void
+    {
+        $subject = new Selector('');
+
+        self::assertSame('', $subject->getSelector());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideInvalidSelectors
+     */
+    public function constructorThrowsExceptionWithInvalidSelector(string $selector): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+
+        new Selector($selector);
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideInvalidSelectors
+     */
+    public function setSelectorThrowsExceptionWithInvalidSelector(string $selector): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+
+        $subject = new Selector('a');
+
+        $subject->setSelector($selector);
+    }
+
+    /**
+     * @test
      *
      * @param non-empty-string $selector
      * @param int<0, max> $expectedSpecificity


### PR DESCRIPTION
... being passed to `Selector` via the constructor or `setSelector()`