### PR TITLE
[CLEANUP] Remove superfluous commented test in `SelectorTest`

### DIFF
--- a/tests/Unit/Property/SelectorTest.php
+++ b/tests/Unit/Property/SelectorTest.php
@@ -173,8 +173,6 @@ final class SelectorTest extends TestCase
             // 'dot only' => ['.'],
             'slash' => ['/'],
             'less-than sign' => ['<'],
-            // This is currently broken.
-            // 'whitespace only' => [" \t\n\r"],
         ];
     }
 


### PR DESCRIPTION
Rejecting whitespace-only selectors was fixed in #1502.