### PR TITLE
[TASK] Use `Property\Declaration` in `ValueTest` DocBlock references

### DIFF
--- a/tests/Functional/Value/ValueTest.php
+++ b/tests/Functional/Value/ValueTest.php
@@ -19,7 +19,7 @@ final class ValueTest extends TestCase
     /**
      * the default set of delimiters for parsing most values
      *
-     * @see \Sabberworm\CSS\Rule\Rule::getDelimitersForPropertyValue
+     * @see \Sabberworm\CSS\Property\Declaration::getDelimitersForPropertyValue
      */
     private const DEFAULT_DELIMITERS = [',', ' ', '/'];
 

--- a/tests/Unit/Value/ValueTest.php
+++ b/tests/Unit/Value/ValueTest.php
@@ -21,7 +21,7 @@ final class ValueTest extends TestCase
     /**
      * the default set of delimiters for parsing most values
      *
-     * @see \Sabberworm\CSS\Rule\Rule::getDelimitersForPropertyValue
+     * @see \Sabberworm\CSS\Property\Declaration::getDelimitersForPropertyValue
      */
     private const DEFAULT_DELIMITERS = [',', ' ', '/'];
 


### PR DESCRIPTION
This replaces `Rule\Rule`, following #1508.