### PR TITLE
[TASK] Use `Declaration::getPropertyName()` in `RuleSet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Please also have a look at our
 - `Rule\Rule` class is deprecated; `Property\Declaration` is a direct
   replacement (#1508)
 - `Rule::setRule()` and `getRule()` are deprecated and replaced with
-  `setPropertyName()` and `getPropertyName()` (#1506)
+  `setPropertyName()` and `getPropertyName()` (#1506, #1519)
 
 ### Removed
 

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -101,7 +101,7 @@ class RuleSet implements CSSElement, CSSListItem, Positionable, RuleContainer
      */
     public function addRule(Declaration $declarationToAdd, ?Declaration $sibling = null): void
     {
-        $propertyName = $declarationToAdd->getRule();
+        $propertyName = $declarationToAdd->getPropertyName();
         if (!isset($this->declarations[$propertyName])) {
             $this->declarations[$propertyName] = [];
         }
@@ -240,7 +240,7 @@ class RuleSet implements CSSElement, CSSListItem, Positionable, RuleContainer
         /** @var array<string, Declaration> $result */
         $result = [];
         foreach ($this->getRules($searchPattern) as $declaration) {
-            $result[$declaration->getRule()] = $declaration;
+            $result[$declaration->getPropertyName()] = $declaration;
         }
 
         return $result;
@@ -251,7 +251,7 @@ class RuleSet implements CSSElement, CSSListItem, Positionable, RuleContainer
      */
     public function removeRule(Declaration $declarationToRemove): void
     {
-        $nameOfPropertyToRemove = $declarationToRemove->getRule();
+        $nameOfPropertyToRemove = $declarationToRemove->getPropertyName();
         if (!isset($this->declarations[$nameOfPropertyToRemove])) {
             return;
         }


### PR DESCRIPTION
This method replaces `getRule()`, which is deprecated as of #1506.