### PR TITLE
[TASK] Update DocBlock for `RuleContainer` to refer to `Declaration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ Please also have a look at our
 
 ### Changed
 
-- `Rule\Rule` class is renamed to `Property\Declaration` (#1508, #1512, #1513)
+- `Rule\Rule` class is renamed to `Property\Declaration`
+  (#1508, #1512, #1513, #1522)
 - `Rule::setRule()` and `getRule()` are replaced with `setPropertyName()` and
   `getPropertyName()` (#1506)
 - `Selector` is now represented as a sequence of `Selector\Component` objects

--- a/src/RuleSet/RuleContainer.php
+++ b/src/RuleSet/RuleContainer.php
@@ -7,7 +7,7 @@ namespace Sabberworm\CSS\RuleSet;
 use Sabberworm\CSS\Property\Declaration;
 
 /**
- * Represents a CSS item that contains `Rules`, defining the methods to manipulate them.
+ * Represents a CSS item that contains `Declaration`s, defining the methods to manipulate them.
  */
 interface RuleContainer
 {


### PR DESCRIPTION
`Rule\Rule` was replaced with `Property\Declaration` in #1508.