### PR TITLE
[CLEANUP] Correct the DocBlock for `RuleSet`

### DIFF
--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -21,8 +21,8 @@ use Sabberworm\CSS\Property\Declaration;
  * The most common form of a rule set is one constrained by a selector, i.e., a `DeclarationBlock`.
  * However, unknown `AtRule`s (like `@font-face`) are rule sets as well.
  *
- * If you want to manipulate a `RuleSet`, use the methods `addRule()`, `getRules()` and `removeRule()`
- * (which accepts either a `Declaration` or a rule name; optionally suffixed by a dash to remove all related rules).
+ * If you want to manipulate a `RuleSet`,
+ * use the methods `addRule()`, `getRules()`, `removeRule()`, `removeMatchingRules()`, etc.
  *
  * Note that `CSSListItem` extends both `Commentable` and `Renderable`, so those interfaces must also be implemented.
  */


### PR DESCRIPTION
`RemoveRule` was split up in #1249 to avoid parameter type overloading, but updating the class DocBlock was missed then.

The class DocBlock should not be describing what individual methods do, so that additional duplicated information has been removed. It exists in the DocBlock for the method.