### PR TITLE
[TASK] Rename `RuleContainer` to `DeclarationList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please also have a look at our
 
 ### Changed
 
+- `RuleSet\RuleContainer` is renamed to `RuleSet\DeclarationList` (#1530)
 - Methods like `setRule()` in `RuleSet` and `DeclarationBlock` have been renamed
   to `setDeclaration()`, etc. (#1521)
 - `Rule\Rule` class is renamed to `Property\Declaration`
@@ -35,6 +36,8 @@ Please also have a look at our
 
 ### Deprecated
 
+- `RuleSet\RuleContainer` is deprecated; use `RuleSet\DeclarationList` instead
+  (#1530)
 - Methods like `setRule()` in `RuleSet` and `DeclarationBlock` are deprecated;
   there are direct replacements such as `setDeclaration()` (#1521)
 - `Rule\Rule` class is deprecated; `Property\Declaration` is a direct

--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -17,6 +17,7 @@ parameters:
 
   bootstrapFiles:
     - %currentWorkingDirectory%/src/Rule/Rule.php
+    - %currentWorkingDirectory%/src/RuleSet/RuleContainer.php
 
   type_perfect:
     no_mixed_property: true

--- a/src/RuleSet/DeclarationList.php
+++ b/src/RuleSet/DeclarationList.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabberworm\CSS\RuleSet;
+
+use Sabberworm\CSS\Property\Declaration;
+
+/**
+ * Represents a CSS item that contains `Declaration`s, defining the methods to manipulate them.
+ */
+interface DeclarationList
+{
+    public function addDeclaration(Declaration $declarationToAdd, ?Declaration $sibling = null): void;
+
+    public function removeDeclaration(Declaration $declarationToRemove): void;
+
+    public function removeMatchingDeclarations(string $searchPattern): void;
+
+    public function removeAllDeclarations(): void;
+
+    /**
+     * @param array<Declaration> $declarations
+     */
+    public function setDeclarations(array $declarations): void;
+
+    /**
+     * @return array<int<0, max>, Declaration>
+     */
+    public function getDeclarations(?string $searchPattern = null): array;
+
+    /**
+     * @return array<string, Declaration>
+     */
+    public function getDeclarationsAssociative(?string $searchPattern = null): array;
+
+    /**
+     * @deprecated in v9.2, will be removed in v10.0; use `addDeclaration()` instead.
+     */
+    public function addRule(Declaration $declarationToAdd, ?Declaration $sibling = null): void;
+
+    /**
+     * @deprecated in v9.2, will be removed in v10.0; use `removeDeclaration()` instead.
+     */
+    public function removeRule(Declaration $declarationToRemove): void;
+
+    /**
+     * @deprecated in v9.2, will be removed in v10.0; use `removeMatchingDeclarations()` instead.
+     */
+    public function removeMatchingRules(string $searchPattern): void;
+
+    /**
+     * @deprecated in v9.2, will be removed in v10.0; use `removeAllDeclarations()` instead.
+     */
+    public function removeAllRules(): void;
+
+    /**
+     * @param array<Declaration> $declarations
+     *
+     * @deprecated in v9.2, will be removed in v10.0; use `setDeclarations()` instead.
+     */
+    public function setRules(array $declarations): void;
+
+    /**
+     * @return array<int<0, max>, Declaration>
+     *
+     * @deprecated in v9.2, will be removed in v10.0; use `getDeclarations()` instead.
+     */
+    public function getRules(?string $searchPattern = null): array;
+
+    /**
+     * @return array<string, Declaration>
+     *
+     * @deprecated in v9.2, will be removed in v10.0; use `getDeclarationsAssociative()` instead.
+     */
+    public function getRulesAssoc(?string $searchPattern = null): array;
+}

--- a/src/RuleSet/RuleContainer.php
+++ b/src/RuleSet/RuleContainer.php
@@ -4,74 +4,9 @@ declare(strict_types=1);
 
 namespace Sabberworm\CSS\RuleSet;
 
-use Sabberworm\CSS\Property\Declaration;
+use function Safe\class_alias;
 
 /**
- * Represents a CSS item that contains `Declaration`s, defining the methods to manipulate them.
+ * @deprecated in v9.2, will be removed in v10.0.  Use `DeclarationList` instead, which is a direct replacement.
  */
-interface RuleContainer
-{
-    public function addDeclaration(Declaration $declarationToAdd, ?Declaration $sibling = null): void;
-
-    public function removeDeclaration(Declaration $declarationToRemove): void;
-
-    public function removeMatchingDeclarations(string $searchPattern): void;
-
-    public function removeAllDeclarations(): void;
-
-    /**
-     * @param array<Declaration> $declarations
-     */
-    public function setDeclarations(array $declarations): void;
-
-    /**
-     * @return array<int<0, max>, Declaration>
-     */
-    public function getDeclarations(?string $searchPattern = null): array;
-
-    /**
-     * @return array<string, Declaration>
-     */
-    public function getDeclarationsAssociative(?string $searchPattern = null): array;
-
-    /**
-     * @deprecated in v9.2, will be removed in v10.0; use `addDeclaration()` instead.
-     */
-    public function addRule(Declaration $declarationToAdd, ?Declaration $sibling = null): void;
-
-    /**
-     * @deprecated in v9.2, will be removed in v10.0; use `removeDeclaration()` instead.
-     */
-    public function removeRule(Declaration $declarationToRemove): void;
-
-    /**
-     * @deprecated in v9.2, will be removed in v10.0; use `removeMatchingDeclarations()` instead.
-     */
-    public function removeMatchingRules(string $searchPattern): void;
-
-    /**
-     * @deprecated in v9.2, will be removed in v10.0; use `removeAllDeclarations()` instead.
-     */
-    public function removeAllRules(): void;
-
-    /**
-     * @param array<Declaration> $declarations
-     *
-     * @deprecated in v9.2, will be removed in v10.0; use `setDeclarations()` instead.
-     */
-    public function setRules(array $declarations): void;
-
-    /**
-     * @return array<int<0, max>, Declaration>
-     *
-     * @deprecated in v9.2, will be removed in v10.0; use `getDeclarations()` instead.
-     */
-    public function getRules(?string $searchPattern = null): array;
-
-    /**
-     * @return array<string, Declaration>
-     *
-     * @deprecated in v9.2, will be removed in v10.0; use `getDeclarationsAssociative()` instead.
-     */
-    public function getRulesAssoc(?string $searchPattern = null): array;
-}
+class_alias(DeclarationList::class, RuleContainer::class);


### PR DESCRIPTION
It contains property declarations not rules, and describing it as a 'list' rather than a 'container' seems more apt, as the declarations are ordered.

Changes to use the new interface name in the source code and tests will be submitted as follow-up PRs.