### PR TITLE
[BUGFIX] Parse attribute selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Please also have a look at our
   `getPropertyName()` (#1506)
 - `Selector` is now represented as a sequence of `Selector\Component` objects
   which can be accessed via `getComponents()`, manipulated individually, or set
-  via `setComponents()` (#1478, #1486, #1487, #1488, #1494, #1496)
+  via `setComponents()` (#1478, #1486, #1487, #1488, #1494, #1496, #1536)
 - `Selector::setSelector()` and `Selector` constructor will now throw exception
   upon provision of an invalid selectior (#1498, #1502)
 - Clean up extra whitespace in CSS selector (#1398)

--- a/tests/Unit/Property/Selector/CompoundSelectorTest.php
+++ b/tests/Unit/Property/Selector/CompoundSelectorTest.php
@@ -57,6 +57,17 @@ final class CompoundSelectorTest extends TestCase
             '`not` with multiple arguments' => [':not(#your-mug, .their-mug)', 110],
             'attribute with `"`' => ['[alt="{}()[]\\"\',"]', 10],
             'attribute with `\'`' => ['[alt=\'{}()[]"\\\',\']', 10],
+            // TODO, broken: specificity should be 11, but the calculator doesn't realize the `#` is in a string.
+            'attribute with `^=`' => ['a[href^="#"]', 111],
+            'attribute with `*=`' => ['a[href*="example"]', 11],
+            // TODO, broken: specificity should be 11, but the calculator doesn't realize the `.` is in a string.
+            'attribute with `$=`' => ['a[href$=".org"]', 21],
+            'attribute with `~=`' => ['span[title~="bonjour"]', 11],
+            'attribute with `|=`' => ['[lang|="en"]', 10],
+            // TODO, broken: specificity should be 11, but the calculator doesn't realize the `i` is in an attribute.
+            'attribute with case insensitive modifier' => ['a[href*="insensitive" i]', 12],
+            // TODO, broken: specificity should be 21, but the calculator doesn't realize the `.` is in a string.
+            'multiple attributes' => ['a[href^="https://"][href$=".org"]', 31],
         ];
     }
 
@@ -173,6 +184,8 @@ final class CompoundSelectorTest extends TestCase
             'attribute value missing closing double quote' => ['a[href="#top]'],
             'attribute value with mismatched quotes, single quote opening' => ['a[href=\'#top"]'],
             'attribute value with mismatched quotes, double quote opening' => ['a[href="#top\']'],
+            'attribute value with extra `[`' => ['a[[href="#top"]'],
+            'attribute value with extra `]`' => ['a[href="#top"]]'],
         ];
     }
 


### PR DESCRIPTION
Don't treat spaces or characters like `~` within them as a stop character representing a combinator.

The bug was introduced by #1496 and related changes that split selector representation and parsing into compound selectors and combinators.

Addresses some of the issues in #1533.