### PR TITLE
[TASK] Use `DeclarationList` in the source code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Please also have a look at our
 
 ### Changed
 
-- `RuleSet\RuleContainer` is renamed to `RuleSet\DeclarationList` (#1530)
+- `RuleSet\RuleContainer` is renamed to `RuleSet\DeclarationList` (#1530, #1539)
 - Methods like `setRule()` in `RuleSet` and `DeclarationBlock` have been renamed
   to `setDeclaration()`, etc. (#1521)
 - `Rule\Rule` class is renamed to `Property\Declaration`

--- a/src/CSSList/CSSBlockList.php
+++ b/src/CSSList/CSSBlockList.php
@@ -8,7 +8,7 @@ use Sabberworm\CSS\CSSElement;
 use Sabberworm\CSS\Property\Declaration;
 use Sabberworm\CSS\Property\Selector;
 use Sabberworm\CSS\RuleSet\DeclarationBlock;
-use Sabberworm\CSS\RuleSet\RuleContainer;
+use Sabberworm\CSS\RuleSet\DeclarationList;
 use Sabberworm\CSS\RuleSet\RuleSet;
 use Sabberworm\CSS\Value\CSSFunction;
 use Sabberworm\CSS\Value\Value;
@@ -98,7 +98,7 @@ abstract class CSSBlockList extends CSSList
                     );
                 }
             }
-        } elseif ($element instanceof RuleContainer) {
+        } elseif ($element instanceof DeclarationList) {
             foreach ($element->getRules($ruleSearchPattern) as $rule) {
                 $result = \array_merge(
                     $result,

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -32,10 +32,10 @@ use Sabberworm\CSS\Settings;
  *
  * Note that `CSSListItem` extends both `Commentable` and `Renderable`, so those interfaces must also be implemented.
  */
-class DeclarationBlock implements CSSElement, CSSListItem, Positionable, RuleContainer
+class DeclarationBlock implements CSSElement, CSSListItem, Positionable, DeclarationList
 {
     use CommentContainer;
-    use LegacyRuleContainerMethods;
+    use LegacyDeclarationListMethods;
     use Position;
 
     /**

--- a/src/RuleSet/LegacyDeclarationListMethods.php
+++ b/src/RuleSet/LegacyDeclarationListMethods.php
@@ -7,9 +7,9 @@ namespace Sabberworm\CSS\RuleSet;
 use Sabberworm\CSS\Property\Declaration;
 
 /**
- * Provides a mapping of the deprecated methods in a `RuleContainer` to their renamed replacements.
+ * Provides a mapping of the deprecated methods in a `DeclarationList` to their renamed replacements.
  */
-trait LegacyRuleContainerMethods
+trait LegacyDeclarationListMethods
 {
     /**
      * @deprecated in v9.2, will be removed in v10.0; use `addDeclaration()` instead.

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -26,10 +26,10 @@ use Sabberworm\CSS\Property\Declaration;
  *
  * Note that `CSSListItem` extends both `Commentable` and `Renderable`, so those interfaces must also be implemented.
  */
-class RuleSet implements CSSElement, CSSListItem, Positionable, RuleContainer
+class RuleSet implements CSSElement, CSSListItem, Positionable, DeclarationList
 {
     use CommentContainer;
-    use LegacyRuleContainerMethods;
+    use LegacyDeclarationListMethods;
     use Position;
 
     /**


### PR DESCRIPTION
The interface was renamed from `RuleContainer` in #1530.

Also rename the trait that transitionally provides a mapping for the methods deprecated in #1521 for the implementing classes.