### PR TITLE
[TASK] Use `DeclarationList` in the tests

### DIFF
--- a/tests/Unit/RuleSet/DeclarationBlockTest.php
+++ b/tests/Unit/RuleSet/DeclarationBlockTest.php
@@ -23,7 +23,7 @@ use TRegx\PhpUnit\DataProviders\DataProvider;
  */
 final class DeclarationBlockTest extends TestCase
 {
-    use RuleContainerTest;
+    use DeclarationListTest;
 
     /**
      * @var DeclarationBlock

--- a/tests/Unit/RuleSet/RuleSetTest.php
+++ b/tests/Unit/RuleSet/RuleSetTest.php
@@ -14,7 +14,7 @@ use Sabberworm\CSS\RuleSet\RuleSet;
  */
 final class RuleSetTest extends TestCase
 {
-    use RuleContainerTest;
+    use DeclarationListTest;
 
     /**
      * @var RuleSet

--- a/tests/unit/RuleSet/DeclarationListTest.php
+++ b/tests/unit/RuleSet/DeclarationListTest.php
@@ -6,24 +6,24 @@ namespace Sabberworm\CSS\Tests\Unit\RuleSet;
 
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\Property\Declaration;
-use Sabberworm\CSS\RuleSet\RuleContainer;
+use Sabberworm\CSS\RuleSet\DeclarationList;
 use TRegx\PhpUnit\DataProviders\DataProvider;
 
 /**
- * This trait provides test methods for unit-testing classes that implement `RuleContainer`.
+ * This trait provides test methods for unit-testing classes that implement `DeclarationList`.
  * It can be `use`d in a `TestCase` which has a `$subject` property that is an instance of the implementing class
  * (the class under test), `setUp()` with default values.
  *
  * @phpstan-require-extends TestCase
  */
-trait RuleContainerTest
+trait DeclarationListTest
 {
     /**
      * @test
      */
-    public function implementsRuleContainer(): void
+    public function implementsDeclarationList(): void
     {
-        self::assertInstanceOf(RuleContainer::class, $this->subject);
+        self::assertInstanceOf(DeclarationList::class, $this->subject);
     }
 
     /**


### PR DESCRIPTION
The interface was renamed from `RuleContainer` in #1530.

Also accordingly rename the trait that provides test methods for implementing classes.