### PR TITLE
[TASK] Use `DeclarationList` in the tests

### DIFF
--- a/tests/Unit/RuleSet/DeclarationBlockTest.php
+++ b/tests/Unit/RuleSet/DeclarationBlockTest.php
@@ -23,7 +23,7 @@ use TRegx\PhpUnit\DataProviders\DataProvider;
  */
 final class DeclarationBlockTest extends TestCase
 {
-    use DeclarationListTest;
+    use DeclarationListTests;
 
     /**
      * @var DeclarationBlock

--- a/tests/Unit/RuleSet/DeclarationListTests.php
+++ b/tests/Unit/RuleSet/DeclarationListTests.php
@@ -16,7 +16,7 @@ use TRegx\PhpUnit\DataProviders\DataProvider;
  *
  * @phpstan-require-extends TestCase
  */
-trait DeclarationListTest
+trait DeclarationListTests
 {
     /**
      * @test

--- a/tests/Unit/RuleSet/RuleSetTest.php
+++ b/tests/Unit/RuleSet/RuleSetTest.php
@@ -14,7 +14,7 @@ use Sabberworm\CSS\RuleSet\RuleSet;
  */
 final class RuleSetTest extends TestCase
 {
-    use DeclarationListTest;
+    use DeclarationListTests;
 
     /**
      * @var RuleSet


### PR DESCRIPTION
The interface was renamed from `RuleContainer` in #1530.

Also accordingly rename the trait that provides test methods for implementing classes.