### PR TITLE
[TASK] Specify the PHPStan errors to ignore for deprecation notices

### DIFF
--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -12,7 +12,7 @@ if (!\class_exists(Rule::class, false) && !\interface_exists(Rule::class, false)
     class_alias(Declaration::class, Rule::class);
     // The test is expected to evaluate to false,
     // but allows for the deprecation notice to be picked up by IDEs like PHPStorm.
-    // @phpstan-ignore-next-line booleanAnd.alwaysTrue
+    // @phpstan-ignore booleanNot.alwaysTrue, booleanNot.alwaysTrue, booleanAnd.alwaysTrue
     if (!\class_exists(Rule::class, false) && !\interface_exists(Rule::class, false)) {
         /**
          * @deprecated in v9.2, will be removed in v10.0.  Use `Property\Declaration` instead, which is a direct

--- a/src/RuleSet/RuleContainer.php
+++ b/src/RuleSet/RuleContainer.php
@@ -10,7 +10,7 @@ if (!\class_exists(RuleContainer::class, false) && !\interface_exists(RuleContai
     class_alias(DeclarationList::class, RuleContainer::class);
     // The test is expected to evaluate to false,
     // but allows for the deprecation notice to be picked up by IDEs like PHPStorm.
-    // @phpstan-ignore-next-line booleanAnd.alwaysTrue
+    // @phpstan-ignore booleanNot.alwaysTrue, booleanNot.alwaysTrue, booleanAnd.alwaysTrue
     if (!\class_exists(RuleContainer::class, false) && !\interface_exists(RuleContainer::class, false)) {
         /**
          * @deprecated in v9.2, will be removed in v10.0.  Use `DeclarationList` instead, which is a direct replacement.


### PR DESCRIPTION
Follow-up from #1559.

`phpstan-ignore-next-line` does not have parameters - it ignores all warnings on the next line regardless
(see https://github.com/phpstan/phpstan/issues/11340#issuecomment-3943559262).

`phpstan-ignore` applies to the next line, and has parameters to specify which warnings to ignore.
Because the `if` statement generates two `booleanNot.alwaysTrue` warnings, this needs to be specified twice in the argument list.