### PR TITLE
[TASK] Test `LineName::getArrayRepresentation()`

### DIFF
--- a/src/Value/LineName.php
+++ b/src/Value/LineName.php
@@ -62,14 +62,4 @@ class LineName extends ValueList
     {
         return '[' . parent::render(OutputFormat::createCompact()) . ']';
     }
-
-    /**
-     * @return array<string, bool|int|float|string|array<mixed>|null>
-     *
-     * @internal
-     */
-    public function getArrayRepresentation(): array
-    {
-        throw new \BadMethodCallException('`getArrayRepresentation` is not yet implemented for `' . self::class . '`');
-    }
 }

--- a/tests/Unit/Value/LineNameTest.php
+++ b/tests/Unit/Value/LineNameTest.php
@@ -6,6 +6,7 @@ namespace Sabberworm\CSS\Tests\Unit\Value;
 
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\Value\LineName;
+use Sabberworm\CSS\Value\Size;
 
 /**
  * @covers \Sabberworm\CSS\Value\LineName
@@ -17,12 +18,62 @@ final class LineNameTest extends TestCase
     /**
      * @test
      */
-    public function getArrayRepresentationThrowsException(): void
+    public function getArrayRepresentationIncludesClassName(): void
     {
-        $this->expectException(\BadMethodCallException::class);
-
         $subject = new LineName();
 
-        $subject->getArrayRepresentation();
+        $result = $subject->getArrayRepresentation();
+
+        self::assertSame('LineName', $result['class']);
+    }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationIncludesStringComponent(): void
+    {
+        $subject = new LineName(['Helvetica']);
+
+        $result = $subject->getArrayRepresentation();
+
+        self::assertSame('Helvetica', $result['components'][0]['value']);
+    }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationIncludesValueComponent(): void
+    {
+        $subject = new LineName([new Size(1)]);
+
+        $result = $subject->getArrayRepresentation();
+
+        self::assertSame('Size', $result['components'][0]['class']);
+    }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationIncludesMultipleMixedComponents(): void
+    {
+        $subject = new LineName([new Size(1), '+', new Size(2)]);
+
+        $result = $subject->getArrayRepresentation();
+
+        self::assertSame('Size', $result['components'][0]['class']);
+        self::assertSame('+', $result['components'][1]['value']);
+        self::assertSame('Size', $result['components'][2]['class']);
+    }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationIncludesSpaceSeparator(): void
+    {
+        $subject = new LineName();
+
+        $result = $subject->getArrayRepresentation();
+
+        self::assertSame(' ', $result['separator']);
     }
 }

--- a/tests/Unit/Value/LineNameTest.php
+++ b/tests/Unit/Value/LineNameTest.php
@@ -42,7 +42,7 @@ final class LineNameTest extends TestCase
     /**
      * @test
      */
-    public function getArrayRepresentationCanIncludesMultipleStringComponents(): void
+    public function getArrayRepresentationCanIncludeMultipleStringComponents(): void
     {
         $name1 = 'main-start';
         $name2 = 'main-end';

--- a/tests/Unit/Value/LineNameTest.php
+++ b/tests/Unit/Value/LineNameTest.php
@@ -6,7 +6,6 @@ namespace Sabberworm\CSS\Tests\Unit\Value;
 
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\Value\LineName;
-use Sabberworm\CSS\Value\Size;
 
 /**
  * @covers \Sabberworm\CSS\Value\LineName
@@ -30,40 +29,31 @@ final class LineNameTest extends TestCase
     /**
      * @test
      */
-    public function getArrayRepresentationIncludesStringComponent(): void
+    public function getArrayRepresentationCanIncludeOneStringComponent(): void
     {
-        $subject = new LineName(['Helvetica']);
+        $name = 'main-start';
+        $subject = new LineName([$name]);
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertSame('Helvetica', $result['components'][0]['value']);
+        self::assertSame($name, $result['components'][0]['value']);
     }
 
     /**
      * @test
      */
-    public function getArrayRepresentationIncludesValueComponent(): void
+    public function getArrayRepresentationCanIncludesMultipleStringComponents(): void
     {
-        $subject = new LineName([new Size(1)]);
+        $name1 = 'main-start';
+        $name2 = 'main-end';
+        $subject = new LineName([$name1, $name2]);
 
         $result = $subject->getArrayRepresentation();
 
-        self::assertSame('Size', $result['components'][0]['class']);
+        self::assertSame($name1, $result['components'][0]['value']);
+        self::assertSame($name2, $result['components'][1]['value']);
     }
 
-    /**
-     * @test
-     */
-    public function getArrayRepresentationIncludesMultipleMixedComponents(): void
-    {
-        $subject = new LineName([new Size(1), '+', new Size(2)]);
-
-        $result = $subject->getArrayRepresentation();
-
-        self::assertSame('Size', $result['components'][0]['class']);
-        self::assertSame('+', $result['components'][1]['value']);
-        self::assertSame('Size', $result['components'][2]['class']);
-    }
 
     /**
      * @test


### PR DESCRIPTION
The tests are basically the same as those for the parent class `ValueList`. The main difference is that the default separator now is a space, not a comma.

Part of #1440.