### PR TITLE
[TASK] Do not treat PHPDoc type information as certain

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -49,12 +49,6 @@ parameters:
 			path: ../../src/Value/Value.php
 
 		-
-			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertSame\(\) with ''red'' and Sabberworm\\CSS\\Value\\Value will always evaluate to false\.$#'
-			identifier: staticMethod.impossibleType
-			count: 1
-			path: ../../tests/ParserTest.php
-
-		-
 			message: '#^Parameter \#1 \$value of method Sabberworm\\CSS\\Property\\Declaration\:\:setValue\(\) expects Sabberworm\\CSS\\Value\\RuleValueList\|string\|null, Sabberworm\\CSS\\Value\\Size given\.$#'
 			identifier: argument.type
 			count: 3

--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -11,6 +11,8 @@ parameters:
     - %currentWorkingDirectory%/src/
     - %currentWorkingDirectory%/tests/
 
+  treatPhpDocTypesAsCertain: false
+
   type_perfect:
     no_mixed_property: true
     no_mixed_caller: true


### PR DESCRIPTION
This is a library. This means that we have no control over how other software calls our methods, and whether they adher to the types required via `@param` annotations.

Hence, we shouldn't rely on those types being certain.