### PR TITLE
[CLEANUP] Remove redundant test code

### DIFF
--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -151,9 +151,6 @@ final class ParserTest extends TestCase
                 self::assertEmpty($colorDeclarations);
             }
         }
-        foreach ($document->getAllValues(null, 'color') as $colorValue) {
-            self::assertSame('red', $colorValue);
-        }
         self::assertSame(
             '#mine {color: red;border-color: #0a64e6;border-color: rgba(10,100,231,.3);outline-color: #222;'
             . "background-color: #232323;}\n"


### PR DESCRIPTION
`getAllValues()` only includes values that are `Value` objects. It does not include `string` values.  So the list returned was empty, the loop had no iterations, and the `assertSame()` was never called.

It doesn't make sense to replace the code with an assertion that `getAllValues()` is returning an empty list, because the `TestCase` is for `Parser`, not `Document`.  Besides, there is already an assertion that `red` is set for the string `color` value.

Uncovered by PHPStan config change in #1583.
This change would also have silenced the same PHPStan warning.