### PR TITLE
[BUGFIX] Do not process `Build/` with Rector

### DIFF
--- a/Build/rector/config.php
+++ b/Build/rector/config.php
@@ -10,7 +10,6 @@ use Rector\Set\ValueObject\SetList;
 return RectorConfig::configure()
     ->withPaths(
         [
-            __DIR__ . '/../../Build',
             __DIR__ . '/../../bin',
             __DIR__ . '/../../src',
             __DIR__ . '/../../tests',


### PR DESCRIPTION
There is no meaningful code in `Build/` for Rector to process. Also, Rector changing its own configuration may lead to strang Inception-like effects.