### PR TITLE
[BUGFIX] Only allow strings as `LineName` components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Please also have a look at our
 
 ### Fixed
 
+- Only allow strings as `LineName` components (#1590)
+
 ### Documentation
 
 ## 9.3.0: Support for modern CSS at-rules and autoloading bugfix

--- a/src/Value/LineName.php
+++ b/src/Value/LineName.php
@@ -18,7 +18,7 @@ use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 class LineName extends ValueList
 {
     /**
-     * @param array<Value|string> $components
+     * @param array<string> $components
      * @param int<1, max>|null $lineNumber
      */
     public function __construct(array $components = [], ?int $lineNumber = null)


### PR DESCRIPTION
Fix the PHPDoc.

Fixes #1589