### PR TITLE
[BUGFIX] Use `@phpstan-ignore` not `@phpstan-ignore-next-line`

### DIFF
--- a/tests/Unit/Parsing/UnexpectedEOFExceptionTest.php
+++ b/tests/Unit/Parsing/UnexpectedEOFExceptionTest.php
@@ -85,7 +85,7 @@ final class UnexpectedEOFExceptionTest extends TestCase
         $expected = 'tea';
         $found = 'coffee';
 
-        // @phpstan-ignore-next-line argument.type We're explicitly testing with an invalid value here.
+        // @phpstan-ignore argument.type (We're explicitly testing with an invalid value here.)
         $exception = new UnexpectedEOFException($expected, $found, 'coding');
 
         $expectedMessage = 'Token “' . $expected . '” (coding) not found. Got “' . $found . '”.';

--- a/tests/Unit/Parsing/UnexpectedTokenExceptionTest.php
+++ b/tests/Unit/Parsing/UnexpectedTokenExceptionTest.php
@@ -85,7 +85,7 @@ final class UnexpectedTokenExceptionTest extends TestCase
         $expected = 'tea';
         $found = 'coffee';
 
-        // @phpstan-ignore-next-line argument.type We're explicitly testing with an invalid value here.
+        // @phpstan-ignore argument.type (We're explicitly testing with an invalid value here.)
         $exception = new UnexpectedTokenException($expected, $found, 'coding');
 
         $expectedMessage = 'Token “' . $expected . '” (coding) not found. Got “' . $found . '”.';


### PR DESCRIPTION
`@phpstan-ignore` has the parameter which is the specific warning to ignore. `@phpstan-ignore-next-line` does not, and will result in suppression of all warnings for the next line.
`@phpstan-ignore` also only applies to the next line (or whatever is relevent in context).