### PR TITLE
[TASK] Move `ParserTest` to `Unit` namespace

### DIFF
--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sabberworm\CSS\Tests\Functional;
+namespace Sabberworm\CSS\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\CSSList\Document;


### PR DESCRIPTION
The test methods in this class are unit tests, testing only the `Parser` class.