### PR TITLE
[BUGFIX] Allow CSS containing only whitespace or comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please also have a look at our
 
 ### Fixed
 
+- Allow CSS containing only whitespace or comments (#1593)
 - Only allow strings as `LineName` components (#1590)
 
 ### Documentation

--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -67,8 +67,8 @@ abstract class CSSList implements CSSElement, CSSListItem, Positionable
         $isRoot = $list instanceof Document;
         $usesLenientParsing = $parserState->getSettings()->usesLenientParsing();
         $comments = [];
+        $parserState->consumeWhiteSpace($comments);
         while (!$parserState->isEnd()) {
-            $parserState->consumeWhiteSpace($comments);
             $listItem = null;
             if ($usesLenientParsing) {
                 try {
@@ -77,7 +77,7 @@ abstract class CSSList implements CSSElement, CSSListItem, Positionable
                 } catch (UnexpectedTokenException $e) {
                     $listItem = false;
                     // If the failed parsing did not consume anything that was to come ...
-                    if ($parserState->currentColumn() === $positionBeforeParse && !$parserState->isEnd()) {
+                    if ($parserState->currentColumn() === $positionBeforeParse) {
                         // ... the unexpected token needs to be skipped, otherwise there'll be an infinite loop.
                         $parserState->consume(1);
                     }

--- a/tests/Functional/ParserTest.php
+++ b/tests/Functional/ParserTest.php
@@ -7,6 +7,8 @@ namespace Sabberworm\CSS\Tests\Functional;
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\CSSList\Document;
 use Sabberworm\CSS\Parser;
+use Sabberworm\CSS\Settings;
+use TRegx\PhpUnit\DataProviders\DataProvider;
 
 /**
  * @covers \Sabberworm\CSS\Parser
@@ -35,5 +37,55 @@ final class ParserTest extends TestCase
         $result = $parser->parse();
 
         self::assertInstanceOf(Document::class, $result);
+    }
+
+    /**
+     * @return array<non-empty-string, array{0: string}>
+     */
+    public static function provideEmptyCss(): array
+    {
+        return [
+            'empty string' => [''],
+            'space' => [' '],
+            'newline' => ["\n"],
+            'carriage return' => ["\r"],
+            'tab' => ["\t"],
+            'Windows line ending' => ["\r\n"],
+            'comment' => ['/* I get put in a separate property */'],
+        ];
+    }
+
+    /**
+     * @return array<non-empty-string, array{0: bool}>
+     */
+    public static function provideLenientParsingFlag(): array
+    {
+        return [
+            'strict parsing' => [false],
+            'lenient parsing' => [true],
+        ];
+    }
+
+    /**
+     * @return DataProvider<non-empty-string, array{0: string, 1: bool}>
+     */
+    public static function provideEmptyCssAndLenientParsingFlag(): DataProvider
+    {
+        return DataProvider::cross(static::provideEmptyCss(), static::provideLenientParsingFlag());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideEmptyCssAndLenientParsingFlag
+     */
+    public function parsesEmptyCss(string $css, bool $parseLeniently): void
+    {
+        $parser = new Parser($css, Settings::create()->withLenientParsing($parseLeniently));
+
+        $result = $parser->parse();
+
+        // Note: Comments for the document are accessed separately via `getComments()`.
+        self::assertSame([], $result->getContents());
     }
 }


### PR DESCRIPTION
The tests added are functional rather than unit tests, as they are indirectly testing `CSSList` rather than `Parser` itself.

Fixes #349