### PR TITLE
[TASK] Temporarily drop the `composer normalize` CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,6 @@ jobs:
             fail-fast: false
             matrix:
                 command:
-                    - composer:normalize
                     - php:cs-fixer
                     - php:sniff
                     - php:stan


### PR DESCRIPTION
Currently, we keep getting errors about problems with GitHub authentication, which breaks this job. We'll need to sort this out first before we re-activate the job.