### PR TITLE
[TASK] Do not scan the PHPStan unit tests with PHPStan

### DIFF
--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -14,6 +14,7 @@ parameters:
     - %currentWorkingDirectory%/tests/
 
   excludePaths:
+    - %currentWorkingDirectory%/tests/Unit/PhpStan/
     - %currentWorkingDirectory%/tests/fixtures/phpstan/
 
   type_perfect:


### PR DESCRIPTION
This is broken with newer versions of PHPStan.

Fixes #1602