### PR TITLE
[TASK] Update the development dependencies

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
   <phar name="composer-normalize" version="^2.44.0" installed="2.52.0" location="./.phive/composer-normalize" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.59.3" installed="3.95.16" location="./.phive/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.59.3" installed="3.95.18" location="./.phive/php-cs-fixer" copy="false"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -30,14 +30,14 @@
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "1.4.0",
         "phpstan/extension-installer": "1.4.3",
-        "phpstan/phpstan": "1.12.33 || 2.2.6",
+        "phpstan/phpstan": "1.12.33 || 2.2.7",
         "phpstan/phpstan-phpunit": "1.4.2 || 2.0.18",
         "phpstan/phpstan-strict-rules": "1.6.2 || 2.0.12",
         "phpunit/phpunit": "8.5.53",
         "rawr/phpunit-data-provider": "3.3.1",
-        "rector/rector": "1.2.10 || 2.5.8",
+        "rector/rector": "1.2.10 || 2.6.1",
         "rector/type-perfect": "1.0.0 || 2.1.4",
-        "squizlabs/php_codesniffer": "4.0.1",
+        "squizlabs/php_codesniffer": "4.0.4",
         "thecodingmachine/phpstan-safe-rule": "1.2.0 || 1.4.7"
     },
     "suggest": {


### PR DESCRIPTION
This includes a security fix in PHP_CodeSniffer.

https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/4.0.2