### PR TITLE
[TASK] Remove `thecodingmachine/safe` dependency (part 1)

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -1,6 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Function preg_match is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\preg_match;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 1
+			path: ../../src/CSSList/CSSList.php
+
+		-
 			message: '#^Parameter \#2 \$found of class Sabberworm\\CSS\\Parsing\\UnexpectedTokenException constructor expects string, Sabberworm\\CSS\\Value\\CSSFunction\|Sabberworm\\CSS\\Value\\CSSString\|Sabberworm\\CSS\\Value\\LineName\|Sabberworm\\CSS\\Value\\Size\|Sabberworm\\CSS\\Value\\URL given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -251,7 +251,7 @@ abstract class CSSList implements CSSElement, CSSListItem, Positionable
         }
 
         $matchResult = \preg_match("/^(-\\w+-)?$match$/i", $identifier);
-        \assert($matchResult !== false);
+        \assert(\is_int($matchResult));
         return $matchResult === 1;
     }
 

--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -25,8 +25,6 @@ use Sabberworm\CSS\Value\CSSString;
 use Sabberworm\CSS\Value\URL;
 use Sabberworm\CSS\Value\Value;
 
-use function Safe\preg_match;
-
 /**
  * This is the most generic container available. It can contain `DeclarationBlock`s (rule sets with a selector),
  * `RuleSet`s as well as other `CSSList` objects.
@@ -252,7 +250,9 @@ abstract class CSSList implements CSSElement, CSSListItem, Positionable
             return true;
         }
 
-        return preg_match("/^(-\\w+-)?$match$/i", $identifier) === 1;
+        $matchResult = \preg_match("/^(-\\w+-)?$match$/i", $identifier);
+        \assert($matchResult !== false);
+        return $matchResult === 1;
     }
 
     /**


### PR DESCRIPTION
As discussed here: https://github.com/MyIntervals/PHP-CSS-Parser/pull/1484#issuecomment-5241402914

`preg_match` can return `false` if:
- The pattern is invalid
- the `u` flag is used and the subject or pattern aren't valid UTF-8
- Backtrack/recursion limits are hit

This `preg_match` can't fail because:
- The pattern is always valid (`$match` is always a fixed value)
- There is no `u` flag
- There is no backtracking or recursion
