### PR TITLE
[TASK] Remove thecodingmachine/safe dependency (part 2)

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -79,6 +79,12 @@ parameters:
 			path: ../../tests/RuleSet/DeclarationBlockTest.php
 
 		-
+			message: '#^Function file_get_contents is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\file_get_contents;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 10
+			path: ../../tests/RuleSet/LenientParsingTest.php
+
+		-
 			message: '#^Parameter \#1 \$type of class Sabberworm\\CSS\\CSSList\\AtRuleBlockList constructor expects non\-empty\-string, '''' given\.$#'
 			identifier: argument.type
 			count: 3

--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -61,6 +61,18 @@ parameters:
 			path: ../../src/Value/Value.php
 
 		-
+			message: '#^Function file_get_contents is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\file_get_contents;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 2
+			path: ../../tests/ParserTest.php
+
+		-
+			message: '#^Function opendir is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\opendir;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 1
+			path: ../../tests/ParserTest.php
+
+		-
 			message: '#^Parameter \#1 \$value of method Sabberworm\\CSS\\Property\\Declaration\:\:setValue\(\) expects Sabberworm\\CSS\\Value\\RuleValueList\|string\|null, Sabberworm\\CSS\\Value\\Size given\.$#'
 			identifier: argument.type
 			count: 3

--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -1,6 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Function file_get_contents is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\file_get_contents;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 1
+			path: ../../bin/quickdump.php
+
+		-
 			message: '#^Function preg_match is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\preg_match;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
 			identifier: theCodingMachineSafe.function
 			count: 1

--- a/bin/quickdump.php
+++ b/bin/quickdump.php
@@ -5,15 +5,16 @@ declare(strict_types=1);
 
 use Sabberworm\CSS\Parser;
 
-use function Safe\file_get_contents;
-
 /**
  * This script is used for generating the examples in the README.
  */
 
 require_once(__DIR__ . '/../vendor/autoload.php');
 
-$source = file_get_contents('php://stdin');
+$source = \file_get_contents('php://stdin');
+if ($source === false) {
+    throw new \RuntimeException('Failed to read from stdin.');
+}
 $parser = new Parser($source);
 
 $document = $parser->parse();

--- a/bin/quickdump.php
+++ b/bin/quickdump.php
@@ -13,7 +13,7 @@ require_once(__DIR__ . '/../vendor/autoload.php');
 
 $source = \file_get_contents('php://stdin');
 if (!\is_string($source)) {
-    throw new \RuntimeException('Failed to read from stdin.');
+    throw new \RuntimeException('Failed to read from stdin.', 1786954465);
 }
 $parser = new Parser($source);
 

--- a/bin/quickdump.php
+++ b/bin/quickdump.php
@@ -12,7 +12,7 @@ use Sabberworm\CSS\Parser;
 require_once(__DIR__ . '/../vendor/autoload.php');
 
 $source = \file_get_contents('php://stdin');
-if ($source === false) {
+if (!\is_string($source)) {
     throw new \RuntimeException('Failed to read from stdin.');
 }
 $parser = new Parser($source);

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -30,9 +30,6 @@ use Sabberworm\CSS\Value\Size;
 use Sabberworm\CSS\Value\URL;
 use Sabberworm\CSS\Value\ValueList;
 
-use function Safe\file_get_contents;
-use function Safe\opendir;
-
 /**
  * @covers \Sabberworm\CSS\Parser
  */
@@ -61,7 +58,7 @@ final class ParserTest extends TestCase
     public function files(): void
     {
         $directory = __DIR__ . '/fixtures';
-        $directoryHandle = opendir($directory);
+        $directoryHandle = \opendir($directory);
 
         /* This is the correct way to loop over the directory. */
         while (false !== ($filename = \readdir($directoryHandle))) {
@@ -76,7 +73,7 @@ final class ParserTest extends TestCase
                 // or a future test of an as-of-now missing feature
                 continue;
             }
-            $parser = new Parser(file_get_contents($directory . '/' . $filename));
+            $parser = new Parser(\file_get_contents($directory . '/' . $filename));
             self::assertNotSame('', $parser->parse()->render());
         }
 
@@ -895,7 +892,7 @@ body {background-color: red;}';
     public static function parsedStructureForFile($filename, $settings = null): Document
     {
         $filename = __DIR__ . "/fixtures/$filename.css";
-        $parser = new Parser(file_get_contents($filename), $settings);
+        $parser = new Parser(\file_get_contents($filename), $settings);
         return $parser->parse();
     }
 

--- a/tests/RuleSet/LenientParsingTest.php
+++ b/tests/RuleSet/LenientParsingTest.php
@@ -10,8 +10,6 @@ use Sabberworm\CSS\Parser;
 use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 use Sabberworm\CSS\Settings;
 
-use function Safe\file_get_contents;
-
 /**
  * @coversNothing
  */
@@ -25,7 +23,7 @@ final class LenientParsingTest extends TestCase
         $this->expectException(UnexpectedTokenException::class);
 
         $pathToFile = __DIR__ . '/../fixtures/-fault-tolerance.css';
-        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->beStrict());
+        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->beStrict());
         $parser->parse();
     }
 
@@ -35,7 +33,7 @@ final class LenientParsingTest extends TestCase
     public function faultToleranceOn(): void
     {
         $pathToFile = __DIR__ . '/../fixtures/-fault-tolerance.css';
-        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
+        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
         $result = $parser->parse();
         self::assertSame(
             '.test1 {}' . "\n" . '.test2 {hello: 2.2;hello: 2000000000000.2;}' . "\n" . '#test {}' . "\n"
@@ -52,7 +50,7 @@ final class LenientParsingTest extends TestCase
         $this->expectException(UnexpectedTokenException::class);
 
         $pathToFile = __DIR__ . '/../fixtures/-end-token.css';
-        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->beStrict());
+        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->beStrict());
         $parser->parse();
     }
 
@@ -64,7 +62,7 @@ final class LenientParsingTest extends TestCase
         $this->expectException(UnexpectedTokenException::class);
 
         $pathToFile = __DIR__ . '/../fixtures/-end-token-2.css';
-        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->beStrict());
+        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->beStrict());
         $parser->parse();
     }
 
@@ -74,7 +72,7 @@ final class LenientParsingTest extends TestCase
     public function endTokenPositive(): void
     {
         $pathToFile = __DIR__ . '/../fixtures/-end-token.css';
-        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
+        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
         $result = $parser->parse();
         self::assertSame('', $result->render());
     }
@@ -85,7 +83,7 @@ final class LenientParsingTest extends TestCase
     public function endToken2Positive(): void
     {
         $pathToFile = __DIR__ . '/../fixtures/-end-token-2.css';
-        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
+        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
         $result = $parser->parse();
         self::assertSame(
             '#home .bg-layout {background-image: url("/bundles/main/img/bg1.png?5");}',
@@ -100,7 +98,7 @@ final class LenientParsingTest extends TestCase
     {
         \setlocale(LC_ALL, 'pt_PT', 'no');
         $pathToFile = __DIR__ . '/../fixtures/-fault-tolerance.css';
-        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
+        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
         $result = $parser->parse();
         self::assertSame(
             '.test1 {}' . "\n" . '.test2 {hello: 2.2;hello: 2000000000000.2;}' . "\n" . '#test {}' . "\n"
@@ -115,7 +113,7 @@ final class LenientParsingTest extends TestCase
     public function caseInsensitivity(): void
     {
         $pathToFile = __DIR__ . '/../fixtures/case-insensitivity.css';
-        $parser = new Parser(file_get_contents($pathToFile));
+        $parser = new Parser(\file_get_contents($pathToFile));
         $result = $parser->parse();
 
         self::assertSame(
@@ -134,7 +132,7 @@ final class LenientParsingTest extends TestCase
     public function cssWithInvalidColorStillGetsParsedAsDocument(): void
     {
         $pathToFile = __DIR__ . '/../fixtures/invalid-color.css';
-        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
+        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->withLenientParsing(true));
         $result = $parser->parse();
 
         self::assertInstanceOf(Document::class, $result);
@@ -148,7 +146,7 @@ final class LenientParsingTest extends TestCase
         $this->expectException(UnexpectedTokenException::class);
 
         $pathToFile = __DIR__ . '/../fixtures/invalid-color.css';
-        $parser = new Parser(file_get_contents($pathToFile), Settings::create()->beStrict());
+        $parser = new Parser(\file_get_contents($pathToFile), Settings::create()->beStrict());
         $parser->parse();
     }
 }


### PR DESCRIPTION
- Giving `false` to `Parser` already throws an exception (string typehint + strict types)
- The `opendir()` call opens the fixtures directory, that should always exist. If it somehow fails, the tests should already fail too