### PR TITLE
[TASK] Remove thecodingmachine/safe dependency (part 3)

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -19,6 +19,24 @@ parameters:
 			path: ../../src/CSSList/CSSList.php
 
 		-
+			message: '#^Function iconv is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\iconv;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 1
+			path: ../../src/Parsing/ParserState.php
+
+		-
+			message: '#^Function preg_match is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\preg_match;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 5
+			path: ../../src/Parsing/ParserState.php
+
+		-
+			message: '#^Function preg_split is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\preg_split;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 1
+			path: ../../src/Parsing/ParserState.php
+
+		-
 			message: '#^Negated boolean expression is always true\.$#'
 			identifier: booleanNot.alwaysTrue
 			count: 1

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -7,10 +7,6 @@ namespace Sabberworm\CSS\Parsing;
 use Sabberworm\CSS\Comment\Comment;
 use Sabberworm\CSS\Settings;
 
-use function Safe\iconv;
-use function Safe\preg_match;
-use function Safe\preg_split;
-
 /**
  * @internal since 8.7.0
  */
@@ -120,7 +116,11 @@ class ParserState
             throw new UnexpectedTokenException('', $this->peek(5), 'identifier', $this->lineNumber);
         }
         while (!$this->isEnd() && ($character = $this->parseCharacter(true)) !== null) {
-            if (preg_match('/[a-zA-Z0-9\\x{00A0}-\\x{FFFF}_-]/Sux', $character) !== 0) {
+            $matchResult = \preg_match('/[a-zA-Z0-9\\x{00A0}-\\x{FFFF}_-]/Sux', $character);
+            if (!\is_int($matchResult)) {
+                throw new \RuntimeException('The CSS is not valid UTF-8.', 1787112617);
+            }
+            if ($matchResult !== 0) {
                 $result .= $character;
             } else {
                 $result .= '\\' . $character;
@@ -144,13 +144,21 @@ class ParserState
             if ($this->comes('\\n') || $this->comes('\\r')) {
                 return '';
             }
-            if (preg_match('/[0-9a-fA-F]/Su', $this->peek()) === 0) {
+            $matchResult = \preg_match('/[0-9a-fA-F]/Su', $this->peek());
+            if (!\is_int($matchResult)) {
+                throw new \RuntimeException('The CSS is not valid UTF-8.', 1787112618);
+            }
+            if ($matchResult === 0) {
                 return $this->consume(1);
             }
             $hexCodePoint = $this->consumeExpression('/^[0-9a-fA-F]{1,6}/u', 6);
             if ($this->strlen($hexCodePoint) < 6) {
                 // Consume whitespace after incomplete unicode escape
-                if (preg_match('/\\s/isSu', $this->peek()) !== 0) {
+                $matchResult = \preg_match('/\\s/isSu', $this->peek());
+                if (!\is_int($matchResult)) {
+                    throw new \RuntimeException('The CSS is not valid UTF-8.', 1787112619);
+                }
+                if ($matchResult !== 0) {
                     if ($this->comes('\\r\\n')) {
                         $this->consume(2);
                     } else {
@@ -164,7 +172,15 @@ class ParserState
                 $utf32EncodedCharacter .= \chr($codePoint & 0xff);
                 $codePoint = $codePoint >> 8;
             }
-            return iconv('utf-32le', $this->charset, $utf32EncodedCharacter);
+            // The suppression is needed because `\iconv` emits a notice, as well as returning `false`, on failure.
+            $convertedCharacter = @\iconv('utf-32le', $this->charset, $utf32EncodedCharacter);
+            if (!\is_string($convertedCharacter)) {
+                throw new \RuntimeException(
+                    'The Unicode escape sequence could not be converted to the target character set.',
+                    1787112620
+                );
+            }
+            return $convertedCharacter;
         }
         if ($isForIdentifier) {
             $peek = \ord($this->peek());
@@ -204,7 +220,14 @@ class ParserState
     {
         $consumed = '';
         do {
-            while (preg_match('/\\s/isSu', $this->peek()) === 1) {
+            while (true) {
+                $matchResult = \preg_match('/\\s/isSu', $this->peek());
+                if (!\is_int($matchResult)) {
+                    throw new \RuntimeException('The CSS is not valid UTF-8.', 1787112621);
+                }
+                if ($matchResult !== 1) {
+                    break;
+                }
                 $consumed .= $this->consume(1);
             }
             if ($this->parserSettings->usesLenientParsing()) {
@@ -318,7 +341,11 @@ class ParserState
     {
         $matches = null;
         $input = ($maximumLength !== null) ? $this->peek($maximumLength) : $this->inputLeft();
-        if (preg_match($expression, $input, $matches, PREG_OFFSET_CAPTURE) !== 1) {
+        $matchResult = \preg_match($expression, $input, $matches, PREG_OFFSET_CAPTURE);
+        if (!\is_int($matchResult)) {
+            throw new \RuntimeException('The CSS is not valid UTF-8.', 1787112622);
+        }
+        if ($matchResult !== 1) {
             throw new UnexpectedTokenException($expression, $this->peek(5), 'expression', $this->lineNumber);
         }
 
@@ -467,7 +494,10 @@ class ParserState
     {
         if ($this->parserSettings->hasMultibyteSupport()) {
             if ($this->streql($this->charset, 'utf-8')) {
-                $result = preg_split('//u', $string, -1, PREG_SPLIT_NO_EMPTY);
+                $result = \preg_split('//u', $string, -1, PREG_SPLIT_NO_EMPTY);
+                if (!\is_array($result)) {
+                    throw new \RuntimeException('The CSS is not valid UTF-8.', 1787112623);
+                }
             } else {
                 $length = \mb_strlen($string, $this->charset);
                 $result = [];

--- a/tests/Unit/Parsing/ParserStateTest.php
+++ b/tests/Unit/Parsing/ParserStateTest.php
@@ -16,6 +16,77 @@ use TRegx\PhpUnit\DataProviders\DataProvider;
 final class ParserStateTest extends TestCase
 {
     /**
+     * @test
+     */
+    public function constructorThrowsForTextThatIsNotValidUtf8(): void
+    {
+        if (\PHP_VERSION_ID < 70304) {
+            // https://bugs.php.net/76127
+            self::markTestSkipped('Before PHP 7.3.4 preg_split did not return false for invalid UTF-8');
+        }
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionCode(1787112623);
+
+        new ParserState("\xFF body{}", Settings::create());
+    }
+
+    /**
+     * @test
+     */
+    public function parseIdentifierThrowsForTextThatIsNotValidUtf8WithoutMultibyteSupport(): void
+    {
+        $subject = new ParserState("a\xFF", Settings::create()->withMultibyteSupport(false));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionCode(1787112617);
+
+        $subject->parseIdentifier();
+    }
+
+    /**
+     * @test
+     */
+    public function parseCharacterThrowsForEscapedTextThatIsNotValidUtf8WithoutMultibyteSupport(): void
+    {
+        $subject = new ParserState("\\\xFF", Settings::create()->withMultibyteSupport(false));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionCode(1787112618);
+
+        $subject->parseCharacter(true);
+    }
+
+    /**
+     * @test
+     */
+    public function parseCharacterThrowsForMultibyteCharacterAfterIncompleteUnicodeEscapeWithoutMultibyteSupport(): void
+    {
+        // "\xC3\xA9" is "é". Without multibyte support, it is split into two separate "characters",
+        // each of which is not valid UTF-8 on its own.
+        $subject = new ParserState("\\3\xC3\xA9", Settings::create()->withMultibyteSupport(false));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionCode(1787112619);
+
+        $subject->parseCharacter(true);
+    }
+
+    /**
+     * @test
+     */
+    public function parseCharacterThrowsForEscapedCodePointThatCannotBeConverted(): void
+    {
+        // 0xFFFFFF is outside the Unicode range, so `\iconv` cannot convert it.
+        $subject = new ParserState('\\FFFFFF', Settings::create());
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionCode(1787112620);
+
+        $subject->parseCharacter(false);
+    }
+
+    /**
      * @return array<
      *             string,
      *             array{
@@ -302,5 +373,31 @@ final class ParserStateTest extends TestCase
         $subject->consumeWhiteSpace();
 
         self::assertTrue($subject->comes($nonWhitespace));
+    }
+
+    /**
+     * @test
+     */
+    public function consumeWhiteSpaceThrowsForTextThatIsNotValidUtf8WithoutMultibyteSupport(): void
+    {
+        $subject = new ParserState("\xFF body{}", Settings::create()->withMultibyteSupport(false));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionCode(1787112621);
+
+        $subject->consumeWhiteSpace();
+    }
+
+    /**
+     * @test
+     */
+    public function consumeExpressionThrowsForTextThatIsNotValidUtf8WithoutMultibyteSupport(): void
+    {
+        $subject = new ParserState("\xFF", Settings::create()->withMultibyteSupport(false));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionCode(1787112622);
+
+        $subject->consumeExpression('/^[0-9a-fA-F]{1,6}/u', 6);
     }
 }

--- a/tests/Unit/Parsing/ParserStateTest.php
+++ b/tests/Unit/Parsing/ParserStateTest.php
@@ -26,6 +26,7 @@ final class ParserStateTest extends TestCase
         }
 
         $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The CSS is not valid UTF-8.');
         $this->expectExceptionCode(1787112623);
 
         new ParserState("\xFF body{}", Settings::create());
@@ -39,6 +40,7 @@ final class ParserStateTest extends TestCase
         $subject = new ParserState("a\xFF", Settings::create()->withMultibyteSupport(false));
 
         $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The CSS is not valid UTF-8.');
         $this->expectExceptionCode(1787112617);
 
         $subject->parseIdentifier();
@@ -52,6 +54,7 @@ final class ParserStateTest extends TestCase
         $subject = new ParserState("\\\xFF", Settings::create()->withMultibyteSupport(false));
 
         $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The CSS is not valid UTF-8.');
         $this->expectExceptionCode(1787112618);
 
         $subject->parseCharacter(true);
@@ -67,6 +70,7 @@ final class ParserStateTest extends TestCase
         $subject = new ParserState("\\3\xC3\xA9", Settings::create()->withMultibyteSupport(false));
 
         $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The CSS is not valid UTF-8.');
         $this->expectExceptionCode(1787112619);
 
         $subject->parseCharacter(true);
@@ -81,6 +85,9 @@ final class ParserStateTest extends TestCase
         $subject = new ParserState('\\FFFFFF', Settings::create());
 
         $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            'The Unicode escape sequence could not be converted to the target character set.'
+        );
         $this->expectExceptionCode(1787112620);
 
         $subject->parseCharacter(false);
@@ -383,6 +390,7 @@ final class ParserStateTest extends TestCase
         $subject = new ParserState("\xFF body{}", Settings::create()->withMultibyteSupport(false));
 
         $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The CSS is not valid UTF-8.');
         $this->expectExceptionCode(1787112621);
 
         $subject->consumeWhiteSpace();
@@ -396,6 +404,7 @@ final class ParserStateTest extends TestCase
         $subject = new ParserState("\xFF", Settings::create()->withMultibyteSupport(false));
 
         $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The CSS is not valid UTF-8.');
         $this->expectExceptionCode(1787112622);
 
         $subject->consumeExpression('/^[0-9a-fA-F]{1,6}/u', 6);


### PR DESCRIPTION
All calls in `ParserState` that can return `false` now throw an exception instead, each with its own unit test that checks for the unique exception code.