### PR TITLE
[TASK] Remove thecodingmachine/safe dependency (part 4)

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -49,6 +49,12 @@ parameters:
 			path: ../../src/Property/Selector/CompoundSelector.php
 
 		-
+			message: '#^Function preg_match_all is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\preg_match_all;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 2
+			path: ../../src/Property/Selector/SpecificityCalculator.php
+
+		-
 			message: '#^Parameter \#2 \$arguments of class Sabberworm\\CSS\\Value\\CSSFunction constructor expects array\<Sabberworm\\CSS\\Value\\Value\|string\>\|Sabberworm\\CSS\\Value\\RuleValueList, Sabberworm\\CSS\\Value\\Value\|string given\.$#'
 			identifier: argument.type
 			count: 1

--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -46,6 +46,12 @@ parameters:
 			message: '#^Function preg_match is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\preg_match;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
 			identifier: theCodingMachineSafe.function
 			count: 1
+			path: ../../src/Property/Declaration.php
+
+		-
+			message: '#^Function preg_match is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\preg_match;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 1
 			path: ../../src/Property/Selector/CompoundSelector.php
 
 		-

--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -52,6 +52,12 @@ parameters:
 			message: '#^Function preg_match is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\preg_match;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
 			identifier: theCodingMachineSafe.function
 			count: 1
+			path: ../../src/Property/Selector.php
+
+		-
+			message: '#^Function preg_match is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\preg_match;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 1
 			path: ../../src/Property/Selector/CompoundSelector.php
 
 		-

--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -43,6 +43,12 @@ parameters:
 			path: ../../src/Parsing/ParserState.php
 
 		-
+			message: '#^Function preg_match is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\preg_match;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 1
+			path: ../../src/Property/Selector/CompoundSelector.php
+
+		-
 			message: '#^Parameter \#2 \$arguments of class Sabberworm\\CSS\\Value\\CSSFunction constructor expects array\<Sabberworm\\CSS\\Value\\Value\|string\>\|Sabberworm\\CSS\\Value\\RuleValueList, Sabberworm\\CSS\\Value\\Value\|string given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Property/Declaration.php
+++ b/src/Property/Declaration.php
@@ -18,8 +18,6 @@ use Sabberworm\CSS\ShortClassNameProvider;
 use Sabberworm\CSS\Value\RuleValueList;
 use Sabberworm\CSS\Value\Value;
 
-use function Safe\preg_match;
-
 /**
  * `Declaration`s just have a string key (the property name) and a 'Value'.
  *
@@ -105,7 +103,9 @@ class Declaration implements Commentable, CSSElement, Positionable
      */
     private static function getDelimitersForPropertyValue(string $propertyName): array
     {
-        if (preg_match('/^font($|-)/', $propertyName) === 1) {
+        $matchResult = \preg_match('/^font($|-)/', $propertyName);
+        \assert(\is_int($matchResult));
+        if ($matchResult === 1) {
             return [',', '/', ' '];
         }
 

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -15,8 +15,6 @@ use Sabberworm\CSS\Renderable;
 use Sabberworm\CSS\Settings;
 use Sabberworm\CSS\ShortClassNameProvider;
 
-use function Safe\preg_match;
-
 /**
  * Class representing a single CSS selector. Selectors have to be split by the comma prior to being passed into this
  * class.
@@ -68,7 +66,10 @@ class Selector implements Renderable
     public static function isValid(string $selector): bool
     {
         // Note: We need to use `static::` here as the constant is overridden in the `KeyframeSelector` class.
-        $numberOfMatches = preg_match(static::SELECTOR_VALIDATION_RX, $selector);
+        $numberOfMatches = \preg_match(static::SELECTOR_VALIDATION_RX, $selector);
+        if (!\is_int($numberOfMatches)) {
+            throw new \RuntimeException('The selector is not valid UTF-8.', 1787284398);
+        }
 
         return $numberOfMatches === 1;
     }

--- a/src/Property/Selector/CompoundSelector.php
+++ b/src/Property/Selector/CompoundSelector.php
@@ -10,8 +10,6 @@ use Sabberworm\CSS\Parsing\ParserState;
 use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 use Sabberworm\CSS\ShortClassNameProvider;
 
-use function Safe\preg_match;
-
 /**
  * Class representing a CSS compound selector.
  * Selectors have to be split at combinators (space, `>`, `+`, `~`) before being passed to this class.
@@ -277,7 +275,10 @@ class CompoundSelector implements Component
 
     private static function isValid(string $value): bool
     {
-        $numberOfMatches = preg_match(self::SELECTOR_VALIDATION_RX, $value);
+        $numberOfMatches = \preg_match(self::SELECTOR_VALIDATION_RX, $value);
+        if (!\is_int($numberOfMatches)) {
+            throw new \RuntimeException('The selector is not valid UTF-8.', 1787283476);
+        }
 
         return $numberOfMatches === 1;
     }

--- a/src/Property/Selector/SpecificityCalculator.php
+++ b/src/Property/Selector/SpecificityCalculator.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sabberworm\CSS\Property\Selector;
 
-use function Safe\preg_match_all;
-
 /**
  * Utility class to calculate the specificity of a CSS selector.
  *
@@ -65,8 +63,10 @@ final class SpecificityCalculator
             /// @todo should exclude \# as well as "#"
             $matches = null;
             $b = \substr_count($selector, '#');
-            $c = preg_match_all(self::NON_ID_ATTRIBUTES_AND_PSEUDO_CLASSES_RX, $selector, $matches);
-            $d = preg_match_all(self::ELEMENTS_AND_PSEUDO_ELEMENTS_RX, $selector, $matches);
+            $c = \preg_match_all(self::NON_ID_ATTRIBUTES_AND_PSEUDO_CLASSES_RX, $selector, $matches);
+            \assert(\is_int($c));
+            $d = \preg_match_all(self::ELEMENTS_AND_PSEUDO_ELEMENTS_RX, $selector, $matches);
+            \assert(\is_int($d));
             self::$cache[$selector] = ($a * 1000) + ($b * 100) + ($c * 10) + $d;
         }
 

--- a/tests/Unit/Property/KeyframeSelectorTest.php
+++ b/tests/Unit/Property/KeyframeSelectorTest.php
@@ -37,4 +37,16 @@ final class KeyframeSelectorTest extends TestCase
 
         self::assertSame('50%', $result['components'][0]['value']);
     }
+
+    /**
+     * @test
+     */
+    public function isValidThrowsForSelectorThatIsNotValidUtf8(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The selector is not valid UTF-8.');
+        $this->expectExceptionCode(1787284398);
+
+        KeyframeSelector::isValid("a\xFF");
+    }
 }

--- a/tests/Unit/Property/Selector/CompoundSelectorTest.php
+++ b/tests/Unit/Property/Selector/CompoundSelectorTest.php
@@ -373,6 +373,18 @@ final class CompoundSelectorTest extends TestCase
 
     /**
      * @test
+     */
+    public function constructorThrowsForValueThatIsNotValidUtf8(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The selector is not valid UTF-8.');
+        $this->expectExceptionCode(1787283476);
+
+        new CompoundSelector("a\xFF");
+    }
+
+    /**
+     * @test
      *
      * @param non-empty-string $value
      *

--- a/tests/Unit/Property/SelectorTest.php
+++ b/tests/Unit/Property/SelectorTest.php
@@ -526,6 +526,18 @@ final class SelectorTest extends TestCase
     /**
      * @test
      */
+    public function isValidThrowsForSelectorThatIsNotValidUtf8(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The selector is not valid UTF-8.');
+        $this->expectExceptionCode(1787284398);
+
+        Selector::isValid("a\xFF");
+    }
+
+    /**
+     * @test
+     */
     public function cleansUpSpacesWithinSelector(): void
     {
         $selector = 'p   >    small';


### PR DESCRIPTION
- This PR tackles all four files in the `Property` directory
- Two of them can fail on invalid UTF-8, both of these have tests
- The others don't use the `/u` modifier, and don't do backtracking, so they can't fail. These got an `assert()`