### PR TITLE
[TASK] Remove thecodingmachine/safe dependency (part 5)

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -73,6 +73,12 @@ parameters:
 			path: ../../src/Rule/Rule.php
 
 		-
+			message: '#^Function class_alias is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\class_alias;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 1
+			path: ../../src/RuleSet/RuleContainer.php
+
+		-
 			message: '#^Parameter \#2 \$arguments of class Sabberworm\\CSS\\Value\\CSSFunction constructor expects array\<Sabberworm\\CSS\\Value\\Value\|string\>\|Sabberworm\\CSS\\Value\\RuleValueList, Sabberworm\\CSS\\Value\\Value\|string given\.$#'
 			identifier: argument.type
 			count: 1

--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -67,6 +67,12 @@ parameters:
 			path: ../../src/Property/Selector/SpecificityCalculator.php
 
 		-
+			message: '#^Function class_alias is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\class_alias;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 1
+			path: ../../src/Rule/Rule.php
+
+		-
 			message: '#^Parameter \#2 \$arguments of class Sabberworm\\CSS\\Value\\CSSFunction constructor expects array\<Sabberworm\\CSS\\Value\\Value\|string\>\|Sabberworm\\CSS\\Value\\RuleValueList, Sabberworm\\CSS\\Value\\Value\|string given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -6,14 +6,13 @@ namespace Sabberworm\CSS\Rule;
 
 use Sabberworm\CSS\Property\Declaration;
 
-use function Safe\class_alias;
-
 // @phpstan-ignore function.impossibleType
 if (!\class_exists(Rule::class, false) && !\interface_exists(Rule::class, false)) {
-    class_alias(Declaration::class, Rule::class);
+    $aliasWasCreated = \class_alias(Declaration::class, Rule::class);
+    \assert($aliasWasCreated);
     // The test is expected to evaluate to false,
     // but allows for the deprecation notice to be picked up by IDEs like PHPStorm.
-    // @phpstan-ignore function.impossibleType
+    // @phpstan-ignore function.impossibleType, booleanNot.alwaysTrue, booleanAnd.alwaysTrue
     if (!\class_exists(Rule::class, false) && !\interface_exists(Rule::class, false)) {
         /**
          * @deprecated in v9.2, will be removed in v10.0.  Use `Property\Declaration` instead, which is a direct

--- a/src/RuleSet/RuleContainer.php
+++ b/src/RuleSet/RuleContainer.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Sabberworm\CSS\RuleSet;
 
-use function Safe\class_alias;
-
 // @phpstan-ignore function.impossibleType
 if (!\class_exists(RuleContainer::class, false) && !\interface_exists(RuleContainer::class, false)) {
-    class_alias(DeclarationList::class, RuleContainer::class);
+    $aliasWasCreated = \class_alias(DeclarationList::class, RuleContainer::class);
+    \assert($aliasWasCreated);
     // The test is expected to evaluate to false,
     // but allows for the deprecation notice to be picked up by IDEs like PHPStorm.
-    // @phpstan-ignore function.impossibleType
+    // @phpstan-ignore function.impossibleType, booleanNot.alwaysTrue, booleanAnd.alwaysTrue
     if (!\class_exists(RuleContainer::class, false) && !\interface_exists(RuleContainer::class, false)) {
         /**
          * @deprecated in v9.2, will be removed in v10.0.  Use `DeclarationList` instead, which is a direct replacement.


### PR DESCRIPTION
As far as I can tell there isn't a way to make this `class_alias()` call return false, so I've added an assert.

PHPStan doesn't understand `Safe\class_alias()` and only reports `function.impossibleType`. Once changed to a normal `class_alias()` it reports two extra errors.