### PR TITLE
[TASK] Remove thecodingmachine/safe dependency (part 6)

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -109,6 +109,12 @@ parameters:
 			path: ../../src/Value/Size.php
 
 		-
+			message: '#^Function preg_match is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\preg_match;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 1
+			path: ../../src/Value/Value.php
+
+		-
 			message: '#^Parameter \#2 \$arguments of class Sabberworm\\CSS\\Value\\CSSFunction constructor expects array\<Sabberworm\\CSS\\Value\\Value\|string\>\|Sabberworm\\CSS\\Value\\RuleValueList, Sabberworm\\CSS\\Value\\Value\|string given\.$#'
 			identifier: argument.type
 			count: 1

--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -85,6 +85,12 @@ parameters:
 			path: ../../src/Value/CSSFunction.php
 
 		-
+			message: '#^Function preg_match is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\preg_match;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 2
+			path: ../../src/Value/CalcFunction.php
+
+		-
 			message: '#^Parameter \#2 \$offset of method Sabberworm\\CSS\\Parsing\\ParserState\:\:peek\(\) expects int\<0, max\>, \-1 given\.$#'
 			identifier: argument.type
 			count: 2

--- a/src/Value/CalcFunction.php
+++ b/src/Value/CalcFunction.php
@@ -8,8 +8,6 @@ use Sabberworm\CSS\Parsing\ParserState;
 use Sabberworm\CSS\Parsing\UnexpectedEOFException;
 use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 
-use function Safe\preg_match;
-
 class CalcFunction extends CSSFunction
 {
     private const T_OPERAND = 1;
@@ -61,10 +59,11 @@ class CalcFunction extends CSSFunction
             } else {
                 if (\in_array($parserState->peek(), $operators, true)) {
                     if (($parserState->comes('-') || $parserState->comes('+'))) {
-                        if (
-                            preg_match('/\\s/', $parserState->peek(1, -1)) !== 1
-                            || preg_match('/\\s/', $parserState->peek(1, 1)) !== 1
-                        ) {
+                        $matchResultBefore = \preg_match('/\\s/', $parserState->peek(1, -1));
+                        \assert(\is_int($matchResultBefore));
+                        $matchResultAfter = \preg_match('/\\s/', $parserState->peek(1, 1));
+                        \assert(\is_int($matchResultAfter));
+                        if ($matchResultBefore !== 1 || $matchResultAfter !== 1) {
                             throw new UnexpectedTokenException(
                                 " {$parserState->peek()} ",
                                 $parserState->peek(1, -1) . $parserState->peek(2),

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -13,8 +13,6 @@ use Sabberworm\CSS\Position\Position;
 use Sabberworm\CSS\Position\Positionable;
 use Sabberworm\CSS\ShortClassNameProvider;
 
-use function Safe\preg_match;
-
 /**
  * Abstract base class for specific classes of CSS values: `Size`, `Color`, `CSSString` and `URL`, and another
  * abstract subclass `ValueList`.
@@ -214,14 +212,20 @@ abstract class Value implements CSSElement, Positionable
         $codepointMaxLength = 6; // Code points outside BMP can use up to six digits
         $range = '';
         $parserState->consume('U+');
-        do {
+        while (true) {
             if ($parserState->comes('-')) {
                 $codepointMaxLength = 13; // Max length is 2 six-digit code points + the dash(-) between them
             }
             $range .= $parserState->consume(1);
-        } while (
-            (\strlen($range) < $codepointMaxLength) && (preg_match('/[A-Fa-f0-9\\?-]/', $parserState->peek()) === 1)
-        );
+            if (\strlen($range) >= $codepointMaxLength) {
+                break;
+            }
+            $matchResult = \preg_match('/[A-Fa-f0-9\\?-]/', $parserState->peek());
+            \assert(\is_int($matchResult));
+            if ($matchResult !== 1) {
+                break;
+            }
+        }
 
         return "U+{$range}";
     }

--- a/tests/Unit/Value/CalcFunctionTest.php
+++ b/tests/Unit/Value/CalcFunctionTest.php
@@ -159,6 +159,10 @@ final class CalcFunctionTest extends TestCase
         return [
             'missing space around -' => ['calc(100%-20px)'],
             'missing space around +' => ['calc(100%+20px)'],
+            'missing space before -' => ['calc(100%- 20px)'],
+            'missing space before +' => ['calc(100%+ 20px)'],
+            'missing space after -' => ['calc(100% -20px)'],
+            'missing space after +' => ['calc(100% +20px)'],
             'invalid operator' => ['calc(100% ^ 20px)'],
         ];
     }


### PR DESCRIPTION
No `/u` on either of these preg_match calls, so they can't return false. 

I've added more cases to `CalcFunctionTest` to add test coverage for the two preg_match calls in `CalcFunction` (the second preg_match previously had no test coverage)