### PR TITLE
[TASK] Remove thecodingmachine/safe dependency (part 7)

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -109,6 +109,18 @@ parameters:
 			path: ../../src/Value/Color.php
 
 		-
+			message: '#^Function preg_match is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\preg_match;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 1
+			path: ../../src/Value/Size.php
+
+		-
+			message: '#^Function preg_replace is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\preg_replace;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
+			count: 2
+			path: ../../src/Value/Size.php
+
+		-
 			message: '#^Strict comparison using \!\=\= between non\-empty\-string and null will always evaluate to true\.$#'
 			identifier: notIdentical.alwaysTrue
 			count: 1

--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -87,6 +87,12 @@ parameters:
 		-
 			message: '#^Function preg_match is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\preg_match;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
 			identifier: theCodingMachineSafe.function
+			count: 1
+			path: ../../src/Value/CSSString.php
+
+		-
+			message: '#^Function preg_match is unsafe to use\. It can return FALSE instead of throwing an exception\. Please add ''use function Safe\\preg_match;'' at the beginning of the file to use the variant provided by the ''thecodingmachine/safe'' library\.$#'
+			identifier: theCodingMachineSafe.function
 			count: 2
 			path: ../../src/Value/CalcFunction.php
 

--- a/src/Value/CSSString.php
+++ b/src/Value/CSSString.php
@@ -11,8 +11,6 @@ use Sabberworm\CSS\Parsing\UnexpectedEOFException;
 use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 use Sabberworm\CSS\ShortClassNameProvider;
 
-use function Safe\preg_match;
-
 /**
  * This class is a wrapper for quoted strings to distinguish them from keywords.
  *
@@ -58,7 +56,14 @@ class CSSString extends PrimitiveValue
         $result = '';
         if ($quote === null) {
             // Unquoted strings end in whitespace or with braces, brackets, parentheses
-            while (preg_match('/[\\s{}()<>\\[\\]]/isu', $parserState->peek()) === 0) {
+            while (true) {
+                $matchResult = \preg_match('/[\\s{}()<>\\[\\]]/isu', $parserState->peek());
+                if (!\is_int($matchResult)) {
+                    throw new \RuntimeException('The CSS is not valid UTF-8.', 1787548272);
+                }
+                if ($matchResult !== 0) {
+                    break;
+                }
                 $result .= $parserState->parseCharacter(false);
             }
         } else {

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -10,9 +10,6 @@ use Sabberworm\CSS\Parsing\UnexpectedEOFException;
 use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 use Sabberworm\CSS\ShortClassNameProvider;
 
-use function Safe\preg_match;
-use function Safe\preg_replace;
-
 /**
  * A `Size` consists of a numeric `size` value and a unit.
  */
@@ -200,10 +197,19 @@ class Size extends PrimitiveValue
     {
         $locale = \localeconv();
         $decimalPoint = \preg_quote($locale['decimal_point'], '/');
-        $size = preg_match('/[\\d\\.]+e[+-]?\\d+/i', (string) $this->size) === 1
-            ? preg_replace("/$decimalPoint?0+$/", '', \sprintf('%f', $this->size)) : (string) $this->size;
+        $matchResult = \preg_match('/[\\d\\.]+e[+-]?\\d+/i', (string) $this->size);
+        \assert(\is_int($matchResult));
+        if ($matchResult === 1) {
+            $size = \preg_replace("/$decimalPoint?0+$/", '', \sprintf('%f', $this->size));
+            \assert(\is_string($size));
+        } else {
+            $size = (string) $this->size;
+        }
 
-        return preg_replace(["/$decimalPoint/", '/^(-?)0\\./'], ['.', '$1.'], $size) . ($this->unit ?? '');
+        $renderedSize = \preg_replace(["/$decimalPoint/", '/^(-?)0\\./'], ['.', '$1.'], $size);
+        \assert(\is_string($renderedSize));
+
+        return $renderedSize . ($this->unit ?? '');
     }
 
     /**

--- a/tests/Unit/Value/CSSStringTest.php
+++ b/tests/Unit/Value/CSSStringTest.php
@@ -6,6 +6,8 @@ namespace Sabberworm\CSS\Tests\Unit\Value;
 
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\OutputFormat;
+use Sabberworm\CSS\Parsing\ParserState;
+use Sabberworm\CSS\Settings;
 use Sabberworm\CSS\Value\CSSString;
 use Sabberworm\CSS\Value\PrimitiveValue;
 use Sabberworm\CSS\Value\Value;
@@ -143,5 +145,19 @@ final class CSSStringTest extends TestCase
         $outputFormat->setStringQuotingType("'");
 
         self::assertSame("'{$input}'", (new CSSString($input))->render($outputFormat));
+    }
+
+    /**
+     * @test
+     */
+    public function parseThrowsForUnquotedStringThatIsNotValidUtf8WithoutMultibyteSupport(): void
+    {
+        $parserState = new ParserState("\xFF", Settings::create()->withMultibyteSupport(false));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The CSS is not valid UTF-8.');
+        $this->expectExceptionCode(1787548272);
+
+        CSSString::parse($parserState);
     }
 }


### PR DESCRIPTION
This is the last code change. Next PR can remove the package.

The preg_match in `CSSString` uses `/u` and can fail, this has a unit test. All others can't fail.