### PR TITLE
Add support for layer declarations ending with semicolon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Please also have a look at our
 
 ### Added
 
+- Add tests for semicolon-terminated `@layer` statements // TODO: add PR ID
+
 ### Changed
 
 ### Deprecated
@@ -19,6 +21,9 @@ Please also have a look at our
 - Remove the `thecodingmachine/safe` dependency (#1622)
 
 ### Fixed
+
+- Parse semicolon-terminated `@layer` statements (and other statement at-rules)
+  instead of consuming until the next `{` // TODO: add PR ID
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Please also have a look at our
 
 ### Added
 
-- Add tests for semicolon-terminated `@layer` statements // TODO: add PR ID
+- Add tests for semicolon-terminated `@layer` statements (#1624)
 
 ### Changed
 
@@ -23,7 +23,7 @@ Please also have a look at our
 ### Fixed
 
 - Parse semicolon-terminated `@layer` statements (and other statement at-rules)
-  instead of consuming until the next `{` // TODO: add PR ID
+  instead of consuming until the next `{` (#1624)
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ Please also have a look at our
 
 ### Added
 
-- Add tests for semicolon-terminated `@layer` statements (#1624)
-
 ### Changed
 
 ### Deprecated

--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -14,6 +14,7 @@ use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 use Sabberworm\CSS\Position\Position;
 use Sabberworm\CSS\Position\Positionable;
 use Sabberworm\CSS\Property\AtRule;
+use Sabberworm\CSS\Property\AtRuleStatement;
 use Sabberworm\CSS\Property\Charset;
 use Sabberworm\CSS\Property\CSSNamespace;
 use Sabberworm\CSS\Property\Import;
@@ -210,8 +211,13 @@ abstract class CSSList implements CSSElement, CSSListItem, Positionable
             }
             return new CSSNamespace($url, $prefix, $identifierLineNumber);
         } else {
-            // Unknown other at rule (font-face or such)
-            $arguments = \trim($parserState->consumeUntil('{', false, true));
+            // Unknown other at rule (font-face, @layer, or such)
+            $arguments = \trim($parserState->consumeUntil(['{', ';'], false, false));
+            if ($parserState->comes(';')) {
+                $parserState->consume(';');
+                return new AtRuleStatement($identifier, $arguments, $identifierLineNumber);
+            }
+            $parserState->consume('{');
             if (\substr_count($arguments, '(') !== \substr_count($arguments, ')')) {
                 if ($parserState->getSettings()->usesLenientParsing()) {
                     return null;

--- a/src/Property/AtRuleStatement.php
+++ b/src/Property/AtRuleStatement.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabberworm\CSS\Property;
+
+use Sabberworm\CSS\Comment\CommentContainer;
+use Sabberworm\CSS\OutputFormat;
+use Sabberworm\CSS\Position\Position;
+use Sabberworm\CSS\Position\Positionable;
+use Sabberworm\CSS\ShortClassNameProvider;
+
+/**
+ * A generic semicolon-terminated at-rule, such as `@layer reset;` or `@layer base, components;`.
+ *
+ * Block at-rules (`@media`, `@layer theme { … }`, `@font-face`, …) are represented by
+ * `AtRuleBlockList` or `AtRuleSet` instead.
+ */
+class AtRuleStatement implements AtRule, Positionable
+{
+    use CommentContainer;
+    use Position;
+    use ShortClassNameProvider;
+
+    /**
+     * @var non-empty-string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $arguments;
+
+    /**
+     * @param non-empty-string $type
+     * @param int<1, max>|null $lineNumber
+     */
+    public function __construct(string $type, string $arguments = '', ?int $lineNumber = null)
+    {
+        $this->type = $type;
+        $this->arguments = $arguments;
+        $this->setPosition($lineNumber);
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function atRuleName(): string
+    {
+        return $this->type;
+    }
+
+    public function atRuleArgs(): string
+    {
+        return $this->arguments;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function render(OutputFormat $outputFormat): string
+    {
+        $formatter = $outputFormat->getFormatter();
+        $result = $formatter->comments($this);
+        $arguments = $this->arguments;
+        if ($arguments !== '') {
+            $arguments = ' ' . $arguments;
+        }
+        $result .= "@{$this->type}$arguments;";
+        return $result;
+    }
+
+    /**
+     * @return array<string, bool|int|float|string|array<mixed>|null>
+     *
+     * @internal
+     */
+    public function getArrayRepresentation(): array
+    {
+        return [
+            'class' => $this->getShortClassName(),
+            'atRuleName' => $this->type,
+            'arguments' => $this->arguments,
+        ];
+    }
+}

--- a/tests/CSSList/AtRuleStatementTest.php
+++ b/tests/CSSList/AtRuleStatementTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabberworm\CSS\Tests\CSSList;
+
+use PHPUnit\Framework\TestCase;
+use Sabberworm\CSS\CSSList\AtRuleBlockList;
+use Sabberworm\CSS\Parser;
+use Sabberworm\CSS\Property\AtRuleStatement;
+use Sabberworm\CSS\RuleSet\AtRuleSet;
+use Sabberworm\CSS\Settings;
+
+/**
+ * @covers \Sabberworm\CSS\CSSList\CSSList
+ * @covers \Sabberworm\CSS\Property\AtRuleStatement
+ */
+final class AtRuleStatementTest extends TestCase
+{
+    /**
+     * @return array<non-empty-string, array{0: non-empty-string, 1: non-empty-string, 2: string}>
+     */
+    public static function provideAtRuleStatementParsingData(): array
+    {
+        return [
+            'layer with single name' => [
+                '@layer reset;',
+                'layer',
+                'reset',
+            ],
+            'layer with multiple names' => [
+                '@layer base, components;',
+                'layer',
+                'base, components',
+            ],
+            'custom statement at-rule' => [
+                '@custom foo;',
+                'custom',
+                'foo',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @param non-empty-string $css
+     * @param non-empty-string $expectedName
+     *
+     * @dataProvider provideAtRuleStatementParsingData
+     */
+    public function parsesAtRuleStatement(string $css, string $expectedName, string $expectedArgs): void
+    {
+        $contents = (new Parser($css))->parse()->getContents();
+        $atRuleStatement = $contents[0];
+
+        self::assertInstanceOf(AtRuleStatement::class, $atRuleStatement);
+        self::assertSame($expectedName, $atRuleStatement->atRuleName());
+        self::assertSame($expectedArgs, $atRuleStatement->atRuleArgs());
+    }
+
+    /**
+     * @test
+     *
+     * @param non-empty-string $css
+     *
+     * @dataProvider provideAtRuleStatementParsingData
+     */
+    public function parsesAtRuleStatementInStrictMode(string $css): void
+    {
+        $contents = (new Parser($css, Settings::create()->beStrict()))->parse()->getContents();
+
+        self::assertNotEmpty($contents, 'Failing CSS: `' . $css . '`');
+        self::assertInstanceOf(AtRuleStatement::class, $contents[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function doesNotConsumeFollowingRulesWhenParsingLayerStatements(): void
+    {
+        $css = "@layer reset;\n"
+            . "@layer base, components;\n"
+            . "@property --tw-scale-x {\n"
+            . "  syntax: \"*\";\n"
+            . "  inherits: false;\n"
+            . "  initial-value: 1;\n"
+            . "}\n"
+            . "@property --tw-scale-y {\n"
+            . "  syntax: \"*\";\n"
+            . "  inherits: false;\n"
+            . "  initial-value: 1;\n"
+            . "}\n";
+
+        $contents = (new Parser($css))->parse()->getContents();
+
+        self::assertCount(4, $contents);
+        self::assertInstanceOf(AtRuleStatement::class, $contents[0]);
+        self::assertSame('reset', $contents[0]->atRuleArgs());
+        self::assertInstanceOf(AtRuleStatement::class, $contents[1]);
+        self::assertSame('base, components', $contents[1]->atRuleArgs());
+        self::assertInstanceOf(AtRuleSet::class, $contents[2]);
+        self::assertSame('property', $contents[2]->atRuleName());
+        self::assertInstanceOf(AtRuleSet::class, $contents[3]);
+        self::assertSame('property', $contents[3]->atRuleName());
+    }
+
+    /**
+     * @test
+     */
+    public function parsesLayerStatementThenLayerBlockInTheSameDocument(): void
+    {
+        $css = '@layer reset; @layer theme { .button { color: blue; } }';
+
+        $contents = (new Parser($css))->parse()->getContents();
+
+        self::assertCount(2, $contents);
+        self::assertInstanceOf(AtRuleStatement::class, $contents[0]);
+        self::assertSame('reset', $contents[0]->atRuleArgs());
+        self::assertInstanceOf(AtRuleBlockList::class, $contents[1]);
+        self::assertSame('theme', $contents[1]->atRuleArgs());
+    }
+
+    /**
+     * @test
+     */
+    public function rendersParsedLayerStatementWithTrailingSemicolon(): void
+    {
+        $rendered = (new Parser('@layer reset;'))->parse()->render();
+
+        self::assertStringContainsString('@layer reset;', $rendered);
+    }
+}

--- a/tests/Functional/Property/AtRuleStatementTest.php
+++ b/tests/Functional/Property/AtRuleStatementTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sabberworm\CSS\Tests\CSSList;
+namespace Sabberworm\CSS\Tests\Functional\Property;
 
 use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\CSSList\AtRuleBlockList;

--- a/tests/Unit/Property/AtRuleStatementTest.php
+++ b/tests/Unit/Property/AtRuleStatementTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sabberworm\CSS\Tests\Unit\Property;
+
+use PHPUnit\Framework\TestCase;
+use Sabberworm\CSS\Comment\Commentable;
+use Sabberworm\CSS\CSSList\CSSListItem;
+use Sabberworm\CSS\OutputFormat;
+use Sabberworm\CSS\Position\Positionable;
+use Sabberworm\CSS\Property\AtRule;
+use Sabberworm\CSS\Property\AtRuleStatement;
+use Sabberworm\CSS\Renderable;
+
+/**
+ * @covers \Sabberworm\CSS\Property\AtRuleStatement
+ */
+final class AtRuleStatementTest extends TestCase
+{
+    /**
+     * @var AtRuleStatement
+     */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new AtRuleStatement('layer');
+    }
+
+    /**
+     * @test
+     */
+    public function implementsAtRule(): void
+    {
+        self::assertInstanceOf(AtRule::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function implementsRenderable(): void
+    {
+        self::assertInstanceOf(Renderable::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function implementsCommentable(): void
+    {
+        self::assertInstanceOf(Commentable::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function implementsCSSListItem(): void
+    {
+        self::assertInstanceOf(CSSListItem::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function implementsPositionable(): void
+    {
+        self::assertInstanceOf(Positionable::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function atRuleNameReturnsTypeProvidedToConstructor(): void
+    {
+        $type = 'layer';
+
+        $subject = new AtRuleStatement($type);
+
+        self::assertSame($type, $subject->atRuleName());
+    }
+
+    /**
+     * @test
+     */
+    public function atRuleArgsByDefaultReturnsEmptyString(): void
+    {
+        self::assertSame('', $this->subject->atRuleArgs());
+    }
+
+    /**
+     * @test
+     */
+    public function atRuleArgsReturnsArgumentsProvidedToConstructor(): void
+    {
+        $arguments = 'reset';
+
+        $subject = new AtRuleStatement('layer', $arguments);
+
+        self::assertSame($arguments, $subject->atRuleArgs());
+    }
+
+    /**
+     * @test
+     */
+    public function getLineNumberByDefaultReturnsNull(): void
+    {
+        self::assertNull($this->subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
+    public function getLineNumberReturnsLineNumberProvidedToConstructor(): void
+    {
+        $lineNumber = 42;
+        $subject = new AtRuleStatement('layer', '', $lineNumber);
+
+        self::assertSame($lineNumber, $subject->getLineNumber());
+    }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationIncludesClassName(): void
+    {
+        $result = $this->subject->getArrayRepresentation();
+
+        self::assertSame('AtRuleStatement', $result['class']);
+    }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationIncludesAtRuleName(): void
+    {
+        $atRuleName = 'layer';
+        $subject = new AtRuleStatement($atRuleName);
+
+        $result = $subject->getArrayRepresentation();
+
+        self::assertSame($atRuleName, $result['atRuleName']);
+    }
+
+    /**
+     * @test
+     */
+    public function getArrayRepresentationIncludesArguments(): void
+    {
+        $arguments = 'reset';
+        $subject = new AtRuleStatement('layer', $arguments);
+
+        $result = $subject->getArrayRepresentation();
+
+        self::assertSame($arguments, $result['arguments']);
+    }
+
+    /**
+     * @test
+     */
+    public function renderWithArgumentsReturnsAtRuleFollowedBySemicolon(): void
+    {
+        $subject = new AtRuleStatement('layer', 'reset');
+
+        self::assertSame('@layer reset;', $subject->render(OutputFormat::create()));
+    }
+
+    /**
+     * @test
+     */
+    public function renderWithoutArgumentsReturnsAtRuleFollowedBySemicolon(): void
+    {
+        self::assertSame('@layer;', $this->subject->render(OutputFormat::create()));
+    }
+
+    /**
+     * @return array<non-empty-string, array{0: OutputFormat}>
+     */
+    public static function provideOutputFormats(): array
+    {
+        return [
+            'default' => [OutputFormat::create()],
+            'compact' => [OutputFormat::createCompact()],
+            'pretty' => [OutputFormat::createPretty()],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideOutputFormats
+     */
+    public function renderProducesTheSameStringForAllOutputFormats(OutputFormat $outputFormat): void
+    {
+        $subject = new AtRuleStatement('layer', 'reset');
+
+        self::assertSame('@layer reset;', $subject->render($outputFormat));
+    }
+}


### PR DESCRIPTION
Semicolon-terminated `@layer` is valid CSS but was parsed as a block, so later rules were swallowed.

`@layer` has two forms ([CSS Cascade 5](https://www.w3.org/TR/css-cascade-5/#layer-empty)):

```
@layer reset;
@layer base, components;
@layer theme { .button { color: blue; } }
```

Generic at-rule parsing always searched for {. For `@layer reset;`, that meant consuming through the next { (e.g. `@property`), so the rest of the stylesheet was treated as nested contents of a fake layer block.

Fix: stop at `{` or `;`. A `;` becomes `AtRuleStatement;` a `{` still becomes `AtRuleBlockList` or `AtRuleSet`. layer stays in `BLOCK_RULES`, so `@layer theme { … }` is unchanged.